### PR TITLE
ci: only trigger review on PR open, not on every push

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -2,13 +2,20 @@ name: opencode-review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
 
 jobs:
   review:
     if: >
-      github.event.pull_request.draft == false &&
-      github.actor != 'dependabot[bot]'
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.draft == false &&
+       github.actor != 'dependabot[bot]') ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       (startsWith(github.event.comment.body, '/review') ||
+        contains(github.event.comment.body, ' /review')))
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary
- Remove `synchronize` from `pull_request` triggers so reviews only run on PR open, reopen, or ready for review
- Add `/review` command support via `issue_comment` trigger for manual re-reviews
- Add `event_name` conditions to correctly handle both trigger types

## Before
Every commit pushed to a PR branch triggered a new review.

## After
- Review triggers only on: `[opened, reopened, ready_for_review]`
- Commenting `/review` on a PR manually triggers the review workflow