### PR TITLE
refactor: Remove console output from handler and capture

### DIFF
--- a/pkg/backend/service.go
+++ b/pkg/backend/service.go
@@ -109,10 +109,8 @@ func (s *Service) Start() error {
 		}
 	})
 
-	// Load item database
-	if err := s.loadItemDatabase(); err != nil && s.debug {
-		fmt.Printf("Warning: Could not load item database: %v\n", err)
-	}
+	// Load item database (errors are non-fatal)
+	_ = s.loadItemDatabase()
 
 	// Create parser
 	s.parser = photon.NewParser(s.handler)

--- a/pkg/capture/capture.go
+++ b/pkg/capture/capture.go
@@ -125,13 +125,12 @@ func (s *Capture) StartOnDevice(deviceName string) error {
 func (s *Capture) captureOnDevice(deviceName, ipAddr string) {
 	handle, err := pcap.OpenLive(deviceName, SnapshotLen, Promiscuous, Timeout)
 	if err != nil {
-		fmt.Printf("Warning: Could not open device %s: %v\n", deviceName, err)
+		// Silently skip devices that can't be opened
 		return
 	}
 
 	// Set BPF filter
 	if err := handle.SetBPFFilter(BPFFilter); err != nil {
-		fmt.Printf("Warning: Could not set BPF filter on %s: %v\n", deviceName, err)
 		handle.Close()
 		return
 	}
@@ -139,12 +138,6 @@ func (s *Capture) captureOnDevice(deviceName, ipAddr string) {
 	s.mu.Lock()
 	s.handles = append(s.handles, handle)
 	s.mu.Unlock()
-
-	if ipAddr != "" {
-		fmt.Printf("📡 Listening on %s (%s)\n", deviceName, ipAddr)
-	} else {
-		fmt.Printf("📡 Listening on %s\n", deviceName)
-	}
 
 	s.wg.Add(1)
 	defer s.wg.Done()
@@ -249,7 +242,6 @@ func (s *Capture) Stop() {
 	}
 
 	s.wg.Wait()
-	fmt.Println("Capture stopped")
 }
 
 // IsOnline returns whether the game is currently sending packets


### PR DESCRIPTION
## Summary
- Move presentation responsibility to frontends (TUI, Wails, CLI)
- Handler now only processes events and notifies via callback
- Remove `fatih/color` dependency from handler
- Remove all `Printf/Println` from event handlers
- Frontends use their own styling (TUI uses lipgloss)

## Problem
TUI rendering was corrupted because the handler was printing directly to stdout, interfering with bubbletea's alternate screen mode.

## Solution
Each frontend is now responsible for its own presentation. The handler focuses solely on event processing and notification.

## Test plan
- [x] Build passes (`go build ./...`)
- [x] Run TUI and verify no rendering issues
- [x] Verify events are displayed with correct colors in TUI