### PR TITLE
refactor: Change default to abbreviated numbers

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -45,7 +45,7 @@ func New(svc *backend.Service, eventChan chan EventMsg, statsChan chan *photon.S
 		svc:         svc,
 		eventChan:   eventChan,
 		statsChan:   statsChan,
-		fullNumbers: true, // Default: show full numbers
+		fullNumbers: false, // Default: abbreviated numbers (e.g., 4.9k)
 	}
 	// Sync debug state from service
 	if svc != nil {


### PR DESCRIPTION
## Summary

Change the default display from full numbers to abbreviated numbers.

## Before
- Default: `4984` (full numbers)
- Press 'f' to toggle to abbreviated

## After
- Default: `4.9k` (abbreviated)
- Press 'f' to toggle to full numbers

## Rationale

Abbreviated numbers are more readable at a glance, especially for large values like fame and silver. Users who prefer exact values can press 'f' to toggle.