### PR TITLE
fix: Pass structured event data to update StatsPanel Fame/Silver

### DIFF
--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -55,6 +55,7 @@ func main() {
 				Type:      string(event.Type),
 				Message:   event.Message,
 				Timestamp: event.Timestamp,
+				Data:      event.Data,
 			}:
 			default:
 			}

--- a/internal/tui/components/statspanel.go
+++ b/internal/tui/components/statspanel.go
@@ -35,9 +35,21 @@ func (s StatsPanel) AddFame(amount int64) StatsPanel {
 	return s
 }
 
+// SetFame sets the session fame total
+func (s StatsPanel) SetFame(amount int64) StatsPanel {
+	s.fame = amount
+	return s
+}
+
 // AddSilver adds silver to the session total
 func (s StatsPanel) AddSilver(amount int64) StatsPanel {
 	s.silver += amount
+	return s
+}
+
+// SetSilver sets the session silver total
+func (s StatsPanel) SetSilver(amount int64) StatsPanel {
+	s.silver = amount
 	return s
 }
 

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -9,9 +9,10 @@ import (
 
 // EventMsg represents a game event to display in the log
 type EventMsg struct {
-	Type      string    // "fame", "silver", "loot", "combat", "info"
-	Message   string    // Formatted message to display
-	Timestamp time.Time // When the event occurred
+	Type      string      // "fame", "silver", "loot", "combat", "info"
+	Message   string      // Formatted message to display
+	Timestamp time.Time   // When the event occurred
+	Data      interface{} // Optional structured data (FameEventData, SilverEventData, etc.)
 }
 
 // StatsUpdateMsg triggers a stats panel update

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -4,6 +4,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/cantalupo555/albion-lens/internal/tui/components"
+	"github.com/cantalupo555/albion-lens/pkg/handlers"
 	"github.com/cantalupo555/albion-lens/pkg/photon"
 )
 
@@ -96,12 +97,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case EventMsg:
 		m.eventLog = m.eventLog.AddEvent(msg.Type, msg.Message, msg.Timestamp)
 
-		// Update session stats based on event type
+		// Update session stats based on event type and data
 		switch msg.Type {
 		case "fame":
-			// Could extract amount from message if needed
+			if data, ok := msg.Data.(*handlers.FameEventData); ok && data != nil {
+				m.statsPanel = m.statsPanel.SetFame(data.Session)
+			}
 		case "silver":
-			// Could extract amount from message if needed
+			if data, ok := msg.Data.(*handlers.SilverEventData); ok && data != nil {
+				m.statsPanel = m.statsPanel.SetSilver(data.Session)
+			}
 		case "loot":
 			m.statsPanel = m.statsPanel.IncrLoot()
 		case "kill":

--- a/pkg/backend/service.go
+++ b/pkg/backend/service.go
@@ -96,11 +96,12 @@ func (s *Service) Start() error {
 	s.handler.SetDiscoveryMode(s.discovery)
 
 	// Set event callback to send events to channel
-	s.handler.SetEventCallback(func(eventType, message string) {
+	s.handler.SetEventCallback(func(eventType, message string, data interface{}) {
 		event := GameEvent{
 			Type:      EventType(eventType),
 			Message:   message,
 			Timestamp: time.Now(),
+			Data:      data,
 		}
 		select {
 		case s.eventsChan <- event:


### PR DESCRIPTION
## Summary
- Modified EventCallback signature to accept structured data parameter
- Added FameEventData and SilverEventData structs to pass actual values
- Updated TUI to extract and display Fame/Silver values in StatsPanel

## Test plan
- [x] Build passes without errors
- [x] TUI displays correctly
- [x] Fame updates in StatsPanel when fame events are captured
- [x] Silver updates in StatsPanel when silver events are captured