### PR TITLE
feat: Add backend service layer for multi-frontend support

### DIFF
--- a/pkg/backend/events.go
+++ b/pkg/backend/events.go
@@ -1,0 +1,54 @@
+// Package backend provides a unified service layer for Albion Online packet capture and event processing.
+// It serves as the backend for multiple frontends (TUI, Wails, Web API).
+package backend
+
+import "time"
+
+// EventType represents the type of game event
+type EventType string
+
+const (
+	EventTypeFame   EventType = "fame"
+	EventTypeSilver EventType = "silver"
+	EventTypeLoot   EventType = "loot"
+	EventTypeKill   EventType = "kill"
+	EventTypeDeath  EventType = "death"
+	EventTypeInfo   EventType = "info"
+)
+
+// GameEvent represents a game event for display in frontends
+type GameEvent struct {
+	Type      EventType   // Type of event (fame, silver, loot, etc.)
+	Message   string      // Formatted message to display
+	Timestamp time.Time   // When the event occurred
+	Data      interface{} // Optional structured data for specific event types
+}
+
+// FameData contains fame-specific event data
+type FameData struct {
+	Gained  int64 // Fame gained in this event
+	Total   int64 // Total fame after this event
+	Session int64 // Total fame gained this session
+}
+
+// SilverData contains silver-specific event data
+type SilverData struct {
+	Amount  int64 // Silver amount in this event
+	Session int64 // Total silver gained this session
+}
+
+// LootData contains loot-specific event data
+type LootData struct {
+	ItemName string // Name of the item
+	ItemID   int32  // Item ID
+	Quantity int32  // Number of items
+	LootedBy string // Player who looted
+	From     string // Source of loot
+}
+
+// CombatData contains combat-specific event data
+type CombatData struct {
+	KillerName string // Name of the killer
+	VictimName string // Name of the victim
+	Session    int    // Total kills or deaths this session
+}

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -1,0 +1,54 @@
+// Package backend provides a unified service layer for Albion Online packet capture and event processing.
+package backend
+
+// Option configures the Service using functional options pattern
+type Option func(*Service)
+
+// WithDevice sets the network device to capture from
+func WithDevice(device string) Option {
+	return func(s *Service) {
+		s.device = device
+	}
+}
+
+// WithDebug enables debug output in the handler
+func WithDebug(debug bool) Option {
+	return func(s *Service) {
+		s.debug = debug
+	}
+}
+
+// WithDiscovery enables discovery mode in the handler
+func WithDiscovery(discovery bool) Option {
+	return func(s *Service) {
+		s.discovery = discovery
+	}
+}
+
+// WithItemDatabasePath sets the path to the ao-bin-dumps item database
+func WithItemDatabasePath(path string) Option {
+	return func(s *Service) {
+		s.itemDBPath = path
+	}
+}
+
+// WithBPFFilter sets a custom BPF filter for packet capture
+func WithBPFFilter(filter string) Option {
+	return func(s *Service) {
+		s.bpfFilter = filter
+	}
+}
+
+// WithEventBufferSize sets the buffer size for the events channel
+func WithEventBufferSize(size int) Option {
+	return func(s *Service) {
+		s.eventBufferSize = size
+	}
+}
+
+// WithStatsBufferSize sets the buffer size for the stats channel
+func WithStatsBufferSize(size int) Option {
+	return func(s *Service) {
+		s.statsBufferSize = size
+	}
+}

--- a/pkg/backend/service.go
+++ b/pkg/backend/service.go
@@ -1,0 +1,307 @@
+// Package backend provides a unified service layer for Albion Online packet capture and event processing.
+// It serves as the backend for multiple frontends (TUI, Wails, Web API).
+package backend
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/cantalupo555/albion-lens/pkg/capture"
+	"github.com/cantalupo555/albion-lens/pkg/handlers"
+	"github.com/cantalupo555/albion-lens/pkg/photon"
+)
+
+const (
+	defaultEventBufferSize = 100
+	defaultStatsBufferSize = 10
+)
+
+// Service encapsulates the Albion Online packet capture and event processing backend.
+// It provides channels for frontend communication and can be used by TUI, Wails, or Web API.
+type Service struct {
+	// Configuration
+	device          string
+	debug           bool
+	discovery       bool
+	itemDBPath      string
+	bpfFilter       string
+	eventBufferSize int
+	statsBufferSize int
+
+	// Internal components
+	handler  *handlers.AlbionHandler
+	parser   *photon.Parser
+	capture  *capture.Capture
+	stopChan chan struct{}
+
+	// Public channels (read-only for frontends)
+	Events       <-chan GameEvent
+	Stats        <-chan *photon.Stats
+	OnlineStatus <-chan bool
+
+	// Internal writable channels
+	eventsChan       chan GameEvent
+	statsChan        chan *photon.Stats
+	onlineStatusChan chan bool
+
+	// State
+	running bool
+	mu      sync.RWMutex
+}
+
+// New creates a new Service with the given options.
+func New(opts ...Option) *Service {
+	s := &Service{
+		eventBufferSize: defaultEventBufferSize,
+		statsBufferSize: defaultStatsBufferSize,
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	// Create channels
+	s.eventsChan = make(chan GameEvent, s.eventBufferSize)
+	s.statsChan = make(chan *photon.Stats, s.statsBufferSize)
+	s.onlineStatusChan = make(chan bool, 1)
+	s.stopChan = make(chan struct{})
+
+	// Expose read-only channels
+	s.Events = s.eventsChan
+	s.Stats = s.statsChan
+	s.OnlineStatus = s.onlineStatusChan
+
+	return s
+}
+
+// Start initializes and starts the packet capture and event processing.
+// Returns an error if capture fails to start.
+func (s *Service) Start() error {
+	s.mu.Lock()
+	if s.running {
+		s.mu.Unlock()
+		return fmt.Errorf("service already running")
+	}
+	s.running = true
+	s.mu.Unlock()
+
+	// Create handler
+	s.handler = handlers.NewAlbionHandler()
+	s.handler.SetDebug(s.debug)
+	s.handler.SetDiscoveryMode(s.discovery)
+
+	// Set event callback to send events to channel
+	s.handler.SetEventCallback(func(eventType, message string) {
+		event := GameEvent{
+			Type:      EventType(eventType),
+			Message:   message,
+			Timestamp: time.Now(),
+		}
+		select {
+		case s.eventsChan <- event:
+		default:
+			// Channel full, drop event
+		}
+	})
+
+	// Load item database
+	if err := s.loadItemDatabase(); err != nil && s.debug {
+		fmt.Printf("Warning: Could not load item database: %v\n", err)
+	}
+
+	// Create parser
+	s.parser = photon.NewParser(s.handler)
+	s.parser.SetDebug(s.debug)
+
+	// Create capture
+	s.capture = capture.NewCapture(func(payload []byte, srcIP, dstIP net.IP, srcPort, dstPort uint16) {
+		_ = s.parser.ParsePacket(payload)
+	})
+
+	// Set online/offline callback
+	s.capture.OnlineCallback = func(online bool) {
+		select {
+		case s.onlineStatusChan <- online:
+		default:
+		}
+
+		// Also send as info event
+		msg := "Waiting for Albion Online traffic..."
+		if online {
+			msg = "Albion Online detected! Capturing packets..."
+		}
+		select {
+		case s.eventsChan <- GameEvent{
+			Type:      EventTypeInfo,
+			Message:   msg,
+			Timestamp: time.Now(),
+		}:
+		default:
+		}
+	}
+
+	// Start stats updater
+	go s.statsUpdater()
+
+	// Start capture
+	var err error
+	if s.device != "" {
+		err = s.capture.StartOnDevice(s.device)
+	} else {
+		err = s.capture.Start()
+	}
+
+	if err != nil {
+		s.mu.Lock()
+		s.running = false
+		s.mu.Unlock()
+		return fmt.Errorf("failed to start capture: %w", err)
+	}
+
+	return nil
+}
+
+// Stop stops the service and cleans up resources.
+func (s *Service) Stop() {
+	s.mu.Lock()
+	if !s.running {
+		s.mu.Unlock()
+		return
+	}
+	s.running = false
+	s.mu.Unlock()
+
+	// Signal stop
+	close(s.stopChan)
+
+	// Stop capture
+	if s.capture != nil {
+		s.capture.Stop()
+	}
+
+	// Close parser
+	if s.parser != nil {
+		s.parser.Close()
+	}
+
+	// Close channels
+	close(s.eventsChan)
+	close(s.statsChan)
+	close(s.onlineStatusChan)
+}
+
+// statsUpdater periodically sends stats to the channel.
+func (s *Service) statsUpdater() {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.stopChan:
+			return
+		case <-ticker.C:
+			if s.parser != nil {
+				select {
+				case s.statsChan <- s.parser.Stats:
+				default:
+				}
+			}
+		}
+	}
+}
+
+// loadItemDatabase attempts to load the item database.
+func (s *Service) loadItemDatabase() error {
+	if s.itemDBPath != "" {
+		return s.handler.LoadItemDatabase(s.itemDBPath)
+	}
+
+	// Try auto-detection
+	commonPaths := []string{
+		"../ao-bin-dumps",
+		"../../ao-bin-dumps",
+		filepath.Join(os.Getenv("HOME"), "Documents/albion/ao-bin-dumps"),
+	}
+
+	for _, path := range commonPaths {
+		if _, err := os.Stat(filepath.Join(path, "items.json")); err == nil {
+			return s.handler.LoadItemDatabase(path)
+		}
+	}
+
+	return nil
+}
+
+// IsRunning returns whether the service is currently running.
+func (s *Service) IsRunning() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.running
+}
+
+// IsOnline returns whether Albion Online traffic is currently being detected.
+func (s *Service) IsOnline() bool {
+	if s.capture == nil {
+		return false
+	}
+	return s.capture.IsOnline()
+}
+
+// SessionFame returns the total fame gained in this session.
+func (s *Service) SessionFame() int64 {
+	if s.handler == nil {
+		return 0
+	}
+	return s.handler.GetSessionFame()
+}
+
+// SessionSilver returns the total silver gained in this session.
+func (s *Service) SessionSilver() int64 {
+	if s.handler == nil {
+		return 0
+	}
+	return s.handler.GetSessionSilver()
+}
+
+// SessionKills returns the number of kills in this session.
+func (s *Service) SessionKills() int {
+	if s.handler == nil {
+		return 0
+	}
+	return s.handler.GetSessionKills()
+}
+
+// SessionDeaths returns the number of deaths in this session.
+func (s *Service) SessionDeaths() int {
+	if s.handler == nil {
+		return 0
+	}
+	return s.handler.GetSessionDeaths()
+}
+
+// SessionLoot returns the number of loot items in this session.
+func (s *Service) SessionLoot() int {
+	if s.handler == nil {
+		return 0
+	}
+	return s.handler.GetSessionLoot()
+}
+
+// ParserStats returns the current parser statistics.
+func (s *Service) ParserStats() *photon.Stats {
+	if s.parser == nil {
+		return nil
+	}
+	return s.parser.Stats
+}
+
+// Handler returns the underlying AlbionHandler for advanced usage.
+// This is useful for discovery mode operations.
+func (s *Service) Handler() *handlers.AlbionHandler {
+	return s.handler
+}


### PR DESCRIPTION
## Summary
- Introduce `pkg/backend` package that encapsulates packet capture, parsing, and event processing into a unified Service
- Enable clean separation between backend logic and frontends (TUI, future Wails, Web API)
- Simplify `cmd/tui/main.go` from ~140 lines to ~97 lines using the new backend service

## Changes
- `pkg/backend/events.go` - Event types and structured data (GameEvent, FameData, SilverData, etc.)
- `pkg/backend/options.go` - Functional options pattern (WithDevice, WithDebug, WithItemDatabasePath, etc.)
- `pkg/backend/service.go` - Main Service with Start()/Stop() lifecycle and public channels
- `cmd/tui/main.go` - Refactored to use backend.Service

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes