### PR TITLE
ci: add auto-labeling workflow for new issues

### DIFF
--- a/.github/workflows/opencode-triage-issues.yml
+++ b/.github/workflows/opencode-triage-issues.yml
@@ -1,0 +1,45 @@
+name: opencode-triage-issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Triage issue
+        uses: anomalyco/opencode/github@latest
+        env:
+          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+        with:
+          model: zai-coding-plan/glm-4.7
+          share: false
+          prompt: |
+            You are triaging a newly opened issue in a cross-platform Go TUI application that captures and decodes Albion Online network traffic.
+
+            ## Instructions
+
+            1. First, list all available labels in this repository by running: `gh label list --json name,description`
+            2. Read the issue title and body carefully
+            3. Determine which labels best match the issue content — you may assign one or more labels
+            4. Apply the labels by running: `gh issue edit <number> --add-label "label1" --add-label "label2"`
+
+            ## Guidelines
+
+            - Only assign labels that genuinely match the issue content
+            - An issue can have multiple labels (e.g., "bug" + "go" if it's a Go bug)
+            - If no label fits, do not assign any
+            - Do NOT create new labels
+            - Do NOT modify the issue title or body


### PR DESCRIPTION
## Summary
- Adds a workflow that automatically labels newly opened issues
- The opencode agent lists available labels via `gh label list`, analyzes the issue content, and applies the most appropriate labels
- Uses `GH_TOKEN` for `gh` CLI authentication (auto-generated, no manual secret needed)

## Safeguards
- Only triggers on `issues: [opened]`
- Excludes Dependabot
- Does not create new labels, comment, or modify issue content
- Only applies labels that genuinely match

## Test plan
- [ ] Open a test issue and verify labels are applied correctly