### PR TITLE
ci: add verification instruction to audit prompt to reduce false positives

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -59,5 +59,7 @@ jobs:
             - Only report real, actionable issues — do NOT invent problems
             - If the codebase is clean or all findings already have open issues, do NOT create any issues
 
+            Before reporting any bug, trace the actual code path to verify it's real. Read the implementation of called functions — do not assume behavior. Only report issues you have high confidence are genuine bugs.
+
             Do NOT suggest stylistic changes or formatting improvements.
             Do NOT modify any files, create branches, or open pull requests. This is a read-only audit — only report findings as a GitHub issue.


### PR DESCRIPTION
## Summary
- Add instruction requiring the audit agent to trace actual code paths before reporting bugs
- Prevents false positives like the ones found in the first audit run (PR #41), where 2 of 3 reported bugs were incorrect

## Context
The first audit run reported 3 critical bugs. After manual investigation, 2 were false positives:
- "Goroutine panic on closed channels" — Go doesn't panic on receive from closed channel
- "Missing bounds check in Protocol16" — BufferReader already provides bounds checking

The new instruction reinforces: verify before reporting.