### PR TITLE
ci: add GH_TOKEN to audit workflow for issue creation

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -22,6 +22,7 @@ jobs:
         uses: anomalyco/opencode/github@latest
         env:
           ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
         with:
           model: zai-coding-plan/glm-4.7
           share: false


### PR DESCRIPTION
## Summary
- Add `GH_TOKEN: ${{ github.token }}` to the audit workflow so the `gh` CLI can create issues
- Without this, the agent has no GitHub authentication for `gh` commands and falls back to creating PRs via OIDC, bypassing the intended read-only audit behavior

## Context
PR #41 was created by the audit workflow despite the prompt explicitly saying "Do NOT create branches or open pull requests". This happened because the `gh` CLI had no token to create issues, so the agent used its OIDC auth to create a PR instead.