### PR TITLE
fix(capture): prevent OOM and goroutine leak in packet capture

### DIFF
--- a/pkg/capture/capture.go
+++ b/pkg/capture/capture.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/gopacket"
@@ -23,6 +24,8 @@ const (
 	BPFFilter = "udp and (port 5055 or port 5056)"
 
 	// Capture settings
+	// Large enough to capture full UDP datagrams regardless of MTU/VPN/tunneling.
+	// gopacket only allocates ci.CaptureLength bytes (actual packet size), not SnapshotLen.
 	SnapshotLen = 65536
 	Promiscuous = false
 	Timeout     = pcap.BlockForever
@@ -35,11 +38,18 @@ type PacketHandler func(payload []byte, srcIP, dstIP net.IP, srcPort, dstPort ui
 type Capture struct {
 	handles []*pcap.Handle
 	handler PacketHandler
-	running bool
-	mu      sync.Mutex
-	wg      sync.WaitGroup
 
-	// Status tracking
+	// Hot path: checked on every packet
+	running atomic.Bool
+
+	// Handles slice protection (append at startup, read at shutdown)
+	handlesMu sync.Mutex
+
+	// WaitGroup for all goroutines
+	wg sync.WaitGroup
+
+	// Status tracking (updated per-packet, protected by mutex)
+	mu             sync.Mutex
 	lastPacketTime time.Time
 	isOnline       bool
 	OnlineCallback func(online bool)
@@ -48,9 +58,8 @@ type Capture struct {
 // NewCapture creates a new network capture instance
 func NewCapture(handler PacketHandler) *Capture {
 	return &Capture{
-		handler:  handler,
-		handles:  make([]*pcap.Handle, 0),
-		isOnline: false,
+		handler: handler,
+		handles: make([]*pcap.Handle, 0),
 	}
 }
 
@@ -88,20 +97,20 @@ func (s *Capture) Start() error {
 		return fmt.Errorf("failed to list devices: %w", err)
 	}
 
-	s.mu.Lock()
-	s.running = true
-	s.mu.Unlock()
+	s.running.Store(true)
 
 	// Start capturing on all devices with IPv4 addresses
 	for _, device := range devices {
 		for _, addr := range device.Addresses {
 			if addr.IP.To4() != nil {
+				s.wg.Add(1)
 				go s.captureOnDevice(device.Name, addr.IP.String())
 			}
 		}
 	}
 
 	// Start online status checker
+	s.wg.Add(1)
 	go s.checkOnlineStatus()
 
 	return nil
@@ -109,13 +118,13 @@ func (s *Capture) Start() error {
 
 // StartOnDevice begins capturing packets on a specific device
 func (s *Capture) StartOnDevice(deviceName string) error {
-	s.mu.Lock()
-	s.running = true
-	s.mu.Unlock()
+	s.running.Store(true)
 
+	s.wg.Add(1)
 	go s.captureOnDevice(deviceName, "")
 
 	// Start online status checker
+	s.wg.Add(1)
 	go s.checkOnlineStatus()
 
 	return nil
@@ -123,9 +132,10 @@ func (s *Capture) StartOnDevice(deviceName string) error {
 
 // captureOnDevice captures packets on a specific network device
 func (s *Capture) captureOnDevice(deviceName, ipAddr string) {
+	defer s.wg.Done()
+
 	handle, err := pcap.OpenLive(deviceName, SnapshotLen, Promiscuous, Timeout)
 	if err != nil {
-		// Silently skip devices that can't be opened
 		return
 	}
 
@@ -135,21 +145,24 @@ func (s *Capture) captureOnDevice(deviceName, ipAddr string) {
 		return
 	}
 
-	s.mu.Lock()
+	s.handlesMu.Lock()
 	s.handles = append(s.handles, handle)
-	s.mu.Unlock()
+	s.handlesMu.Unlock()
 
-	s.wg.Add(1)
-	defer s.wg.Done()
-
+	// Use NextPacket() loop instead of Packets() channel.
+	// This avoids the 1000-packet channel buffer and background goroutine
+	// that leaks on shutdown when the channel is full.
 	packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
-	for packet := range packetSource.Packets() {
-		s.mu.Lock()
-		if !s.running {
-			s.mu.Unlock()
+
+	for {
+		if !s.running.Load() {
 			break
 		}
-		s.mu.Unlock()
+
+		packet, err := packetSource.NextPacket()
+		if err != nil {
+			continue
+		}
 
 		s.processPacket(packet)
 	}
@@ -209,16 +222,17 @@ func (s *Capture) processPacket(packet gopacket.Packet) {
 
 // checkOnlineStatus periodically checks if the game is still sending packets
 func (s *Capture) checkOnlineStatus() {
+	defer s.wg.Done()
+
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
 	for range ticker.C {
-		s.mu.Lock()
-		if !s.running {
-			s.mu.Unlock()
+		if !s.running.Load() {
 			return
 		}
 
+		s.mu.Lock()
 		if s.isOnline && time.Since(s.lastPacketTime) > 5*time.Second {
 			s.isOnline = false
 			s.mu.Unlock()
@@ -233,13 +247,13 @@ func (s *Capture) checkOnlineStatus() {
 
 // Stop stops all packet capture
 func (s *Capture) Stop() {
-	s.mu.Lock()
-	s.running = false
-	s.mu.Unlock()
+	s.running.Store(false)
 
+	s.handlesMu.Lock()
 	for _, handle := range s.handles {
 		handle.Close()
 	}
+	s.handlesMu.Unlock()
 
 	s.wg.Wait()
 }

--- a/pkg/photon/parser.go
+++ b/pkg/photon/parser.go
@@ -285,6 +285,14 @@ func (p *Parser) handleSendFragment(data []byte, sequenceNumber int32) {
 
 	fragmentLength := len(data) - FragmentHeaderLength
 
+	// Validate totalLength to prevent OOM from corrupted packets
+	if totalLength <= 0 || totalLength > 10*1024*1024 {
+		if p.debug {
+			fmt.Printf("  [Photon] Fragment totalLength out of range: %d\n", totalLength)
+		}
+		return
+	}
+
 	// Validate we have enough data
 	if r.Remaining() < fragmentLength {
 		if p.debug {

--- a/pkg/photon/protocol16.go
+++ b/pkg/photon/protocol16.go
@@ -130,6 +130,9 @@ func readValue(r *BufferReader, paramType byte) interface{} {
 		if err != nil {
 			return nil
 		}
+		if int(length) > r.Remaining() {
+			return nil
+		}
 		arr, err := r.ReadBytes(int(length))
 		if err != nil {
 			return nil
@@ -139,6 +142,9 @@ func readValue(r *BufferReader, paramType byte) interface{} {
 	case TypeArray:
 		length, err := r.ReadUint16()
 		if err != nil {
+			return nil
+		}
+		if int(length) > r.Remaining() {
 			return nil
 		}
 		elemType, err := r.ReadByte()
@@ -157,6 +163,9 @@ func readValue(r *BufferReader, paramType byte) interface{} {
 		if err != nil {
 			return nil
 		}
+		if int(length) > r.Remaining()/4 {
+			return nil
+		}
 
 		arr := make([]int32, length)
 		for i := 0; i < int(length); i++ {
@@ -171,6 +180,9 @@ func readValue(r *BufferReader, paramType byte) interface{} {
 	case TypeStringArray:
 		length, err := r.ReadUint16()
 		if err != nil {
+			return nil
+		}
+		if int(length) > r.Remaining() {
 			return nil
 		}
 
@@ -194,6 +206,9 @@ func readValue(r *BufferReader, paramType byte) interface{} {
 		}
 		length, err := r.ReadUint16()
 		if err != nil {
+			return nil
+		}
+		if int(length) > r.Remaining() {
 			return nil
 		}
 
@@ -232,6 +247,9 @@ func readValue(r *BufferReader, paramType byte) interface{} {
 	case TypeObjectArray:
 		length, err := r.ReadUint16()
 		if err != nil {
+			return nil
+		}
+		if int(length) > r.Remaining() {
 			return nil
 		}
 


### PR DESCRIPTION
## Summary

Fixes memory exhaustion (100% RAM + swap) that occurred when packet capture started, plus a goroutine leak on shutdown.

## Root Cause

Two independent issues:

1. **Unbounded `make()` from packet data** — The Protocol16 parameter decoder used `uint32` lengths read directly from network packets in `make()` calls without validation. A single corrupted or misaligned `TypeIntegerArray` length could trigger `make([]int32, 2000000000)` = 8 GB allocation, instantly exhausting all system memory.

2. **gopacket `Packets()` goroutine leak** — The `Packets()` method spawns a background goroutine that fills a 1000-packet channel. On `Stop()`, if the goroutine is blocked sending to the full channel, it never reads the closed handle EOF and leaks forever — retaining all 1000 buffered `Packet` objects.

## Changes

### Commit 1: OOM bounds checks
- `protocol16.go`: Validate all array/dict lengths against `r.Remaining()` before `make()`
- `parser.go`: Cap fragment `totalLength` at 10 MB (was unbounded `int32`)

### Commit 2: Capture loop rewrite
- Replace `Packets()` channel with `NextPacket()` loop (eliminates 1000-packet buffer + background goroutine)
- Move `wg.Add(1)` before goroutine launch (fixes shutdown race)
- Use `atomic.Bool` for `running` flag (eliminates mutex contention per packet)
- Track `checkOnlineStatus` goroutine with WaitGroup

## Validation

- `go vet ./...` — clean
- `go test ./...` — all pass
- Manual test: confirmed OOM no longer occurs during active gameplay

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

This PR fixes two critical bugs in packet capture: OOM from corrupted packets (unbounded `make()` with attacker-controlled lengths in Protocol16 decoder) and a goroutine leak on shutdown (gopacket's `Packets()` background goroutine never exiting when the channel is full). Bounds checks were added to `protocol16.go` and `parser.go`, and the capture loop was rewritten from `Packets()` channel to synchronous `NextPacket()` to eliminate the background goroutine and 1000-packet buffer entirely.

---
<sup>Written for commit 2fe0cd957f56a581ae37e56e957caad005822afe. Summary will update on new commits.</sup>
<!-- end-auto-generated -->