### PR TITLE
ci(release): reorder changelog sections to prioritize refactoring

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,16 +160,16 @@ jobs:
             CHANGELOG="${CHANGELOG}### 🐛 Bug Fixes"$'\n\n'"${FIXES}"$'\n'
           fi
           
+          if [ -n "$REFACTOR" ]; then
+            CHANGELOG="${CHANGELOG}### ♻️ Code Refactoring"$'\n\n'"${REFACTOR}"$'\n'
+          fi
+          
           if [ -n "$PERFORMANCE" ]; then
             CHANGELOG="${CHANGELOG}### ⚡ Performance Improvements"$'\n\n'"${PERFORMANCE}"$'\n'
           fi
           
           if [ -n "$DOCS" ]; then
             CHANGELOG="${CHANGELOG}### 📚 Documentation"$'\n\n'"${DOCS}"$'\n'
-          fi
-          
-          if [ -n "$REFACTOR" ]; then
-            CHANGELOG="${CHANGELOG}### ♻️ Code Refactoring"$'\n\n'"${REFACTOR}"$'\n'
           fi
           
           if [ -n "$TESTS" ]; then


### PR DESCRIPTION
## Summary
Updates the release workflow to reorder changelog sections, prioritizing code refactoring by moving it higher in the generated release notes.

## Changes Made
- Reordered changelog generation sections in `.github/workflows/release.yml`.
- Moved the "♻️ Code Refactoring" section to appear immediately after "🐛 Bug Fixes" (previously positioned after "📚 Documentation").
- Aligned the changelog structure with the conventions used in the `vocab-smart-card` project.

## Testing
- [x] Workflow validated (syntax check)
- [x] No regressions expected (reordering only)

## Additional Notes
This adjustment ensures that refactoring efforts are more visible in release summaries, following the established pattern in related projects.
