### PR TITLE
ci: replace hardcoded model with repository variable

### DIFF
--- a/.github/workflows/opencode-audit.yml
+++ b/.github/workflows/opencode-audit.yml
@@ -24,7 +24,7 @@ jobs:
           ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
           GH_TOKEN: ${{ github.token }}
         with:
-          model: zai-coding-plan/glm-4.7
+          model: ${{ vars.OPENCODE_MODEL }}
           share: false
           prompt: |
             This is a cross-platform Go TUI application (Charmbracelet BubbleTea + Bubbles) that captures and decodes Albion Online network traffic using gopacket and libpcap (CGO). It parses the Photon Engine protocol and Protocol16 encoding to track in-game events (fame, silver, loot).

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
         with:
-          model: zai-coding-plan/glm-4.7
+          model: ${{ vars.OPENCODE_MODEL }}
           share: false
           prompt: |
             This is a cross-platform Go TUI application (Charmbracelet BubbleTea + Bubbles) that captures and decodes Albion Online network traffic using gopacket and libpcap (CGO). It parses the Photon Engine protocol and Protocol16 encoding to track in-game events (fame, silver, loot).

--- a/.github/workflows/opencode-triage-issues.yml
+++ b/.github/workflows/opencode-triage-issues.yml
@@ -24,7 +24,7 @@ jobs:
           ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
           GH_TOKEN: ${{ github.token }}
         with:
-          model: zai-coding-plan/glm-4.7
+          model: ${{ vars.OPENCODE_MODEL }}
           share: false
           prompt: |
             You are triaging a newly opened issue in a cross-platform Go TUI application that captures and decodes Albion Online network traffic.

--- a/.github/workflows/opencode-triage-pr.yml
+++ b/.github/workflows/opencode-triage-pr.yml
@@ -26,7 +26,7 @@ jobs:
           ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
           GH_TOKEN: ${{ github.token }}
         with:
-          model: zai-coding-plan/glm-4.7
+          model: ${{ vars.OPENCODE_MODEL }}
           share: false
           prompt: |
             You are triaging a newly opened pull request in a cross-platform Go TUI application that captures and decodes Albion Online network traffic.

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -30,4 +30,4 @@ jobs:
         env:
           ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
         with:
-          model: zai-coding-plan/glm-4.7
+          model: ${{ vars.OPENCODE_MODEL }}


### PR DESCRIPTION
## Summary
- Replace hardcoded `zai-coding-plan/glm-4.7` with `${{ vars.OPENCODE_MODEL }}` in all 5 opencode workflows
- Centralizes the model configuration in a single place (Settings > Variables > `OPENCODE_MODEL`)

## Affected workflows
- `opencode-audit.yml`
- `opencode-review.yml`
- `opencode-triage-issues.yml`
- `opencode-triage-pr.yml`
- `opencode.yml`