### PR TITLE
ci(release): upgrade Go to 1.26 for nfpm compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
   contents: write
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
 
 jobs:
   # ===========================================================================

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ sudo ./albion-lens
 
 ### Option 2: Build from Source
 
-Requires **Go 1.25+** and **libpcap-dev** installed.
+Requires **Go 1.26+** and **libpcap-dev** installed.
 
 ```bash
 # Clone the repository

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cantalupo555/albion-lens
 
-go 1.25
+go 1.26
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0


### PR DESCRIPTION
## Summary
Upgrade Go from 1.25 to 1.26 in the release pipeline to restore compatibility with `nfpm@latest`.

## Pipeline Changes
- `.github/workflows/release.yml`: bumped `GO_VERSION` from `1.25` to `1.26`
- `go.mod`: updated `go` directive from `1.25` to `1.26`
- `README.md`: updated Go requirement from `1.25+` to `1.26+`

## Motivation
The v0.5.0 release failed because `nfpm v2.47.0` requires Go >= 1.26.4, but the workflow was using Go 1.25 with `GOTOOLCHAIN=local`, preventing `build-linux` jobs from completing.

## Verification
- [x] Build verified locally with Go 1.26
- [x] `go mod tidy` ran successfully
- [ ] Release workflow passes after merge

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

Upgrades Go from 1.25 to 1.26 across `go.mod`, CI workflow, and README to resolve a build failure in the v0.5.0 release pipeline caused by `nfpm v2.47.0` requiring Go >= 1.26.4 with `GOTOOLCHAIN=local`.

---
<sup>Written for commit ed7cf961d66396dde6252487efa8c9036af4cf1d. Summary will update on new commits.</sup>
<!-- end-auto-generated -->