### PR TITLE
fix: Improve buffer metrics consistency and thread-safety

### DIFF
--- a/pkg/backend/service.go
+++ b/pkg/backend/service.go
@@ -124,6 +124,7 @@ func (s *Service) Start() error {
 
 	// Create parser
 	s.parser = photon.NewParser(s.handler)
+	s.parser.Stats.BufferCapacity = cap(s.eventsChan) // Set once at startup
 	// Note: Parser debug is not enabled because it uses fmt.Printf which interferes with TUI
 
 	// Create capture
@@ -221,7 +222,6 @@ func (s *Service) statsUpdater() {
 			if s.parser != nil {
 				// Snapshot buffer metrics (Peak usage in last interval)
 				s.parser.Stats.SnapshotBufferPeak()
-				s.parser.Stats.BufferCapacity = cap(s.eventsChan)
 
 				select {
 				case s.statsChan <- s.parser.Stats:


### PR DESCRIPTION
## Summary

This PR addresses quality improvements identified in the buffer monitoring implementation:

1. **Consistent Reset behavior**
2. **Eliminated data race**
3. **Clear documentation**

## Changes

### 1. Add buffer metrics reset in Stats.Reset()

**File:** `pkg/photon/stats.go:278-281`

- `BufferPeakDisplay` and `bufferPeakInternal` now reset properly
- `BufferCapacity` intentionally not reset (invariant after initialization)
- Ensures consistency with other metrics

### 2. Eliminate BufferCapacity data race

**Files:** `pkg/backend/service.go:127` and `:224`

**Before:** Written every second in statsUpdater (60x/min)
**After:** Set once during Start()

**Benefits:**
- Eliminates race between statsUpdater write and UI read
- Performance improvement (1 write vs 60 writes/minute)
- `cap(chan)` is constant, no need for repeated assignments

### 3. Add comprehensive documentation

**File:** `pkg/photon/stats.go:58-70` and `:33-35`

- Documents "peak per interval" strategy
- Clarifies BufferPeakDisplay shows temporal peaks, not absolute maximum
- Prevents confusion about reset semantics

## Validation

- [x] All existing tests pass
- [x] No data races detected (`go test -race`)
- [x] Code compiles without warnings
- [x] Documentation is clear and accurate

## ❌ What Was NOT Implemented

**Tests for buffer functions** - Will be implemented in a separate branch:
- ❌ `TestUpdateBufferPeak()` - verifies CAS logic
- ❌ `TestSnapshotBufferPeak()` - verifies reset and promotion
- ❌ `TestBufferPeakConcurrent()` - verifies thread-safety
- ❌ `TestStatsResetIncludesBuffer()` - verifies Reset() is complete

**Rationale:** Tests will be added in a dedicated test branch to keep commits organized and reviewable.

## Technical Notes

The "peak per interval" behavior is intentional and confirmed with the user. This shows temporal variations in buffer usage rather than absolute maximum since session start, which is more useful for detecting bursts.

## Related

Parent PR: #30 (merged)