### PR TITLE
ci: disable session sharing in review workflow

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -26,6 +26,7 @@ jobs:
           ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
         with:
           model: zai-coding-plan/glm-4.7
+          share: false
           prompt: |
             This is a cross-platform Go TUI application (Charmbracelet BubbleTea + Bubbles) that captures and decodes Albion Online network traffic using gopacket and libpcap (CGO). It parses the Photon Engine protocol and Protocol16 encoding to track in-game events (fame, silver, loot).
 


### PR DESCRIPTION
## Summary
- Disable session sharing (`share: false`) in the opencode review workflow
- The `share` option defaults to `true` for public repositories, adding a social card image and opencode session link to PR comments
- The session link (`opencode.ai/s/{id}`) returns 404, so disable it explicitly

## Test plan
- [x] Verify workflow syntax is valid
- [x] Next PR should only show review text + `[github run]` link (no social card or session link)