### PR TITLE
ci: Use SHA-based filtering for changelog PR detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,22 +43,18 @@ jobs:
           echo "Current tag: $CURRENT_TAG"
           echo "Previous tag: $PREVIOUS_TAG"
           
-          # Get date range for PR search
+          # Get all commit SHAs between tags (this is the authoritative source)
+          # Using SHA-based filtering instead of date-based to avoid duplicates
           if [ -n "$PREVIOUS_TAG" ]; then
-            # Get the date of the previous tag's commit
-            START_DATE=$(git log -1 --format=%aI "$PREVIOUS_TAG" 2>/dev/null)
+            COMMIT_SHAS=$(git log --format=%H "${PREVIOUS_TAG}..${CURRENT_TAG}" 2>/dev/null || echo "")
             COMPARE_URL="**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/${PREVIOUS_TAG}...${CURRENT_TAG}"
           else
-            # If no previous tag, use repository creation date (far past)
-            START_DATE="2000-01-01T00:00:00Z"
+            # If no previous tag, get all commits up to current tag
+            COMMIT_SHAS=$(git log --format=%H "${CURRENT_TAG}" 2>/dev/null || echo "")
             COMPARE_URL=""
           fi
           
-          # Use current time as END_DATE to include PRs merged up until now
-          # (using commit date could exclude PRs merged after the commit but before the tag push)
-          END_DATE=$(date -Iseconds)
-          
-          echo "Date range: $START_DATE to $END_DATE"
+          echo "Found $(echo "$COMMIT_SHAS" | grep -c . || echo 0) commits between tags"
           
           # Initialize category strings
           FEATURES=""
@@ -72,7 +68,7 @@ jobs:
           OTHERS=""
           
           # Fetch merged PRs using GitHub API
-          # The API returns PRs sorted by updated date, we filter by merge date
+          # We check if each PR's merge_commit_sha is in our list of commits between tags
           PAGE=1
           while true; do
             RESPONSE=$(gh api \
@@ -85,23 +81,25 @@ jobs:
               break
             fi
             
-            # Parse PRs and check if they were merged within our date range
-            FOUND_OLD=false
+            # Track if we found any matching PRs in this page
+            FOUND_MATCH=false
+            
+            # Parse PRs and check if their merge commit is in our commit list
             while IFS= read -r pr_data; do
               [ -z "$pr_data" ] && continue
               
               MERGED_AT=$(echo "$pr_data" | jq -r '.merged_at // empty')
               [ -z "$MERGED_AT" ] && continue  # Skip if not merged
               
-              # Check if merge date is within our range
-              if [[ "$MERGED_AT" < "$START_DATE" ]]; then
-                FOUND_OLD=true
-                continue
+              MERGE_COMMIT_SHA=$(echo "$pr_data" | jq -r '.merge_commit_sha // empty')
+              [ -z "$MERGE_COMMIT_SHA" ] && continue  # Skip if no merge commit
+              
+              # Check if this PR's merge commit is in our list of commits between tags
+              if ! echo "$COMMIT_SHAS" | grep -q "^${MERGE_COMMIT_SHA}$"; then
+                continue  # Skip if merge commit is not between our tags
               fi
               
-              if [[ "$MERGED_AT" > "$END_DATE" ]]; then
-                continue
-              fi
+              FOUND_MATCH=true
               
               PR_NUMBER=$(echo "$pr_data" | jq -r '.number')
               PR_TITLE=$(echo "$pr_data" | jq -r '.title')
@@ -143,11 +141,6 @@ jobs:
                   ;;
               esac
             done < <(echo "$RESPONSE" | jq -c '.[]')
-            
-            # If we found PRs older than our start date, we can stop paginating
-            if [ "$FOUND_OLD" = true ]; then
-              break
-            fi
             
             PAGE=$((PAGE + 1))
             # Safety limit to avoid infinite loops


### PR DESCRIPTION
## Problem

The date-based filtering in the changelog generation caused PRs to appear in **multiple releases**. This happened in v0.2.0 and v0.2.1 where PRs #10 and #11 appeared in both changelogs.

### Root Cause

The previous logic used `merged_at` timestamps from the GitHub API to filter PRs, but:
- PR merge timestamps don't always align with commit timestamps
- The `START_DATE` was based on the previous tag's commit date, not when the tag was created
- PRs could be merged (via GitHub UI) after commits were already included in a tag

### Example of the Issue

| PR | Commits in tag | PR merged via GitHub |
|----|----------------|---------------------|
| #10 | v0.2.0 ✓ | After v0.2.0 was tagged |
| #11 | v0.2.0 ✓ | After v0.2.0 was tagged |

Both PRs appeared in v0.2.1 changelog because their `merged_at` timestamps fell within v0.2.1's date range.

## Solution

Changed from **date-based filtering** to **SHA-based filtering**:

1. Get all commit SHAs between `PREVIOUS_TAG..CURRENT_TAG` using `git log`
2. For each PR, check if its `merge_commit_sha` is in that list
3. Only include PRs whose merge commit is actually between the tags

This is deterministic and based on the actual Git history, not timestamps.

## Changes

```diff
- START_DATE=$(git log -1 --format=%aI "$PREVIOUS_TAG")
- END_DATE=$(date -Iseconds)
- # Filter PRs by: START_DATE < merged_at < END_DATE
+ COMMIT_SHAS=$(git log --format=%H "${PREVIOUS_TAG}..${CURRENT_TAG}")
+ # Filter PRs by: merge_commit_sha in COMMIT_SHAS
```