### PR TITLE
ci: add scheduled code audit workflow

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -1,0 +1,62 @@
+name: opencode-audit
+
+on:
+  schedule:
+    - cron: '0 9 * * 1,4' # Every Monday and Thursday at 9:00 UTC
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode audit
+        uses: anomalyco/opencode/github@latest
+        env:
+          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
+        with:
+          model: zai-coding-plan/glm-4.7
+          share: false
+          prompt: |
+            This is a cross-platform Go TUI application (Charmbracelet BubbleTea + Bubbles) that captures and decodes Albion Online network traffic using gopacket and libpcap (CGO). It parses the Photon Engine protocol and Protocol16 encoding to track in-game events (fame, silver, loot).
+
+            Perform a code audit on the entire codebase. Read the source files and analyze the project.
+
+            ## What to audit
+
+            1. **Race conditions** — goroutines sharing state without proper synchronization (mutexes, channels), especially between packet capture goroutines and TUI update loops
+            2. **Resource leaks** — unclosed packet captures, file handles, goroutines without shutdown paths, channels that are never closed
+            3. **Dead code** — exported functions/types that are never used, unreachable code paths, unused constants or variables
+            4. **TODO/FIXME/HACK comments** — list any found with file path and line number
+            5. **Error handling gaps** — errors silently discarded with `_`, missing nil checks on pointers, panics that should be recoverable errors
+            6. **Test coverage gaps** — critical logic paths (protocol parsing, event handling) without corresponding tests
+            7. **Hardcoded values** — magic numbers, hardcoded ports, timeouts, or buffer sizes that should be constants
+            8. **Cross-platform issues** — code that assumes Linux-only behavior without build tags or runtime checks for Windows/macOS
+            9. **Outdated documentation** — comments, docstrings, or inline documentation that no longer reflect the current code behavior (e.g., referencing removed functions, describing old logic, or mentioning features that were changed)
+            10. **Security vulnerabilities** — hardcoded secrets or credentials, unsafe handling of raw network data, buffer overflows in protocol parsing, missing bounds checks on untrusted input, improper use of unsafe pointers
+            11. **Albion Online ToS compliance** — this application must remain strictly passive (read-only network sniffing). Flag any code that sends packets, injects data, modifies game traffic, writes to network sockets, or interferes with Albion Online servers in any way. Per SBI's policy: "As long as you just look and analyze we are ok with it. The moment you modify or manipulate something or somehow interfere with our services we will react."
+            12. **Protocol parsing correctness** — off-by-one errors in buffer reads, incorrect byte order assumptions (little-endian vs big-endian), missing bounds checks on Photon Engine and Protocol16 packet data, panics from reading beyond slice length
+            13. **CGO memory safety** — memory allocated by C (libpcap) that is not properly freed on the Go side, dangling pointers across the Go/C boundary, unsafe.Pointer misuse that could cause segfaults
+            14. **Goroutine lifecycle** — goroutines that never terminate or lack shutdown paths, missing context cancellation propagation, channels blocked indefinitely without timeouts, goroutine leaks on application exit
+            15. **Trailing whitespace and blank lines** — lines with trailing spaces at the end, unnecessary consecutive blank lines, and files not ending with a single newline
+
+            ## Output format
+
+            Before creating any issues, first list all existing open issues in the repository. For each finding, check if an open issue already covers the same problem (same file, same area of code, same type of issue). If it does, skip it — do NOT create duplicates.
+
+            Create a separate GitHub issue for each new finding:
+            - Each issue with a descriptive title that summarizes the specific problem (e.g., "Race condition in packet handler between capture and TUI goroutines")
+            - Include: severity (bug/warning/info), file path, line number, description, and how to reproduce or trigger the issue
+            - Only report real, actionable issues — do NOT invent problems
+            - If the codebase is clean or all findings already have open issues, do NOT create any issues
+
+            Do NOT suggest stylistic changes or formatting improvements.
+            Do NOT modify any files, create branches, or open pull requests. This is a read-only audit — only report findings as a GitHub issue.


### PR DESCRIPTION
## Summary
- Adds a new workflow that audits the codebase on a schedule (Monday and Thursday at 9:00 UTC)
- Can also be triggered manually via `workflow_dispatch`
- Creates individual GitHub issues for each finding, skipping duplicates

## Audit checklist (15 items)
1. Race conditions
2. Resource leaks
3. Dead code
4. TODO/FIXME/HACK comments
5. Error handling gaps
6. Test coverage gaps
7. Hardcoded values
8. Cross-platform issues
9. Outdated documentation
10. Security vulnerabilities
11. Albion Online ToS compliance
12. Protocol parsing correctness
13. CGO memory safety
14. Goroutine lifecycle
15. Trailing whitespace and blank lines

## Safeguards
- Read-only: `contents: read` — cannot modify code, create branches, or open PRs
- Deduplication: checks existing open issues before creating new ones
- No noise: skips issue creation if codebase is clean