### PR TITLE
fix: Use current time for changelog date range

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,9 @@ jobs:
             COMPARE_URL=""
           fi
           
-          # Get the date of the current tag's commit
-          END_DATE=$(git log -1 --format=%aI "$CURRENT_TAG" 2>/dev/null)
+          # Use current time as END_DATE to include PRs merged up until now
+          # (using commit date could exclude PRs merged after the commit but before the tag push)
+          END_DATE=$(date -Iseconds)
           
           echo "Date range: $START_DATE to $END_DATE"
           


### PR DESCRIPTION
## Problem

The changelog generation was using the commit date of the tag to filter PRs. This caused PRs that were merged **after** the commit was created but **before** the tag was pushed to be excluded from the changelog.

### Example:
- Commit created: `10:43 UTC` (Author Date)
- PR #24 merged: `10:46 UTC`
- Workflow runs: `10:50 UTC`
- Result: PR #24 was excluded because its merge date (`10:46`) was after the Author Date (`10:43`)

## Solution

Changed `END_DATE` from using the commit's Author Date to using the **current time** when the workflow runs. This ensures all PRs merged up until the moment of release are included.

## Changes

```diff
- # Get the date of the current tag's commit
- END_DATE=$(git log -1 --format=%aI "$CURRENT_TAG" 2>/dev/null)
+ # Use current time as END_DATE to include PRs merged up until now
+ # (using commit date could exclude PRs merged after the commit but before the tag push)
+ END_DATE=$(date -Iseconds)
```