### PR TITLE
docs: Fix build path from cmd/sniffer to cmd/tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ cd albion-lens
 go mod download
 
 # Build
-go build -o bin/albion-lens ./cmd/sniffer
+go build -o bin/albion-lens ./cmd/tui
 
 # Run (requires sudo for packet capture)
 sudo ./bin/albion-lens


### PR DESCRIPTION
## Summary

- Fix build instructions in README: `./cmd/sniffer` → `./cmd/tui`

## Context

The `cmd/sniffer` directory was removed in PR #16. This updates the README build instructions to use the correct path.