### PR TITLE
feat(photon): migrate decoder from Protocol16 to Protocol18

### DIFF
--- a/pkg/photon/buffer.go
+++ b/pkg/photon/buffer.go
@@ -259,3 +259,98 @@ func (r *BufferReader) Slice(n int) (*BufferReader, error) {
 func (r *BufferReader) RemainingBytes() []byte {
 	return r.data[r.offset:]
 }
+
+// ============================================
+// Protocol18: Varint reads (protobuf-style)
+// ============================================
+
+// ReadVarint32 reads a protobuf-style varint as uint32.
+func (r *BufferReader) ReadVarint32() (uint32, error) {
+	var value uint32
+	shift := 0
+	for shift != 35 {
+		b, err := r.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		value |= uint32(b&0x7F) << shift
+		shift += 7
+		if b&0x80 == 0 {
+			return value, nil
+		}
+	}
+	return value, nil
+}
+
+// ReadVarint64 reads a protobuf-style varint as uint64.
+func (r *BufferReader) ReadVarint64() (uint64, error) {
+	var value uint64
+	shift := 0
+	for shift != 70 {
+		b, err := r.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		value |= uint64(b&0x7F) << shift
+		shift += 7
+		if b&0x80 == 0 {
+			return value, nil
+		}
+	}
+	return value, nil
+}
+
+// DecodeZigZag32 decodes a zigzag-encoded uint32 to int32.
+func DecodeZigZag32(value uint32) int32 {
+	return int32((value >> 1) ^ (0 - (value & 1)))
+}
+
+// DecodeZigZag64 decodes a zigzag-encoded uint64 to int64.
+func DecodeZigZag64(value uint64) int64 {
+	return int64((value >> 1) ^ (0 - (value & 1)))
+}
+
+// ============================================
+// Protocol18: Little-endian reads
+// ============================================
+
+// ReadInt16LE reads 2 bytes little-endian as int16.
+func (r *BufferReader) ReadInt16LE() (int16, error) {
+	if !r.CanRead(2) {
+		return 0, ErrBufferUnderflow
+	}
+	val := int16(r.data[r.offset]) | int16(r.data[r.offset+1])<<8
+	r.offset += 2
+	return val, nil
+}
+
+// ReadUint16LE reads 2 bytes little-endian as uint16.
+func (r *BufferReader) ReadUint16LE() (uint16, error) {
+	if !r.CanRead(2) {
+		return 0, ErrBufferUnderflow
+	}
+	val := uint16(r.data[r.offset]) | uint16(r.data[r.offset+1])<<8
+	r.offset += 2
+	return val, nil
+}
+
+// ReadFloat32LE reads 4 bytes little-endian as float32.
+func (r *BufferReader) ReadFloat32LE() (float32, error) {
+	if !r.CanRead(4) {
+		return 0, ErrBufferUnderflow
+	}
+	bits := uint32(r.data[r.offset]) | uint32(r.data[r.offset+1])<<8 |
+		uint32(r.data[r.offset+2])<<16 | uint32(r.data[r.offset+3])<<24
+	r.offset += 4
+	return math.Float32frombits(bits), nil
+}
+
+// ReadFloat64LE reads 8 bytes little-endian as float64.
+func (r *BufferReader) ReadFloat64LE() (float64, error) {
+	if !r.CanRead(8) {
+		return 0, ErrBufferUnderflow
+	}
+	bits := binary.LittleEndian.Uint64(r.data[r.offset:])
+	r.offset += 8
+	return math.Float64frombits(bits), nil
+}

--- a/pkg/photon/buffer.go
+++ b/pkg/photon/buffer.go
@@ -10,6 +10,9 @@ import (
 // ErrBufferUnderflow is returned when there are not enough bytes to read.
 var ErrBufferUnderflow = errors.New("buffer underflow: not enough data to read")
 
+// ErrVarintOverflow is returned when a varint exceeds the maximum valid length.
+var ErrVarintOverflow = errors.New("varint overflow: value exceeds maximum size")
+
 // BufferReader provides sequential reading of a byte buffer
 // with automatic offset management and bounds checking.
 type BufferReader struct {
@@ -267,37 +270,39 @@ func (r *BufferReader) RemainingBytes() []byte {
 // ReadVarint32 reads a protobuf-style varint as uint32.
 func (r *BufferReader) ReadVarint32() (uint32, error) {
 	var value uint32
-	shift := 0
-	for shift != 35 {
+	for shift := 0; shift <= 28; shift += 7 {
 		b, err := r.ReadByte()
 		if err != nil {
 			return 0, err
 		}
-		value |= uint32(b&0x7F) << shift
-		shift += 7
 		if b&0x80 == 0 {
-			return value, nil
+			if shift == 28 && b > 0x0F {
+				return 0, ErrVarintOverflow
+			}
+			return value | uint32(b)<<shift, nil
 		}
+		value |= uint32(b&0x7F) << shift
 	}
-	return value, nil
+	return 0, ErrVarintOverflow
 }
 
 // ReadVarint64 reads a protobuf-style varint as uint64.
 func (r *BufferReader) ReadVarint64() (uint64, error) {
 	var value uint64
-	shift := 0
-	for shift != 70 {
+	for shift := 0; shift <= 63; shift += 7 {
 		b, err := r.ReadByte()
 		if err != nil {
 			return 0, err
 		}
-		value |= uint64(b&0x7F) << shift
-		shift += 7
 		if b&0x80 == 0 {
-			return value, nil
+			if shift == 63 && b > 1 {
+				return 0, ErrVarintOverflow
+			}
+			return value | uint64(b)<<shift, nil
 		}
+		value |= uint64(b&0x7F) << shift
 	}
-	return value, nil
+	return 0, ErrVarintOverflow
 }
 
 // DecodeZigZag32 decodes a zigzag-encoded uint32 to int32.

--- a/pkg/photon/buffer_varint_test.go
+++ b/pkg/photon/buffer_varint_test.go
@@ -1,0 +1,188 @@
+package photon
+
+import (
+	"testing"
+)
+
+func TestReadVarint32(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		want    uint32
+		wantErr error
+	}{
+		{"zero", []byte{0x00}, 0, nil},
+		{"one", []byte{0x01}, 1, nil},
+		{"127", []byte{0x7F}, 127, nil},
+		{"128", []byte{0x80, 0x01}, 128, nil},
+		{"300", []byte{0xAC, 0x02}, 300, nil},
+		{"16384", []byte{0x80, 0x80, 0x01}, 16384, nil},
+		{"max_uint32", []byte{0xFF, 0xFF, 0xFF, 0xFF, 0x0F}, 0xFFFFFFFF, nil},
+		{"truncated", []byte{0x80}, 0, ErrBufferUnderflow},
+		{"overflow_5bytes", []byte{0x80, 0x80, 0x80, 0x80, 0x10}, 0, ErrVarintOverflow},
+		{"overflow_6bytes", []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x01}, 0, ErrVarintOverflow},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewBufferReader(tt.data)
+			got, err := r.ReadVarint32()
+			if tt.wantErr != nil {
+				if err != tt.wantErr {
+					t.Errorf("expected error %v, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("expected %d, got %d", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestReadVarint64(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		want    uint64
+		wantErr error
+	}{
+		{"zero", []byte{0x00}, 0, nil},
+		{"one", []byte{0x01}, 1, nil},
+		{"300", []byte{0xAC, 0x02}, 300, nil},
+		{"max_uint32", []byte{0xFF, 0xFF, 0xFF, 0xFF, 0x0F}, 0xFFFFFFFF, nil},
+		{"large_8bytes", []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F}, 0x00FFFFFFFFFFFFFF, nil},
+		{"max_uint64", []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01}, 0xFFFFFFFFFFFFFFFF, nil},
+		{"truncated", []byte{0x80}, 0, ErrBufferUnderflow},
+		{"overflow_10bytes", []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x02}, 0, ErrVarintOverflow},
+		{"overflow_11bytes", []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01}, 0, ErrVarintOverflow},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewBufferReader(tt.data)
+			got, err := r.ReadVarint64()
+			if tt.wantErr != nil {
+				if err != tt.wantErr {
+					t.Errorf("expected error %v, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("expected %d, got %d", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestDecodeZigZag32(t *testing.T) {
+	tests := []struct {
+		input uint32
+		want  int32
+	}{
+		{0, 0},
+		{1, -1},
+		{2, 1},
+		{3, -2},
+		{4, 2},
+		{10, 5},
+		{11, -6},
+		{9, -5},
+		{0xFFFFFFFF, -2147483648},
+	}
+
+	for _, tt := range tests {
+		got := DecodeZigZag32(tt.input)
+		if got != tt.want {
+			t.Errorf("DecodeZigZag32(%d) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestDecodeZigZag64(t *testing.T) {
+	tests := []struct {
+		input uint64
+		want  int64
+	}{
+		{0, 0},
+		{1, -1},
+		{2, 1},
+		{3, -2},
+		{10, 5},
+		{0xFFFFFFFFFFFFFFFF, -9223372036854775808},
+	}
+
+	for _, tt := range tests {
+		got := DecodeZigZag64(tt.input)
+		if got != tt.want {
+			t.Errorf("DecodeZigZag64(%d) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestReadInt16LE(t *testing.T) {
+	// 0x0201 LE = 513
+	r := NewBufferReader([]byte{0x01, 0x02})
+	val, err := r.ReadInt16LE()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != 513 {
+		t.Errorf("expected 513, got %d", val)
+	}
+
+	// 0xFFFF = -1
+	r = NewBufferReader([]byte{0xFF, 0xFF})
+	val, _ = r.ReadInt16LE()
+	if val != -1 {
+		t.Errorf("expected -1, got %d", val)
+	}
+
+	// underflow
+	r = NewBufferReader([]byte{0x01})
+	_, err = r.ReadInt16LE()
+	if err != ErrBufferUnderflow {
+		t.Errorf("expected ErrBufferUnderflow, got %v", err)
+	}
+}
+
+func TestReadUint16LE(t *testing.T) {
+	r := NewBufferReader([]byte{0x34, 0x12})
+	val, err := r.ReadUint16LE()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != 0x1234 {
+		t.Errorf("expected 0x1234, got 0x%04X", val)
+	}
+}
+
+func TestReadFloat32LE(t *testing.T) {
+	// IEEE 754 float32 1.0 = 0x3F800000, LE: 0x00, 0x00, 0x80, 0x3F
+	r := NewBufferReader([]byte{0x00, 0x00, 0x80, 0x3F})
+	val, err := r.ReadFloat32LE()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != 1.0 {
+		t.Errorf("expected 1.0, got %f", val)
+	}
+}
+
+func TestReadFloat64LE(t *testing.T) {
+	// IEEE 754 float64 1.0 = 0x3FF0000000000000, LE: 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F
+	r := NewBufferReader([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F})
+	val, err := r.ReadFloat64LE()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != 1.0 {
+		t.Errorf("expected 1.0, got %f", val)
+	}
+}

--- a/pkg/photon/parser.go
+++ b/pkg/photon/parser.go
@@ -234,13 +234,8 @@ func (p *Parser) handleSendReliable(data []byte) {
 
 	r := NewBufferReader(data)
 
-	// Read signal byte
-	signalByte, _ := r.ReadByte()
-
-	// Check signal byte
-	if signalByte != 243 && signalByte != 253 {
-		return
-	}
+	// Skip signal byte (Protocol18 does not validate it, unlike Protocol16)
+	_ = r.Skip(1)
 
 	messageType, _ := r.ReadByte()
 
@@ -347,7 +342,7 @@ func (p *Parser) decodeOperationRequest(r *BufferReader) {
 	}
 
 	operationCode, _ := r.ReadByte()
-	parameters := decodeParameterTable(r)
+	parameters := decodeParameterTable18(r)
 
 	p.Stats.IncrRequestsDecoded()
 
@@ -367,26 +362,19 @@ func (p *Parser) decodeOperationResponse(r *BufferReader) {
 	}
 
 	operationCode, _ := r.ReadByte()
-	returnCode, _ := r.ReadInt16()
+	returnCode, _ := r.ReadInt16LE()
 
-	// Read debug message (optional)
+	// Read debug message: type byte + typed value (Protocol18 format)
 	debugMessage := ""
 	if !r.IsEmpty() {
-		paramType, _ := r.PeekByte()
-		if paramType != 0 && paramType != TypeNull {
-			// Read type byte
-			_, _ = r.ReadByte()
-			// Read string value
-			if msg, err := r.ReadString(); err == nil {
-				debugMessage = msg
-			}
-		} else {
-			// Skip null type byte
-			_, _ = r.ReadByte()
+		debugType, _ := r.ReadByte()
+		debugVal := deserialize18(r, debugType)
+		if s, ok := debugVal.(string); ok {
+			debugMessage = s
 		}
 	}
 
-	parameters := decodeParameterTable(r)
+	parameters := decodeParameterTable18(r)
 
 	p.Stats.IncrResponsesDecoded()
 
@@ -406,7 +394,7 @@ func (p *Parser) decodeEventData(r *BufferReader) {
 	}
 
 	eventCode, _ := r.ReadByte()
-	parameters := decodeParameterTable(r)
+	parameters := decodeParameterTable18(r)
 
 	p.Stats.IncrEventsDecoded()
 

--- a/pkg/photon/protocol18.go
+++ b/pkg/photon/protocol18.go
@@ -1,0 +1,460 @@
+package photon
+
+// Protocol18 type codes (from Protocol18Type.cs)
+const (
+	P18Unknown           = 0
+	P18Boolean           = 2
+	P18Byte              = 3
+	P18Short             = 4
+	P18Float             = 5
+	P18Double            = 6
+	P18String            = 7
+	P18Null              = 8
+	P18CompressedInt     = 9
+	P18CompressedLong    = 10
+	P18Int1              = 11
+	P18Int1Negative      = 12
+	P18Int2              = 13
+	P18Int2Negative      = 14
+	P18Long1             = 15
+	P18Long1Negative     = 16
+	P18Long2             = 17
+	P18Long2Negative     = 18
+	P18Custom            = 19
+	P18Dictionary        = 20
+	P18Hashtable         = 21
+	P18ObjectArray       = 23
+	P18OperationRequest  = 24
+	P18OperationResponse = 25
+	P18EventData         = 26
+	P18BooleanFalse      = 27
+	P18BooleanTrue       = 28
+	P18ShortZero         = 29
+	P18IntZero           = 30
+	P18LongZero          = 31
+	P18FloatZero         = 32
+	P18DoubleZero        = 33
+	P18ByteZero          = 34
+	P18Array             = 64
+	P18BooleanArray      = 66
+	P18ByteArray         = 67
+	P18ShortArray        = 68
+	P18FloatArray        = 69
+	P18DoubleArray       = 70
+	P18StringArray       = 71
+	P18CompressedIntArray  = 73
+	P18CompressedLongArray = 74
+	P18CustomTypeArray   = 83
+	P18DictionaryArray   = 84
+	P18HashtableArray    = 85
+	P18CustomTypeSlim    = 128
+)
+
+const maxSlimCustomTypeCode = 228
+
+// decodeParameterTable18 decodes a Protocol18 parameter table.
+// Format: [count:1byte] then for each entry: [key:1byte][typeCode:1byte][value]
+func decodeParameterTable18(r *BufferReader) map[byte]interface{} {
+	if r.Remaining() < 1 {
+		return make(map[byte]interface{})
+	}
+
+	size, _ := r.ReadByte()
+	params := make(map[byte]interface{}, size)
+
+	for i := 0; i < int(size); i++ {
+		if r.Remaining() < 2 {
+			break
+		}
+		key, _ := r.ReadByte()
+		typeCode, _ := r.ReadByte()
+		params[key] = deserialize18(r, typeCode)
+	}
+
+	return params
+}
+
+// deserialize18 dispatches based on Protocol18 type code.
+func deserialize18(r *BufferReader, typeCode byte) interface{} {
+	if typeCode >= P18CustomTypeSlim && typeCode <= maxSlimCustomTypeCode {
+		return deserializeCustomType18(r, typeCode)
+	}
+
+	switch typeCode {
+	case P18Boolean:
+		val, _ := r.ReadByte()
+		return val != 0
+
+	case P18Byte, P18ByteZero:
+		if typeCode == P18ByteZero {
+			return byte(0)
+		}
+		val, _ := r.ReadByte()
+		return val
+
+	case P18Short:
+		val, _ := r.ReadInt16LE()
+		return val
+
+	case P18Float:
+		val, _ := r.ReadFloat32LE()
+		return val
+
+	case P18Double:
+		val, _ := r.ReadFloat64LE()
+		return val
+
+	case P18String:
+		return readString18(r)
+
+	case P18Null, P18Unknown:
+		return nil
+
+	case P18CompressedInt:
+		raw, _ := r.ReadVarint32()
+		return DecodeZigZag32(raw)
+
+	case P18CompressedLong:
+		raw, _ := r.ReadVarint64()
+		return DecodeZigZag64(raw)
+
+	case P18Int1:
+		val, _ := r.ReadByte()
+		return int32(val)
+
+	case P18Int1Negative:
+		val, _ := r.ReadByte()
+		return -int32(val)
+
+	case P18Int2:
+		val, _ := r.ReadUint16LE()
+		return int32(val)
+
+	case P18Int2Negative:
+		val, _ := r.ReadUint16LE()
+		return -int32(val)
+
+	case P18Long1:
+		val, _ := r.ReadByte()
+		return int64(val)
+
+	case P18Long1Negative:
+		val, _ := r.ReadByte()
+		return -int64(val)
+
+	case P18Long2:
+		val, _ := r.ReadUint16LE()
+		return int64(val)
+
+	case P18Long2Negative:
+		val, _ := r.ReadUint16LE()
+		return -int64(val)
+
+	case P18Dictionary:
+		return deserializeDictionary18(r)
+
+	case P18Hashtable:
+		return deserializeHashtable18(r)
+
+	case P18ObjectArray:
+		return deserializeObjectArray18(r)
+
+	case P18BooleanFalse:
+		return false
+
+	case P18BooleanTrue:
+		return true
+
+	case P18ShortZero:
+		return int16(0)
+
+	case P18IntZero:
+		return int32(0)
+
+	case P18LongZero:
+		return int64(0)
+
+	case P18FloatZero:
+		return float32(0)
+
+	case P18DoubleZero:
+		return float64(0)
+
+	case P18ByteArray:
+		return deserializeByteArray18(r)
+
+	case P18ShortArray:
+		return deserializeShortArray18(r)
+
+	case P18FloatArray:
+		return deserializeFloatArray18(r)
+
+	case P18DoubleArray:
+		return deserializeDoubleArray18(r)
+
+	case P18StringArray:
+		return deserializeStringArray18(r)
+
+	case P18CompressedIntArray:
+		return deserializeCompressedIntArray18(r)
+
+	case P18CompressedLongArray:
+		return deserializeCompressedLongArray18(r)
+
+	case P18BooleanArray:
+		return deserializeBooleanArray18(r)
+
+	case P18Custom:
+		return deserializeCustomType18(r, 0)
+
+	default:
+		return nil
+	}
+}
+
+func readString18(r *BufferReader) string {
+	strLen, err := r.ReadVarint32()
+	if err != nil || strLen == 0 {
+		return ""
+	}
+	if int(strLen) > r.Remaining() {
+		return ""
+	}
+	b, err := r.ReadBytes(int(strLen))
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func deserializeDictionary18(r *BufferReader) map[interface{}]interface{} {
+	if r.Remaining() < 2 {
+		return nil
+	}
+	keyType, _ := r.ReadByte()
+	valueType, _ := r.ReadByte()
+
+	size, err := r.ReadVarint32()
+	if err != nil || size == 0 || int(size) > r.Remaining() {
+		return make(map[interface{}]interface{})
+	}
+
+	dict := make(map[interface{}]interface{}, size)
+
+	for i := uint32(0); i < size && !r.IsEmpty(); i++ {
+		var key, val interface{}
+		if keyType == P18Unknown {
+			if r.IsEmpty() {
+				break
+			}
+			kt, _ := r.ReadByte()
+			key = deserialize18(r, kt)
+		} else {
+			key = deserialize18(r, keyType)
+		}
+		if valueType == P18Unknown {
+			if r.IsEmpty() {
+				break
+			}
+			vt, _ := r.ReadByte()
+			val = deserialize18(r, vt)
+		} else {
+			val = deserialize18(r, valueType)
+		}
+		if key != nil {
+			dict[key] = val
+		}
+	}
+
+	return dict
+}
+
+func deserializeHashtable18(r *BufferReader) map[interface{}]interface{} {
+	size, err := r.ReadVarint32()
+	if err != nil || size == 0 || int(size) > r.Remaining() {
+		return make(map[interface{}]interface{})
+	}
+
+	dict := make(map[interface{}]interface{}, size)
+
+	for i := uint32(0); i < size && !r.IsEmpty(); i++ {
+		if r.IsEmpty() {
+			break
+		}
+		kt, _ := r.ReadByte()
+		key := deserialize18(r, kt)
+		if r.IsEmpty() {
+			break
+		}
+		vt, _ := r.ReadByte()
+		val := deserialize18(r, vt)
+		if key != nil {
+			dict[key] = val
+		}
+	}
+
+	return dict
+}
+
+func deserializeObjectArray18(r *BufferReader) []interface{} {
+	size, err := r.ReadVarint32()
+	if err != nil || int(size) > r.Remaining() {
+		return nil
+	}
+
+	arr := make([]interface{}, size)
+	for i := uint32(0); i < size && !r.IsEmpty(); i++ {
+		elemType, _ := r.ReadByte()
+		arr[i] = deserialize18(r, elemType)
+	}
+	return arr
+}
+
+func deserializeByteArray18(r *BufferReader) []byte {
+	arrLen, err := r.ReadVarint32()
+	if err != nil || int(arrLen) > r.Remaining() {
+		return nil
+	}
+	b, err := r.ReadBytes(int(arrLen))
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+func deserializeShortArray18(r *BufferReader) []int16 {
+	arrLen, err := r.ReadVarint32()
+	if err != nil || int(arrLen*2) > r.Remaining() {
+		return nil
+	}
+	arr := make([]int16, arrLen)
+	for i := uint32(0); i < arrLen; i++ {
+		val, err := r.ReadInt16LE()
+		if err != nil {
+			break
+		}
+		arr[i] = val
+	}
+	return arr
+}
+
+func deserializeFloatArray18(r *BufferReader) []float32 {
+	arrLen, err := r.ReadVarint32()
+	if err != nil || int(arrLen*4) > r.Remaining() {
+		return nil
+	}
+	arr := make([]float32, arrLen)
+	for i := uint32(0); i < arrLen; i++ {
+		val, err := r.ReadFloat32LE()
+		if err != nil {
+			break
+		}
+		arr[i] = val
+	}
+	return arr
+}
+
+func deserializeDoubleArray18(r *BufferReader) []float64 {
+	arrLen, err := r.ReadVarint32()
+	if err != nil || int(arrLen*8) > r.Remaining() {
+		return nil
+	}
+	arr := make([]float64, arrLen)
+	for i := uint32(0); i < arrLen; i++ {
+		val, err := r.ReadFloat64LE()
+		if err != nil {
+			break
+		}
+		arr[i] = val
+	}
+	return arr
+}
+
+func deserializeStringArray18(r *BufferReader) []string {
+	arrLen, err := r.ReadVarint32()
+	if err != nil || int(arrLen) > r.Remaining() {
+		return nil
+	}
+	arr := make([]string, arrLen)
+	for i := uint32(0); i < arrLen && !r.IsEmpty(); i++ {
+		arr[i] = readString18(r)
+	}
+	return arr
+}
+
+func deserializeCompressedIntArray18(r *BufferReader) []int32 {
+	arrLen, err := r.ReadVarint32()
+	if err != nil || int(arrLen) > r.Remaining() {
+		return nil
+	}
+	arr := make([]int32, arrLen)
+	for i := uint32(0); i < arrLen && !r.IsEmpty(); i++ {
+		raw, err := r.ReadVarint32()
+		if err != nil {
+			break
+		}
+		arr[i] = DecodeZigZag32(raw)
+	}
+	return arr
+}
+
+func deserializeCompressedLongArray18(r *BufferReader) []int64 {
+	arrLen, err := r.ReadVarint32()
+	if err != nil || int(arrLen) > r.Remaining() {
+		return nil
+	}
+	arr := make([]int64, arrLen)
+	for i := uint32(0); i < arrLen && !r.IsEmpty(); i++ {
+		raw, err := r.ReadVarint64()
+		if err != nil {
+			break
+		}
+		arr[i] = DecodeZigZag64(raw)
+	}
+	return arr
+}
+
+func deserializeBooleanArray18(r *BufferReader) []bool {
+	arrLen, err := r.ReadVarint32()
+	if err != nil || int(arrLen) > r.Remaining()*8 {
+		return nil
+	}
+	arr := make([]bool, arrLen)
+	fullBytes := arrLen / 8
+	idx := uint32(0)
+	for i := uint32(0); i < fullBytes; i++ {
+		b, _ := r.ReadByte()
+		for bit := 0; bit < 8 && idx < arrLen; bit++ {
+			arr[idx] = b&(1<<bit) != 0
+			idx++
+		}
+	}
+	for idx < arrLen {
+		b, _ := r.ReadByte()
+		bit := uint32(0)
+		for idx < arrLen && bit < 8 {
+			arr[idx] = b&(1<<bit) != 0
+			idx++
+			bit++
+		}
+	}
+	return arr
+}
+
+func deserializeCustomType18(r *BufferReader, slimCode byte) interface{} {
+	var typeCode byte
+	if slimCode == 0 {
+		typeCode, _ = r.ReadByte()
+	} else {
+		typeCode = slimCode - P18CustomTypeSlim
+	}
+	length, err := r.ReadVarint32()
+	if err != nil || int(length) > r.Remaining() {
+		return nil
+	}
+	data, _ := r.ReadBytes(int(length))
+	return map[string]interface{}{
+		"customTypeCode": typeCode,
+		"data":           data,
+	}
+}

--- a/pkg/photon/protocol18.go
+++ b/pkg/photon/protocol18.go
@@ -159,6 +159,15 @@ func deserialize18(r *BufferReader, typeCode byte) interface{} {
 	case P18ObjectArray:
 		return deserializeObjectArray18(r)
 
+	case P18CustomTypeArray:
+		return deserializeCustomTypeArray18(r)
+
+	case P18DictionaryArray:
+		return deserializeDictionaryArray18(r)
+
+	case P18HashtableArray:
+		return deserializeHashtableArray18(r)
+
 	case P18BooleanFalse:
 		return false
 
@@ -233,7 +242,10 @@ func deserializeDictionary18(r *BufferReader) map[interface{}]interface{} {
 	}
 	keyType, _ := r.ReadByte()
 	valueType, _ := r.ReadByte()
+	return deserializeDictEntries18(r, keyType, valueType)
+}
 
+func deserializeDictEntries18(r *BufferReader, keyType, valueType byte) map[interface{}]interface{} {
 	size, err := r.ReadVarint32()
 	if err != nil || size == 0 || int(size) > r.Remaining() {
 		return make(map[interface{}]interface{})
@@ -324,7 +336,7 @@ func deserializeByteArray18(r *BufferReader) []byte {
 
 func deserializeShortArray18(r *BufferReader) []int16 {
 	arrLen, err := r.ReadVarint32()
-	if err != nil || int(arrLen*2) > r.Remaining() {
+	if err != nil || arrLen > uint32(r.Remaining())/2 {
 		return nil
 	}
 	arr := make([]int16, arrLen)
@@ -340,7 +352,7 @@ func deserializeShortArray18(r *BufferReader) []int16 {
 
 func deserializeFloatArray18(r *BufferReader) []float32 {
 	arrLen, err := r.ReadVarint32()
-	if err != nil || int(arrLen*4) > r.Remaining() {
+	if err != nil || arrLen > uint32(r.Remaining())/4 {
 		return nil
 	}
 	arr := make([]float32, arrLen)
@@ -356,7 +368,7 @@ func deserializeFloatArray18(r *BufferReader) []float32 {
 
 func deserializeDoubleArray18(r *BufferReader) []float64 {
 	arrLen, err := r.ReadVarint32()
-	if err != nil || int(arrLen*8) > r.Remaining() {
+	if err != nil || arrLen > uint32(r.Remaining())/8 {
 		return nil
 	}
 	arr := make([]float64, arrLen)
@@ -457,4 +469,54 @@ func deserializeCustomType18(r *BufferReader, slimCode byte) interface{} {
 		"customTypeCode": typeCode,
 		"data":           data,
 	}
+}
+
+func deserializeCustomTypeArray18(r *BufferReader) []interface{} {
+	arrLen, err := r.ReadVarint32()
+	if err != nil || arrLen > uint32(r.Remaining()) {
+		return nil
+	}
+	typeCode, _ := r.ReadByte()
+	arr := make([]interface{}, arrLen)
+	for i := uint32(0); i < arrLen && !r.IsEmpty(); i++ {
+		length, err := r.ReadVarint32()
+		if err != nil || int(length) > r.Remaining() {
+			break
+		}
+		data, _ := r.ReadBytes(int(length))
+		arr[i] = map[string]interface{}{
+			"customTypeCode": typeCode,
+			"data":           data,
+		}
+	}
+	return arr
+}
+
+func deserializeDictionaryArray18(r *BufferReader) []map[interface{}]interface{} {
+	if r.Remaining() < 2 {
+		return nil
+	}
+	keyType, _ := r.ReadByte()
+	valueType, _ := r.ReadByte()
+	arrLen, err := r.ReadVarint32()
+	if err != nil || arrLen > uint32(r.Remaining()) {
+		return nil
+	}
+	arr := make([]map[interface{}]interface{}, arrLen)
+	for i := uint32(0); i < arrLen && !r.IsEmpty(); i++ {
+		arr[i] = deserializeDictEntries18(r, keyType, valueType)
+	}
+	return arr
+}
+
+func deserializeHashtableArray18(r *BufferReader) []map[interface{}]interface{} {
+	arrLen, err := r.ReadVarint32()
+	if err != nil || arrLen > uint32(r.Remaining()) {
+		return nil
+	}
+	arr := make([]map[interface{}]interface{}, arrLen)
+	for i := uint32(0); i < arrLen && !r.IsEmpty(); i++ {
+		arr[i] = deserializeHashtable18(r)
+	}
+	return arr
 }

--- a/pkg/photon/protocol18.go
+++ b/pkg/photon/protocol18.go
@@ -50,8 +50,6 @@ const (
 	P18CustomTypeSlim    = 128
 )
 
-const maxSlimCustomTypeCode = 228
-
 // decodeParameterTable18 decodes a Protocol18 parameter table.
 // Format: [count:1byte] then for each entry: [key:1byte][typeCode:1byte][value]
 func decodeParameterTable18(r *BufferReader) map[byte]interface{} {
@@ -76,7 +74,7 @@ func decodeParameterTable18(r *BufferReader) map[byte]interface{} {
 
 // deserialize18 dispatches based on Protocol18 type code.
 func deserialize18(r *BufferReader, typeCode byte) interface{} {
-	if typeCode >= P18CustomTypeSlim && typeCode <= maxSlimCustomTypeCode {
+	if typeCode >= P18CustomTypeSlim {
 		return deserializeCustomType18(r, typeCode)
 	}
 
@@ -156,7 +154,7 @@ func deserialize18(r *BufferReader, typeCode byte) interface{} {
 	case P18Hashtable:
 		return deserializeHashtable18(r)
 
-	case P18ObjectArray:
+	case P18ObjectArray, P18Array:
 		return deserializeObjectArray18(r)
 
 	case P18CustomTypeArray:
@@ -226,7 +224,8 @@ func readString18(r *BufferReader) string {
 	if err != nil || strLen == 0 {
 		return ""
 	}
-	if int(strLen) > r.Remaining() {
+	if strLen > uint32(r.Remaining()) {
+		_ = r.Skip(r.Remaining())
 		return ""
 	}
 	b, err := r.ReadBytes(int(strLen))
@@ -247,7 +246,7 @@ func deserializeDictionary18(r *BufferReader) map[interface{}]interface{} {
 
 func deserializeDictEntries18(r *BufferReader, keyType, valueType byte) map[interface{}]interface{} {
 	size, err := r.ReadVarint32()
-	if err != nil || size == 0 || int(size) > r.Remaining() {
+	if err != nil || size == 0 || size > uint32(r.Remaining()) {
 		return make(map[interface{}]interface{})
 	}
 
@@ -283,7 +282,7 @@ func deserializeDictEntries18(r *BufferReader, keyType, valueType byte) map[inte
 
 func deserializeHashtable18(r *BufferReader) map[interface{}]interface{} {
 	size, err := r.ReadVarint32()
-	if err != nil || size == 0 || int(size) > r.Remaining() {
+	if err != nil || size == 0 || size > uint32(r.Remaining()) {
 		return make(map[interface{}]interface{})
 	}
 
@@ -310,7 +309,7 @@ func deserializeHashtable18(r *BufferReader) map[interface{}]interface{} {
 
 func deserializeObjectArray18(r *BufferReader) []interface{} {
 	size, err := r.ReadVarint32()
-	if err != nil || int(size) > r.Remaining() {
+	if err != nil || size > uint32(r.Remaining()) {
 		return nil
 	}
 
@@ -324,7 +323,7 @@ func deserializeObjectArray18(r *BufferReader) []interface{} {
 
 func deserializeByteArray18(r *BufferReader) []byte {
 	arrLen, err := r.ReadVarint32()
-	if err != nil || int(arrLen) > r.Remaining() {
+	if err != nil || arrLen > uint32(r.Remaining()) {
 		return nil
 	}
 	b, err := r.ReadBytes(int(arrLen))
@@ -384,7 +383,7 @@ func deserializeDoubleArray18(r *BufferReader) []float64 {
 
 func deserializeStringArray18(r *BufferReader) []string {
 	arrLen, err := r.ReadVarint32()
-	if err != nil || int(arrLen) > r.Remaining() {
+	if err != nil || arrLen > uint32(r.Remaining()) {
 		return nil
 	}
 	arr := make([]string, arrLen)
@@ -396,7 +395,7 @@ func deserializeStringArray18(r *BufferReader) []string {
 
 func deserializeCompressedIntArray18(r *BufferReader) []int32 {
 	arrLen, err := r.ReadVarint32()
-	if err != nil || int(arrLen) > r.Remaining() {
+	if err != nil || arrLen > uint32(r.Remaining()) {
 		return nil
 	}
 	arr := make([]int32, arrLen)
@@ -412,7 +411,7 @@ func deserializeCompressedIntArray18(r *BufferReader) []int32 {
 
 func deserializeCompressedLongArray18(r *BufferReader) []int64 {
 	arrLen, err := r.ReadVarint32()
-	if err != nil || int(arrLen) > r.Remaining() {
+	if err != nil || arrLen > uint32(r.Remaining()) {
 		return nil
 	}
 	arr := make([]int64, arrLen)
@@ -428,7 +427,7 @@ func deserializeCompressedLongArray18(r *BufferReader) []int64 {
 
 func deserializeBooleanArray18(r *BufferReader) []bool {
 	arrLen, err := r.ReadVarint32()
-	if err != nil || int(arrLen) > r.Remaining()*8 {
+	if err != nil || arrLen > uint32(r.Remaining())*8 {
 		return nil
 	}
 	arr := make([]bool, arrLen)
@@ -461,7 +460,8 @@ func deserializeCustomType18(r *BufferReader, slimCode byte) interface{} {
 		typeCode = slimCode - P18CustomTypeSlim
 	}
 	length, err := r.ReadVarint32()
-	if err != nil || int(length) > r.Remaining() {
+	if err != nil || length > uint32(r.Remaining()) {
+		_ = r.Skip(r.Remaining())
 		return nil
 	}
 	data, _ := r.ReadBytes(int(length))
@@ -480,7 +480,8 @@ func deserializeCustomTypeArray18(r *BufferReader) []interface{} {
 	arr := make([]interface{}, arrLen)
 	for i := uint32(0); i < arrLen && !r.IsEmpty(); i++ {
 		length, err := r.ReadVarint32()
-		if err != nil || int(length) > r.Remaining() {
+		if err != nil || length > uint32(r.Remaining()) {
+			_ = r.Skip(r.Remaining())
 			break
 		}
 		data, _ := r.ReadBytes(int(length))

--- a/pkg/photon/protocol18_test.go
+++ b/pkg/photon/protocol18_test.go
@@ -1,0 +1,528 @@
+package photon
+
+import (
+	"math"
+	"testing"
+)
+
+func TestDeserialize18_SimpleTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		typeCode byte
+		data     []byte
+		want     interface{}
+	}{
+		{"boolean_true", P18Boolean, []byte{0x01}, true},
+		{"boolean_false", P18Boolean, []byte{0x00}, false},
+		{"boolean_true_const", P18BooleanTrue, []byte{}, true},
+		{"boolean_false_const", P18BooleanFalse, []byte{}, false},
+		{"byte", P18Byte, []byte{0x42}, byte(0x42)},
+		{"byte_zero", P18ByteZero, []byte{}, byte(0)},
+		{"short", P18Short, []byte{0x34, 0x12}, int16(0x1234)},
+		{"short_zero", P18ShortZero, []byte{}, int16(0)},
+		{"float", P18Float, []byte{0x00, 0x00, 0x80, 0x3F}, float32(1.0)},
+		{"float_zero", P18FloatZero, []byte{}, float32(0)},
+		{"double", P18Double, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F}, float64(1.0)},
+		{"double_zero", P18DoubleZero, []byte{}, float64(0)},
+		{"null", P18Null, []byte{}, nil},
+		{"int_zero", P18IntZero, []byte{}, int32(0)},
+		{"long_zero", P18LongZero, []byte{}, int64(0)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewBufferReader(tt.data)
+			got := deserialize18(r, tt.typeCode)
+			if got != tt.want {
+				t.Errorf("expected %v (%T), got %v (%T)", tt.want, tt.want, got, got)
+			}
+		})
+	}
+}
+
+func TestDeserialize18_CompressedInt(t *testing.T) {
+	r := NewBufferReader([]byte{0x00})
+	got := deserialize18(r, P18CompressedInt)
+	if got != int32(0) {
+		t.Errorf("expected 0, got %v", got)
+	}
+
+	// varint 1 -> zigzag -1
+	r = NewBufferReader([]byte{0x01})
+	got = deserialize18(r, P18CompressedInt)
+	if got != int32(-1) {
+		t.Errorf("expected -1, got %v", got)
+	}
+
+	// varint 2 -> zigzag 1
+	r = NewBufferReader([]byte{0x02})
+	got = deserialize18(r, P18CompressedInt)
+	if got != int32(1) {
+		t.Errorf("expected 1, got %v", got)
+	}
+}
+
+func TestDeserialize18_SmallInts(t *testing.T) {
+	// Int1: single byte value
+	r := NewBufferReader([]byte{42})
+	got := deserialize18(r, P18Int1)
+	if got != int32(42) {
+		t.Errorf("Int1: expected 42, got %v", got)
+	}
+
+	// Int1Negative: single byte negated
+	r = NewBufferReader([]byte{42})
+	got = deserialize18(r, P18Int1Negative)
+	if got != int32(-42) {
+		t.Errorf("Int1Negative: expected -42, got %v", got)
+	}
+
+	// Int2: uint16 LE
+	r = NewBufferReader([]byte{0x34, 0x12})
+	got = deserialize18(r, P18Int2)
+	if got != int32(0x1234) {
+		t.Errorf("Int2: expected %d, got %v", 0x1234, got)
+	}
+
+	// Long1
+	r = NewBufferReader([]byte{7})
+	got = deserialize18(r, P18Long1)
+	if got != int64(7) {
+		t.Errorf("Long1: expected 7, got %v", got)
+	}
+}
+
+func TestDeserialize18_String(t *testing.T) {
+	// "hi" - varint length 2, then "hi"
+	r := NewBufferReader([]byte{0x02, 'h', 'i'})
+	got := deserialize18(r, P18String)
+	if got != "hi" {
+		t.Errorf("expected 'hi', got %v", got)
+	}
+
+	// empty string
+	r = NewBufferReader([]byte{0x00})
+	got = deserialize18(r, P18String)
+	if got != "" {
+		t.Errorf("expected '', got %v", got)
+	}
+}
+
+func TestDecodeParameterTable18(t *testing.T) {
+	// 2 params:
+	//   key=1, type=CompressedInt(9), value=varint 0 -> zigzag 0
+	//   key=2, type=String(7), value="ok"
+	data := []byte{
+		0x02,                   // 2 entries
+		0x01, 0x09, 0x00,       // key=1, CompressedInt, varint 0
+		0x02, 0x07, 0x02, 'o', 'k', // key=2, String, len=2, "ok"
+	}
+	r := NewBufferReader(data)
+	params := decodeParameterTable18(r)
+
+	if len(params) != 2 {
+		t.Fatalf("expected 2 params, got %d", len(params))
+	}
+	if params[1] != int32(0) {
+		t.Errorf("param[1]: expected int32(0), got %v (%T)", params[1], params[1])
+	}
+	if params[2] != "ok" {
+		t.Errorf("param[2]: expected 'ok', got %v", params[2])
+	}
+}
+
+func TestDecodeParameterTable18_Empty(t *testing.T) {
+	r := NewBufferReader([]byte{0x00})
+	params := decodeParameterTable18(r)
+	if len(params) != 0 {
+		t.Errorf("expected 0 params, got %d", len(params))
+	}
+}
+
+func TestDeserializeShortArray18(t *testing.T) {
+	// 3 shorts: [10, 20, -1] in LE
+	data := []byte{
+		0x03,                   // array length = 3
+		0x0A, 0x00,             // 10
+		0x14, 0x00,             // 20
+		0xFF, 0xFF,             // -1
+	}
+	r := NewBufferReader(data)
+	arr := deserializeShortArray18(r)
+	if len(arr) != 3 {
+		t.Fatalf("expected 3 elements, got %d", len(arr))
+	}
+	if arr[0] != 10 || arr[1] != 20 || arr[2] != -1 {
+		t.Errorf("expected [10, 20, -1], got %v", arr)
+	}
+}
+
+func TestDeserializeShortArray18_OverflowProtection(t *testing.T) {
+	// Crafted varint that decodes to a huge array length but with very few bytes remaining.
+	// arrLen = 0x80000002 (2147483650), elemSize = 2
+	// Old code: int(arrLen*2) = int(0x00000004) = 4 > remaining -> might pass or fail depending on remaining
+	// New code: arrLen > remaining/2 -> 2147483650 > small_number -> rejects
+	// Encode 0x80000002 as varint: byte0=0x82, byte1=0x80, byte2=0x80, byte3=0x80, byte4=0x04
+	// (0x80000002 = 2147483650)
+	// Varint encoding: 0x02|0x80, 0x00|0x80, 0x00|0x80, 0x00|0x80, 0x04
+	// Check: (2) | (0<<7) | (0<<14) | (0<<21) | (4<<28) = 2 + 0 + 0 + 0 + 0x40000000 = 0x40000002
+	// That's not right. Let me compute: we want 0x80000002
+	// Bits: 10 00000 00000000 00000000 00000010
+	// Group by 7 from LSB: 0000010 | 0000000 | 0000000 | 0000000 | 0000100 (5 groups)
+	// Wait: 0x80000002 = 2^31 + 2
+	// In 7-bit groups (LSB first): 
+	//   2 & 0x7F = 0x02, shift >> 7
+	//   0 & 0x7F = 0x00, shift >> 7
+	//   0 & 0x7F = 0x00, shift >> 7
+	//   0 & 0x7F = 0x00, shift >> 7
+	//   (0x80000002 >> 28) & 0x0F = 0x08
+	// So varint bytes: 0x82, 0x80, 0x80, 0x80, 0x08
+	data := []byte{
+		0x82, 0x80, 0x80, 0x80, 0x08, // varint = 0x80000002
+		0xFF, 0xFF, // only 2 bytes of data (1 short)
+	}
+	r := NewBufferReader(data)
+	arr := deserializeShortArray18(r)
+	if arr != nil {
+		t.Errorf("expected nil (overflow protection), got %v", arr)
+	}
+}
+
+func TestDeserializeFloatArray18(t *testing.T) {
+	// 2 floats: [1.0, -1.0] in LE
+	data := []byte{
+		0x02,
+		0x00, 0x00, 0x80, 0x3F, // 1.0
+		0x00, 0x00, 0x80, 0xBF, // -1.0
+	}
+	r := NewBufferReader(data)
+	arr := deserializeFloatArray18(r)
+	if len(arr) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(arr))
+	}
+	if arr[0] != 1.0 || arr[1] != -1.0 {
+		t.Errorf("expected [1.0, -1.0], got %v", arr)
+	}
+}
+
+func TestDeserializeFloatArray18_OverflowProtection(t *testing.T) {
+	// arrLen = 0x80000002, elemSize = 4
+	// old code: int(0x80000002*4) = int(0x00000008) = 8
+	// new code: 0x80000002 > remaining/4
+	data := []byte{
+		0x82, 0x80, 0x80, 0x80, 0x08, // varint = 0x80000002
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	}
+	r := NewBufferReader(data)
+	arr := deserializeFloatArray18(r)
+	if arr != nil {
+		t.Errorf("expected nil (overflow protection), got %v", arr)
+	}
+}
+
+func TestDeserializeDoubleArray18(t *testing.T) {
+	// 1 double: [1.0] in LE
+	data := []byte{
+		0x01,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F,
+	}
+	r := NewBufferReader(data)
+	arr := deserializeDoubleArray18(r)
+	if len(arr) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(arr))
+	}
+	if arr[0] != 1.0 {
+		t.Errorf("expected [1.0], got %v", arr)
+	}
+}
+
+func TestDeserializeDoubleArray18_OverflowProtection(t *testing.T) {
+	// arrLen = 0x80000002, elemSize = 8
+	// old code: int(0x80000002*8) = int(0x00000010) = 16
+	// new code: 0x80000002 > remaining/8
+	data := []byte{
+		0x82, 0x80, 0x80, 0x80, 0x08,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+	r := NewBufferReader(data)
+	arr := deserializeDoubleArray18(r)
+	if arr != nil {
+		t.Errorf("expected nil (overflow protection), got %v", arr)
+	}
+}
+
+func TestDeserializeByteArray18(t *testing.T) {
+	data := []byte{0x03, 0xAA, 0xBB, 0xCC}
+	r := NewBufferReader(data)
+	arr := deserializeByteArray18(r)
+	if len(arr) != 3 {
+		t.Fatalf("expected 3 bytes, got %d", len(arr))
+	}
+	if arr[0] != 0xAA || arr[1] != 0xBB || arr[2] != 0xCC {
+		t.Errorf("expected [0xAA, 0xBB, 0xCC], got %v", arr)
+	}
+}
+
+func TestDeserializeStringArray18(t *testing.T) {
+	// ["ab", "c"]
+	data := []byte{
+		0x02,             // 2 strings
+		0x02, 'a', 'b',  // "ab"
+		0x01, 'c',        // "c"
+	}
+	r := NewBufferReader(data)
+	arr := deserializeStringArray18(r)
+	if len(arr) != 2 {
+		t.Fatalf("expected 2 strings, got %d", len(arr))
+	}
+	if arr[0] != "ab" || arr[1] != "c" {
+		t.Errorf("expected ['ab', 'c'], got %v", arr)
+	}
+}
+
+func TestDeserializeCompressedIntArray18(t *testing.T) {
+	// [0, -1, 1] -> varints: 0(zigzag 0), 1(zigzag -1), 2(zigzag 1)
+	data := []byte{0x03, 0x00, 0x01, 0x02}
+	r := NewBufferReader(data)
+	arr := deserializeCompressedIntArray18(r)
+	if len(arr) != 3 {
+		t.Fatalf("expected 3 elements, got %d", len(arr))
+	}
+	if arr[0] != 0 || arr[1] != -1 || arr[2] != 1 {
+		t.Errorf("expected [0, -1, 1], got %v", arr)
+	}
+}
+
+func TestDeserializeBooleanArray18(t *testing.T) {
+	// 10 booleans packed in 2 bytes: 0b00000011, 0b00000001
+	// bits: 1,1,0,0,0,0,0,0, 1,0,0,0,0,0,0,0
+	data := []byte{0x0A, 0x03, 0x01}
+	r := NewBufferReader(data)
+	arr := deserializeBooleanArray18(r)
+	if len(arr) != 10 {
+		t.Fatalf("expected 10 elements, got %d", len(arr))
+	}
+	expected := []bool{true, true, false, false, false, false, false, false, true, false}
+	for i, want := range expected {
+		if arr[i] != want {
+			t.Errorf("index %d: expected %v, got %v", i, want, arr[i])
+		}
+	}
+}
+
+func TestDeserializeDictionary18(t *testing.T) {
+	// keyType=CompressedInt(9), valueType=String(7), size=2
+	// entry: key=varint 0 (zigzag 0=0), value="x"
+	// entry: key=varint 2 (zigzag 1), value="y"
+	data := []byte{
+		0x09, 0x07,       // keyType=P18CompressedInt, valueType=P18String
+		0x02,             // size=2
+		0x00,             // key: varint 0 -> zigzag 0
+		0x01, 'x',        // value: string len=1 "x"
+		0x02,             // key: varint 2 -> zigzag 1
+		0x01, 'y',        // value: string len=1 "y"
+	}
+	r := NewBufferReader(data)
+	dict := deserializeDictionary18(r)
+	if dict == nil {
+		t.Fatal("expected non-nil dictionary")
+	}
+	if len(dict) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(dict))
+	}
+	if dict[int32(0)] != "x" {
+		t.Errorf("dict[0]: expected 'x', got %v", dict[int32(0)])
+	}
+	if dict[int32(1)] != "y" {
+		t.Errorf("dict[1]: expected 'y', got %v", dict[int32(1)])
+	}
+}
+
+func TestDeserializeHashtable18(t *testing.T) {
+	// size=2, each entry: [keyType][key][valueType][value]
+	data := []byte{
+		0x02,                   // size=2
+		0x09, 0x00,             // keyType=CompressedInt, key=varint 0 (zigzag 0)
+		0x07, 0x01, 'A',        // valueType=String, "A"
+		0x09, 0x02,             // keyType=CompressedInt, key=varint 2 (zigzag 1)
+		0x07, 0x01, 'B',        // valueType=String, "B"
+	}
+	r := NewBufferReader(data)
+	dict := deserializeHashtable18(r)
+	if dict == nil {
+		t.Fatal("expected non-nil hashtable")
+	}
+	if len(dict) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(dict))
+	}
+}
+
+func TestDeserializeObjectArray18(t *testing.T) {
+	// [1, "hi"] -> types: CompressedInt, String
+	data := []byte{
+		0x02,                   // 2 elements
+		0x09, 0x00,             // CompressedInt, varint 0 (zigzag 0)
+		0x07, 0x02, 'h', 'i',   // String, len=2 "hi"
+	}
+	r := NewBufferReader(data)
+	arr := deserializeObjectArray18(r)
+	if len(arr) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(arr))
+	}
+	if arr[0] != int32(0) {
+		t.Errorf("element 0: expected int32(0), got %v", arr[0])
+	}
+	if arr[1] != "hi" {
+		t.Errorf("element 1: expected 'hi', got %v", arr[1])
+	}
+}
+
+func TestDeserializeCustomType18(t *testing.T) {
+	// typeCode=5, length=3, data=[1,2,3]
+	data := []byte{0x05, 0x03, 0x01, 0x02, 0x03}
+	r := NewBufferReader(data)
+	got := deserializeCustomType18(r, 0)
+	m, ok := got.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map, got %T", got)
+	}
+	if m["customTypeCode"] != byte(5) {
+		t.Errorf("expected typeCode 5, got %v", m["customTypeCode"])
+	}
+	dataBytes, ok := m["data"].([]byte)
+	if !ok {
+		t.Fatalf("expected []byte, got %T", m["data"])
+	}
+	if len(dataBytes) != 3 || dataBytes[0] != 1 || dataBytes[1] != 2 || dataBytes[2] != 3 {
+		t.Errorf("expected [1,2,3], got %v", dataBytes)
+	}
+}
+
+func TestDeserializeCustomTypeArray18(t *testing.T) {
+	// typeCode=5, arrayLen=2, each element: [length][data]
+	data := []byte{
+		0x02,                   // array length = 2
+		0x05,                   // custom type code
+		0x02, 0xAA, 0xBB,       // elem 0: len=2, data
+		0x01, 0xCC,             // elem 1: len=1, data
+	}
+	r := NewBufferReader(data)
+	arr := deserializeCustomTypeArray18(r)
+	if len(arr) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(arr))
+	}
+}
+
+func TestDeserializeHashtableArray18(t *testing.T) {
+	// arrayLen=2, each element is a hashtable
+	data := []byte{
+		0x02,                   // array length = 2
+		0x00,                   // hashtable 0: empty (size=0)
+		0x00,                   // hashtable 1: empty (size=0)
+	}
+	r := NewBufferReader(data)
+	arr := deserializeHashtableArray18(r)
+	if arr == nil {
+		t.Fatal("expected non-nil array")
+	}
+}
+
+func TestDeserializeDictionaryArray18(t *testing.T) {
+	// keyType=CompressedInt(9), valueType=CompressedInt(9), arrayLen=1
+	// dict 0: size=1, entry: key=0, value=0
+	data := []byte{
+		0x09, 0x09,   // keyType, valueType
+		0x01,         // array length = 1
+		0x01,         // dict 0: entry count = 1
+		0x00,         // key: varint 0
+		0x00,         // value: varint 0
+	}
+	r := NewBufferReader(data)
+	arr := deserializeDictionaryArray18(r)
+	if arr == nil {
+		t.Fatal("expected non-nil array")
+	}
+	if len(arr) != 1 {
+		t.Fatalf("expected 1 dict, got %d", len(arr))
+	}
+}
+
+func TestDeserialize18_UnknownType(t *testing.T) {
+	r := NewBufferReader([]byte{0x01, 0x02})
+	got := deserialize18(r, 0xFF)
+	if got != nil {
+		t.Errorf("expected nil for unknown type, got %v", got)
+	}
+}
+
+func TestDeserialize18_CustomTypeSlim(t *testing.T) {
+	// Slim code 128 -> typeCode = 128 - 128 = 0
+	// Then reads length + data
+	data := []byte{0x02, 0xAA, 0xBB}
+	r := NewBufferReader(data)
+	got := deserialize18(r, P18CustomTypeSlim)
+	m, ok := got.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map, got %T", got)
+	}
+	if m["customTypeCode"] != byte(0) {
+		t.Errorf("expected typeCode 0, got %v", m["customTypeCode"])
+	}
+}
+
+func TestVarintRoundTrip(t *testing.T) {
+	// Verify that ReadVarint32 can decode what a correct encoder would produce
+	values := []uint32{0, 1, 127, 128, 16383, 16384, 2097151, 2097152, 268435455, 268435456, math.MaxUint32}
+	for _, v := range values {
+		encoded := encodeVarint32(v)
+		r := NewBufferReader(encoded)
+		got, err := r.ReadVarint32()
+		if err != nil {
+			t.Errorf("ReadVarint32(%d): unexpected error: %v", v, err)
+			continue
+		}
+		if got != v {
+			t.Errorf("ReadVarint32: expected %d, got %d (encoded: %v)", v, got, encoded)
+		}
+	}
+}
+
+func TestVarint64RoundTrip(t *testing.T) {
+	values := []uint64{0, 1, 127, 128, 16384, math.MaxUint32, math.MaxInt64, math.MaxUint64}
+	for _, v := range values {
+		encoded := encodeVarint64(v)
+		r := NewBufferReader(encoded)
+		got, err := r.ReadVarint64()
+		if err != nil {
+			t.Errorf("ReadVarint64(%d): unexpected error: %v", v, err)
+			continue
+		}
+		if got != v {
+			t.Errorf("ReadVarint64: expected %d, got %d (encoded: %v)", v, got, encoded)
+		}
+	}
+}
+
+// encodeVarint32 encodes a uint32 as a protobuf-style varint.
+func encodeVarint32(v uint32) []byte {
+	var buf []byte
+	for v >= 0x80 {
+		buf = append(buf, byte(v)|0x80)
+		v >>= 7
+	}
+	buf = append(buf, byte(v))
+	return buf
+}
+
+// encodeVarint64 encodes a uint64 as a protobuf-style varint.
+func encodeVarint64(v uint64) []byte {
+	var buf []byte
+	for v >= 0x80 {
+		buf = append(buf, byte(v)|0x80)
+		v >>= 7
+	}
+	buf = append(buf, byte(v))
+	return buf
+}

--- a/pkg/photon/protocol18_test.go
+++ b/pkg/photon/protocol18_test.go
@@ -451,7 +451,7 @@ func TestDeserializeDictionaryArray18(t *testing.T) {
 
 func TestDeserialize18_UnknownType(t *testing.T) {
 	r := NewBufferReader([]byte{0x01, 0x02})
-	got := deserialize18(r, 0xFF)
+	got := deserialize18(r, 1)
 	if got != nil {
 		t.Errorf("expected nil for unknown type, got %v", got)
 	}


### PR DESCRIPTION
## Summary

Albion Online migrated from Photon Protocol16 to Protocol18. This switches the parameter decoder to match.

## Key differences

| Aspect | Protocol16 (old) | Protocol18 (new) |
|--------|-----------------|-----------------|
| Param count | 2 bytes | 1 byte |
| Integers | Fixed 4-byte BE | Varint + ZigZag |
| Short/Float/Double | Big-endian | Little-endian |
| String length | 2-byte BE | Varint |
| Signal byte | Required (243/253) | Skipped, no validation |
| Type codes | ASCII chars | Numeric enum |

## Files

- **protocol18.go** (new): full type system + parameter decoder
- **buffer.go**: added varint, ZigZag, little-endian read methods
- **parser.go**: removed signal byte validation, switched to Protocol18 decoding

## Validation

- `go vet ./...` — clean
- `go test ./...` — all pass
- Manual test: confirmed fame/silver/loot events are now detected

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

This PR migrates Albion Online's photon decoder from Photon Protocol16 to Protocol18 by introducing a new `protocol18.go` with a full type system and parameter decoder, adding varint/ZigZag/LE read methods to `buffer.go`, and removing signal-byte validation from `parser.go`. Subsequent commits hardened the decoder with tests, added support for P18Array and full slim ranges, and fixed truncated varint handling. The result is correct detection of fame, silver, and loot events under the new protocol.

---
<sup>Written for commit 874c80d9363a761f42c3ca8a721dd0b0624f5c48. Summary will update on new commits.</sup>
<!-- end-auto-generated -->