### PR TITLE
ci: add auto-labeling workflow for new pull requests

### DIFF
--- a/.github/workflows/opencode-triage-pr.yml
+++ b/.github/workflows/opencode-triage-pr.yml
@@ -1,0 +1,47 @@
+name: opencode-triage-pr
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  triage:
+    if: >
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Triage pull request
+        uses: anomalyco/opencode/github@latest
+        env:
+          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+        with:
+          model: zai-coding-plan/glm-4.7
+          share: false
+          prompt: |
+            You are triaging a newly opened pull request in a cross-platform Go TUI application that captures and decodes Albion Online network traffic.
+
+            ## Instructions
+
+            1. First, list all available labels in this repository by running: `gh label list --json name,description`
+            2. Analyze the PR: read the title, body, and the actual code changes (run `git diff master...HEAD` and read changed files)
+            3. Determine which labels best match the PR content — you may assign one or more labels
+            4. Apply the labels by running: `gh pr edit <number> --add-label "label1" --add-label "label2"`
+
+            ## Guidelines
+
+            - Only assign labels that genuinely match the PR content
+            - A PR can have multiple labels (e.g., "enhancement" + "go" if it adds a new Go feature)
+            - If no label fits, do not assign any
+            - Do NOT create new labels
+            - Do NOT modify the PR title or body


### PR DESCRIPTION
## Summary
- Adds a workflow that automatically labels newly opened pull requests
- The opencode agent lists available labels via `gh label list`, analyzes the PR title, body, and code diff, and applies the most appropriate labels
- Uses `GH_TOKEN` for `gh` CLI authentication (auto-generated, no manual secret needed)
- Runs independently from the review workflow (which handles code review comments)

## Safeguards
- Only triggers on `pull_request: [opened]` (not on every push)
- Excludes drafts and Dependabot
- Does not create new labels, comment, or modify PR content
- Only applies labels that genuinely match

## Test plan
- [ ] Open a test PR and verify labels are applied correctly