### PR TITLE
refactor(tui): extract testable event batching and add TUI test coverage

### DIFF
--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -13,6 +13,13 @@ import (
 	"github.com/cantalupo555/albion-lens/pkg/photon"
 )
 
+const (
+	bulkEventChannelSize = 5                       // 5 batches × eventBatchSize = 250 events buffered
+	statsChannelSize     = 10
+	eventBatchSize       = 50
+	eventFlushInterval   = 50 * time.Millisecond
+)
+
 func main() {
 	// Parse command line flags
 	listDevices := flag.Bool("list", false, "List available network devices")
@@ -44,72 +51,11 @@ func main() {
 	svc := backend.New(opts...)
 
 	// Create channels for TUI communication
-	// Use a buffered channel for bulk messages
-	bulkEventChan := make(chan tui.BulkEventMsg, 5) // 5 batches of 50 = 250 events
-	statsChan := make(chan *photon.Stats, 10)
+	bulkEventChan := make(chan tui.BulkEventMsg, bulkEventChannelSize)
+	statsChan := make(chan *photon.Stats, statsChannelSize)
 
 	// Bridge backend events to TUI with batching
-	go func() {
-		const batchSize = 50
-		const flushInterval = 50 * time.Millisecond
-		
-		buffer := make([]tui.EventMsg, 0, batchSize)
-		ticker := time.NewTicker(flushInterval)
-		defer ticker.Stop()
-
-		flush := func() {
-			if len(buffer) == 0 {
-				return
-			}
-			// Create a copy of the buffer to send
-			msg := make(tui.BulkEventMsg, len(buffer))
-			copy(msg, buffer)
-			
-			select {
-			case bulkEventChan <- msg:
-				// Success
-			default:
-				// Channel full, drop ENTIRE batch
-				if stats := svc.ParserStats(); stats != nil {
-					// Increment dropped count for each event in the batch
-					for i := 0; i < len(buffer); i++ {
-						stats.IncrEventsDropped()
-					}
-				}
-			}
-			// Reset buffer
-			buffer = buffer[:0]
-		}
-
-		for {
-			select {
-			case event, ok := <-svc.Events:
-				if !ok {
-					// Channel closed
-					flush()
-					return
-				}
-				
-				// Add to buffer
-				buffer = append(buffer, tui.EventMsg{
-					Type:      string(event.Type),
-					Message:   event.Message,
-					Timestamp: event.Timestamp,
-					Data:      event.Data,
-				})
-
-				// Flush if full
-				if len(buffer) >= batchSize {
-					flush()
-					// Reset ticker to avoid double flushing
-					ticker.Reset(flushInterval)
-				}
-
-			case <-ticker.C:
-				flush()
-			}
-		}
-	}()
+	go bridgeEvents(svc.Events, bulkEventChan, svc.ParserStats)
 
 	// Bridge backend stats to TUI
 	go func() {
@@ -146,5 +92,71 @@ func main() {
 	if _, err := p.Run(); err != nil {
 		fmt.Printf("Error running TUI: %v\n", err)
 		os.Exit(1)
+	}
+}
+
+// bridgeEvents reads game events from eventsCh, batches them, and forwards
+// them as BulkEventMsg to bulkEventChan. When the channel is full, dropped
+// events are counted via statsFn.
+func bridgeEvents(
+	eventsCh <-chan backend.GameEvent,
+	bulkEventChan chan<- tui.BulkEventMsg,
+	statsFn func() *photon.Stats,
+) {
+	buffer := make([]tui.EventMsg, 0, eventBatchSize)
+	ticker := time.NewTicker(eventFlushInterval)
+	defer ticker.Stop()
+
+	flush := func() {
+		if len(buffer) == 0 {
+			return
+		}
+		// Create a copy of the buffer to send
+		msg := make(tui.BulkEventMsg, len(buffer))
+		copy(msg, buffer)
+
+		select {
+		case bulkEventChan <- msg:
+			// Success
+		default:
+			// Channel full, drop ENTIRE batch
+			if stats := statsFn(); stats != nil {
+				// Increment dropped count for each event in the batch
+				for i := 0; i < len(buffer); i++ {
+					stats.IncrEventsDropped()
+				}
+			}
+		}
+		// Reset buffer
+		buffer = buffer[:0]
+	}
+
+	for {
+		select {
+		case event, ok := <-eventsCh:
+			if !ok {
+				// Channel closed
+				flush()
+				return
+			}
+
+			// Add to buffer
+			buffer = append(buffer, tui.EventMsg{
+				Type:      string(event.Type),
+				Message:   event.Message,
+				Timestamp: event.Timestamp,
+				Data:      event.Data,
+			})
+
+			// Flush if full
+			if len(buffer) >= eventBatchSize {
+				flush()
+				// Reset ticker to avoid double flushing
+				ticker.Reset(eventFlushInterval)
+			}
+
+		case <-ticker.C:
+			flush()
+		}
 	}
 }

--- a/cmd/tui/main_test.go
+++ b/cmd/tui/main_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cantalupo555/albion-lens/internal/tui"
+	"github.com/cantalupo555/albion-lens/pkg/backend"
+	"github.com/cantalupo555/albion-lens/pkg/photon"
+)
+
+// ============================================
+// bridgeEvents tests
+// ============================================
+
+func TestBridgeEventsBatching(t *testing.T) {
+	eventsCh := make(chan backend.GameEvent, 10)
+	bulkCh := make(chan tui.BulkEventMsg, 5)
+
+	go bridgeEvents(eventsCh, bulkCh, func() *photon.Stats { return nil })
+	defer close(eventsCh)
+
+	eventsCh <- backend.GameEvent{Type: backend.EventTypeInfo, Message: "event1"}
+	eventsCh <- backend.GameEvent{Type: backend.EventTypeInfo, Message: "event2"}
+
+	select {
+	case batch := <-bulkCh:
+		if len(batch) != 2 {
+			t.Errorf("expected 2 events in batch, got %d", len(batch))
+		}
+		if batch[0].Message != "event1" {
+			t.Errorf("expected first event message 'event1', got %q", batch[0].Message)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for timer-flushed batch")
+	}
+}
+
+func TestBridgeEventsFlushOnBatchFull(t *testing.T) {
+	eventsCh := make(chan backend.GameEvent, 200)
+	bulkCh := make(chan tui.BulkEventMsg, 5)
+
+	go bridgeEvents(eventsCh, bulkCh, func() *photon.Stats { return nil })
+	defer close(eventsCh)
+
+	for i := 0; i < eventBatchSize; i++ {
+		eventsCh <- backend.GameEvent{Type: backend.EventTypeInfo, Message: "batch event"}
+	}
+
+	select {
+	case batch := <-bulkCh:
+		if len(batch) != eventBatchSize {
+			t.Errorf("expected %d events in full batch, got %d", eventBatchSize, len(batch))
+		}
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("timeout waiting for full-batch flush")
+	}
+}
+
+func TestBridgeEventsChannelClose(t *testing.T) {
+	eventsCh := make(chan backend.GameEvent, 10)
+	bulkCh := make(chan tui.BulkEventMsg, 5)
+
+	done := make(chan struct{})
+	go func() {
+		bridgeEvents(eventsCh, bulkCh, func() *photon.Stats { return nil })
+		close(done)
+	}()
+
+	eventsCh <- backend.GameEvent{Type: backend.EventTypeInfo, Message: "final event"}
+	close(eventsCh)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("bridgeEvents did not return after channel close")
+	}
+
+	// Final flush should have delivered the buffered event
+	select {
+	case batch := <-bulkCh:
+		if len(batch) != 1 {
+			t.Errorf("expected 1 event in final flush, got %d", len(batch))
+		}
+	case <-time.After(200 * time.Millisecond):
+		// Acceptable if already flushed via timer
+	}
+}
+
+func TestBridgeEventsDropWhenFull(t *testing.T) {
+	eventsCh := make(chan backend.GameEvent, 200)
+	bulkCh := make(chan tui.BulkEventMsg, 1)
+
+	stats := photon.NewStats()
+	go bridgeEvents(eventsCh, bulkCh, func() *photon.Stats { return stats })
+
+	// Fill bulkCh to capacity so sends fail
+	bulkCh <- tui.BulkEventMsg{{Type: "blocker", Message: "filler"}}
+
+	// Send enough events to fill the buffer and trigger a flush
+	for i := 0; i < eventBatchSize; i++ {
+		eventsCh <- backend.GameEvent{Type: backend.EventTypeInfo, Message: "to be dropped"}
+	}
+
+	// Wait for drops to be counted (poll up to 1 second)
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if stats.GetEventsDropped() >= eventBatchSize {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	dropped := stats.GetEventsDropped()
+	if dropped == 0 {
+		t.Error("expected dropped events > 0 when bulk channel is full")
+	}
+
+	close(eventsCh)
+}
+
+func TestBridgeEventsEmptyFlushSendsNothing(t *testing.T) {
+	eventsCh := make(chan backend.GameEvent, 10)
+	bulkCh := make(chan tui.BulkEventMsg, 5)
+
+	go bridgeEvents(eventsCh, bulkCh, func() *photon.Stats { return nil })
+
+	// Wait for at least one flush interval with no events
+	time.Sleep(eventFlushInterval * 2)
+
+	select {
+	case <-bulkCh:
+		t.Error("expected no batch when buffer is empty")
+	default:
+		// Success: nothing sent
+	}
+
+	close(eventsCh)
+}
+
+// ============================================
+// Constants tests
+// ============================================
+
+func TestConstantsHaveExpectedValues(t *testing.T) {
+	if bulkEventChannelSize != 5 {
+		t.Errorf("expected bulkEventChannelSize=5, got %d", bulkEventChannelSize)
+	}
+	if statsChannelSize != 10 {
+		t.Errorf("expected statsChannelSize=10, got %d", statsChannelSize)
+	}
+	if eventBatchSize != 50 {
+		t.Errorf("expected eventBatchSize=50, got %d", eventBatchSize)
+	}
+	if eventFlushInterval != 50*time.Millisecond {
+		t.Errorf("expected eventFlushInterval=50ms, got %v", eventFlushInterval)
+	}
+}

--- a/internal/tui/components/eventlog.go
+++ b/internal/tui/components/eventlog.go
@@ -2,7 +2,6 @@ package components
 
 import (
 	"fmt"
-	"math"
 	"strings"
 	"time"
 
@@ -199,29 +198,29 @@ func (e EventLog) formatEventMessage(event Event) string {
 	case "fame":
 		if data, ok := event.Data.(*handlers.FameEventData); ok && data != nil {
 			return fmt.Sprintf("⭐ FAME: +%s | Total: %s | Session: %s",
-				formatNumber(data.Gained, e.fullNumbers),
-				formatNumber(data.Total, e.fullNumbers),
-				formatNumber(data.Session, e.fullNumbers))
+				FormatNumber(data.Gained, e.fullNumbers),
+				FormatNumber(data.Total, e.fullNumbers),
+				FormatNumber(data.Session, e.fullNumbers))
 		}
 	case "silver":
 		if data, ok := event.Data.(*handlers.SilverEventData); ok && data != nil {
 			return fmt.Sprintf("💰 %s looted silver (%s) from %s | Session: %s",
 				data.LootedBy,
-				formatNumber(data.Amount, e.fullNumbers),
+				FormatNumber(data.Amount, e.fullNumbers),
 				data.LootedFrom,
-				formatNumber(data.Session, e.fullNumbers))
+				FormatNumber(data.Session, e.fullNumbers))
 		}
 	case "respec":
 		if data, ok := event.Data.(*handlers.RespecEventData); ok && data != nil {
 			if data.PaidSilver > 0 {
 				return fmt.Sprintf("🏆 RESPEC: +%s credits | Silver cost: -%s | Session: %s",
-					formatNumber(data.Gained, e.fullNumbers),
-					formatNumber(data.PaidSilver, e.fullNumbers),
-					formatNumber(data.SessionTotal, e.fullNumbers))
+					FormatNumber(data.Gained, e.fullNumbers),
+					FormatNumber(data.PaidSilver, e.fullNumbers),
+					FormatNumber(data.SessionTotal, e.fullNumbers))
 			}
 			return fmt.Sprintf("🏆 RESPEC: +%s credits | Session: %s",
-				formatNumber(data.Gained, e.fullNumbers),
-				formatNumber(data.SessionTotal, e.fullNumbers))
+				FormatNumber(data.Gained, e.fullNumbers),
+				FormatNumber(data.SessionTotal, e.fullNumbers))
 		}
 	case "loot":
 		if data, ok := event.Data.(*handlers.LootEventData); ok && data != nil {
@@ -249,22 +248,6 @@ func (e EventLog) formatEventMessage(event Event) string {
 	}
 	// Fallback to original message
 	return event.Message
-}
-
-// formatNumber formats a number based on fullNumbers setting
-func formatNumber(amount int64, full bool) string {
-	if full {
-		return fmt.Sprintf("%d", amount)
-	}
-	// Abbreviated format with truncation (floor) instead of rounding
-	if amount >= 1000000 {
-		val := math.Floor(float64(amount)/100000.0) / 10.0
-		return fmt.Sprintf("%.1fM", val)
-	} else if amount >= 1000 {
-		val := math.Floor(float64(amount)/100.0) / 10.0
-		return fmt.Sprintf("%.1fk", val)
-	}
-	return fmt.Sprintf("%d", amount)
 }
 
 // ScrollUp scrolls the viewport up

--- a/internal/tui/components/eventlog_test.go
+++ b/internal/tui/components/eventlog_test.go
@@ -59,3 +59,273 @@ func TestFormatEventMessageRespecWithoutSilver(t *testing.T) {
 		t.Errorf("should not show 'Silver cost' when PaidSilver=0, got: %s", msg)
 	}
 }
+
+// ============================================
+// formatEventMessage: other event types
+// ============================================
+
+func TestFormatEventMessageFame(t *testing.T) {
+	e := EventLog{fullNumbers: true}
+
+	event := Event{
+		Type: "fame",
+		Data: &handlers.FameEventData{
+			Gained:  500,
+			Total:   5000,
+			Session: 2000,
+		},
+		Timestamp: time.Now(),
+	}
+
+	msg := e.formatEventMessage(event)
+
+	if !strings.Contains(msg, "FAME") {
+		t.Errorf("expected 'FAME' in message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "+500") {
+		t.Errorf("expected '+500' gained in message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "5000") {
+		t.Errorf("expected '5000' total in message, got: %s", msg)
+	}
+}
+
+func TestFormatEventMessageSilver(t *testing.T) {
+	e := EventLog{fullNumbers: true}
+
+	event := Event{
+		Type: "silver",
+		Data: &handlers.SilverEventData{
+			Amount:     750,
+			Session:    3000,
+			LootedBy:   "PlayerA",
+			LootedFrom: "BossNPC",
+		},
+		Timestamp: time.Now(),
+	}
+
+	msg := e.formatEventMessage(event)
+
+	if !strings.Contains(msg, "PlayerA") {
+		t.Errorf("expected 'PlayerA' (looter) in message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "750") {
+		t.Errorf("expected '750' amount in message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "BossNPC") {
+		t.Errorf("expected 'BossNPC' (source) in message, got: %s", msg)
+	}
+}
+
+func TestFormatEventMessageLoot(t *testing.T) {
+	e := EventLog{fullNumbers: true}
+
+	event := Event{
+		Type: "loot",
+		Data: &handlers.LootEventData{
+			LootedBy:   "PlayerX",
+			ItemName:   "Abyssal Sword",
+			Quantity:    3,
+			LootedFrom:  "Dungeon Boss",
+		},
+		Timestamp: time.Now(),
+	}
+
+	msg := e.formatEventMessage(event)
+
+	if !strings.Contains(msg, "PlayerX") {
+		t.Errorf("expected looter name in message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "Abyssal Sword") {
+		t.Errorf("expected item name in message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "x3") {
+		t.Errorf("expected 'x3' quantity in message, got: %s", msg)
+	}
+}
+
+func TestFormatEventMessageKill(t *testing.T) {
+	e := EventLog{fullNumbers: true}
+
+	event := Event{
+		Type: "kill",
+		Data: &handlers.KillEventData{
+			SessionKills: 5,
+		},
+		Timestamp: time.Now(),
+	}
+
+	msg := e.formatEventMessage(event)
+
+	if !strings.Contains(msg, "Killed") {
+		t.Errorf("expected 'Killed' in message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "5") {
+		t.Errorf("expected session kills count '5' in message, got: %s", msg)
+	}
+}
+
+func TestFormatEventMessageDeathWithKiller(t *testing.T) {
+	e := EventLog{fullNumbers: true}
+
+	event := Event{
+		Type: "death",
+		Data: &handlers.DeathEventData{
+			Victim: "NoobSlayer",
+			Killer: "BossEnemy",
+		},
+		Timestamp: time.Now(),
+	}
+
+	msg := e.formatEventMessage(event)
+
+	if !strings.Contains(msg, "NoobSlayer") {
+		t.Errorf("expected victim name in message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "BossEnemy") {
+		t.Errorf("expected killer name in message, got: %s", msg)
+	}
+}
+
+func TestFormatEventMessageDeathWithoutKiller(t *testing.T) {
+	e := EventLog{fullNumbers: true}
+
+	event := Event{
+		Type: "death",
+		Data: &handlers.DeathEventData{
+			Victim: "UnluckyPlayer",
+			Killer: "",
+		},
+		Timestamp: time.Now(),
+	}
+
+	msg := e.formatEventMessage(event)
+
+	if !strings.Contains(msg, "UnluckyPlayer") {
+		t.Errorf("expected victim name in message, got: %s", msg)
+	}
+	if strings.Contains(msg, "Killed by") {
+		t.Errorf("should not show 'Killed by' when Killer is empty, got: %s", msg)
+	}
+}
+
+func TestFormatEventMessageFallback(t *testing.T) {
+	e := EventLog{fullNumbers: true}
+
+	event := Event{
+		Type:    "unknown_type",
+		Message: "Custom fallback message",
+	}
+
+	msg := e.formatEventMessage(event)
+
+	if msg != "Custom fallback message" {
+		t.Errorf("expected fallback message, got: %s", msg)
+	}
+}
+
+// ============================================
+// AddEvents / Clear / SetFullNumbers tests
+// ============================================
+
+func TestAddEventsBatch(t *testing.T) {
+	e := NewEventLog()
+	e = e.SetSize(60, 20)
+
+	events := []Event{
+		{Type: "fame", Message: "fame event", Timestamp: time.Now()},
+		{Type: "silver", Message: "silver event", Timestamp: time.Now()},
+		{Type: "loot", Message: "loot event", Timestamp: time.Now()},
+	}
+
+	e = e.AddEvents(events)
+
+	view := e.View()
+	if !strings.Contains(view, "fame event") {
+		t.Error("expected 'fame event' in view after AddEvents")
+	}
+	if !strings.Contains(view, "silver event") {
+		t.Error("expected 'silver event' in view after AddEvents")
+	}
+}
+
+func TestAddEventsEmpty(t *testing.T) {
+	e := NewEventLog()
+	e = e.SetSize(60, 20)
+
+	// Adding empty slice should not panic
+	e = e.AddEvents([]Event{})
+}
+
+func TestAddEventsTrimsAtMaxEvents(t *testing.T) {
+	e := NewEventLog()
+	e = e.SetSize(120, 30)
+
+	// Add maxEvents+1 events
+	events := make([]Event, maxEvents+1)
+	for i := range events {
+		events[i] = Event{
+			Type:    "info",
+			Message: "filler",
+		}
+	}
+	events[maxEvents].Message = "newest event"
+
+	e = e.AddEvents(events)
+
+	// Should only keep the newest maxEvents events
+	if len(e.events) != maxEvents {
+		t.Errorf("expected %d events after trim, got %d", maxEvents, len(e.events))
+	}
+
+	// The newest event should be present
+	view := e.View()
+	if !strings.Contains(view, "newest event") {
+		t.Error("expected newest event to be retained after trim")
+	}
+}
+
+func TestClear(t *testing.T) {
+	e := NewEventLog()
+	e = e.SetSize(60, 20)
+
+	e = e.AddEvents([]Event{
+		{Type: "info", Message: "test event", Timestamp: time.Now()},
+	})
+
+	e = e.Clear()
+
+	if len(e.events) != 0 {
+		t.Errorf("expected 0 events after clear, got %d", len(e.events))
+	}
+	if len(e.renderedLines) != 0 {
+		t.Errorf("expected 0 rendered lines after clear, got %d", len(e.renderedLines))
+	}
+}
+
+func TestSetFullNumbersReRender(t *testing.T) {
+	e := NewEventLog()
+	e = e.SetSize(80, 20)
+
+	// Add event with full numbers (default)
+	e = e.AddEvents([]Event{
+		{
+			Type:      "fame",
+			Data:      &handlers.FameEventData{Gained: 1500, Total: 5000, Session: 3000},
+			Timestamp: time.Now(),
+		},
+	})
+
+	viewFull := e.View()
+	if !strings.Contains(viewFull, "1500") {
+		t.Error("expected full number '1500' with fullNumbers=true")
+	}
+
+	// Toggle to abbreviated
+	e = e.SetFullNumbers(false)
+
+	viewAbbrev := e.View()
+	if !strings.Contains(viewAbbrev, "1.5k") {
+		t.Error("expected abbreviated '1.5k' with fullNumbers=false")
+	}
+}

--- a/internal/tui/components/format.go
+++ b/internal/tui/components/format.go
@@ -1,0 +1,24 @@
+package components
+
+import (
+	"fmt"
+	"math"
+)
+
+// FormatNumber formats a number based on the full flag.
+// If full is true, returns the full number (e.g., 4984).
+// If full is false, returns abbreviated form (e.g., 4.9k) with truncation (floor).
+func FormatNumber(amount int64, full bool) string {
+	if full {
+		return fmt.Sprintf("%d", amount)
+	}
+	// Abbreviated format with truncation (floor) instead of rounding
+	if amount >= 1000000 {
+		val := math.Floor(float64(amount)/100000.0) / 10.0
+		return fmt.Sprintf("%.1fM", val)
+	} else if amount >= 1000 {
+		val := math.Floor(float64(amount)/100.0) / 10.0
+		return fmt.Sprintf("%.1fk", val)
+	}
+	return fmt.Sprintf("%d", amount)
+}

--- a/internal/tui/components/format_test.go
+++ b/internal/tui/components/format_test.go
@@ -1,0 +1,46 @@
+package components
+
+import "testing"
+
+func TestFormatNumberFull(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0"},
+		{999, "999"},
+		{1000, "1000"},
+		{4984, "4984"},
+		{999999, "999999"},
+		{1000000, "1000000"},
+		{1500000, "1500000"},
+	}
+	for _, tt := range tests {
+		got := FormatNumber(tt.input, true)
+		if got != tt.want {
+			t.Errorf("FormatNumber(%d, true) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestFormatNumberAbbreviated(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0"},
+		{999, "999"},
+		{1000, "1.0k"},
+		{4984, "4.9k"},
+		{999999, "999.9k"},
+		{1000000, "1.0M"},
+		{1500000, "1.5M"},
+		{12500000, "12.5M"},
+	}
+	for _, tt := range tests {
+		got := FormatNumber(tt.input, false)
+		if got != tt.want {
+			t.Errorf("FormatNumber(%d, false) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/tui/components/statspanel_test.go
+++ b/internal/tui/components/statspanel_test.go
@@ -73,6 +73,178 @@ func TestStatsPanelViewShowsRespecSilverWhenNonZero(t *testing.T) {
 	}
 }
 
+// ============================================
+// Fame tests
+// ============================================
+
+func TestStatsPanelSetFame(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.SetFame(5000)
+
+	if s.fame != 5000 {
+		t.Errorf("expected fame 5000, got %d", s.fame)
+	}
+}
+
+func TestStatsPanelAddFame(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.AddFame(100)
+	s = s.AddFame(200)
+
+	if s.fame != 300 {
+		t.Errorf("expected accumulated fame 300, got %d", s.fame)
+	}
+}
+
+// ============================================
+// Silver tests
+// ============================================
+
+func TestStatsPanelSetSilver(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.SetSilver(8000)
+
+	if s.silver != 8000 {
+		t.Errorf("expected silver 8000, got %d", s.silver)
+	}
+}
+
+func TestStatsPanelAddSilver(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.AddSilver(500)
+	s = s.AddSilver(250)
+
+	if s.silver != 750 {
+		t.Errorf("expected accumulated silver 750, got %d", s.silver)
+	}
+}
+
+// ============================================
+// Kill/Death/Loot counter tests
+// ============================================
+
+func TestStatsPanelIncrKills(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.IncrKills()
+	s = s.IncrKills()
+	s = s.IncrKills()
+
+	if s.kills != 3 {
+		t.Errorf("expected kills 3, got %d", s.kills)
+	}
+}
+
+func TestStatsPanelIncrDeaths(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.IncrDeaths()
+	s = s.IncrDeaths()
+
+	if s.deaths != 2 {
+		t.Errorf("expected deaths 2, got %d", s.deaths)
+	}
+}
+
+func TestStatsPanelIncrLoot(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.IncrLoot()
+	s = s.IncrLoot()
+	s = s.IncrLoot()
+	s = s.IncrLoot()
+
+	if s.lootCount != 4 {
+		t.Errorf("expected lootCount 4, got %d", s.lootCount)
+	}
+}
+
+// ============================================
+// Reset tests (full)
+// ============================================
+
+func TestStatsPanelResetClearsAll(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.SetFame(5000)
+	s = s.SetSilver(3000)
+	s = s.SetRespec(1000)
+	s = s.SetRespecSilver(500)
+	s = s.IncrKills()
+	s = s.IncrDeaths()
+	s = s.IncrLoot()
+
+	s = s.Reset()
+
+	if s.fame != 0 {
+		t.Errorf("expected fame 0 after reset, got %d", s.fame)
+	}
+	if s.silver != 0 {
+		t.Errorf("expected silver 0 after reset, got %d", s.silver)
+	}
+	if s.respec != 0 {
+		t.Errorf("expected respec 0 after reset, got %d", s.respec)
+	}
+	if s.respecSilver != 0 {
+		t.Errorf("expected respecSilver 0 after reset, got %d", s.respecSilver)
+	}
+	if s.kills != 0 {
+		t.Errorf("expected kills 0 after reset, got %d", s.kills)
+	}
+	if s.deaths != 0 {
+		t.Errorf("expected deaths 0 after reset, got %d", s.deaths)
+	}
+	if s.lootCount != 0 {
+		t.Errorf("expected lootCount 0 after reset, got %d", s.lootCount)
+	}
+}
+
+// ============================================
+// View tests (all stats)
+// ============================================
+
+func TestStatsPanelViewShowsAllLabels(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.SetFullNumbers(true)
+	s = s.SetFame(1000)
+	s = s.SetSilver(2000)
+	s = s.IncrKills()
+	s = s.IncrDeaths()
+	s = s.IncrLoot()
+	s = s.SetSize(40, 14)
+
+	output := s.View()
+
+	labels := []string{"Fame", "Silver", "Respec", "Kills", "Deaths", "Loot"}
+	for _, label := range labels {
+		if !strings.Contains(output, label) {
+			t.Errorf("expected '%s' label in view", label)
+		}
+	}
+}
+
+func TestStatsPanelViewAbbreviatedNumbers(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.SetFullNumbers(false)
+	s = s.SetFame(1500000)
+	s = s.SetSize(40, 14)
+
+	output := s.View()
+
+	if !strings.Contains(output, "1.5M") {
+		t.Error("expected abbreviated '1.5M' in view with fullNumbers=false")
+	}
+}
+
+func TestStatsPanelViewFullNumbers(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.SetFullNumbers(true)
+	s = s.SetFame(1500000)
+	s = s.SetSize(40, 14)
+
+	output := s.View()
+
+	if !strings.Contains(output, "1500000") {
+		t.Error("expected full '1500000' in view with fullNumbers=true")
+	}
+}
+
 func TestStatsPanelViewNegativeSilverAbbreviated(t *testing.T) {
 	s := NewStatsPanel()
 	s = s.SetFullNumbers(false)

--- a/internal/tui/components/statusbar.go
+++ b/internal/tui/components/statusbar.go
@@ -39,6 +39,11 @@ func (s StatusBar) SetOnline(online bool) StatusBar {
 	return s
 }
 
+// Online returns whether the status bar shows online status
+func (s StatusBar) Online() bool {
+	return s.online
+}
+
 // UpdateStats updates the stats display
 func (s StatusBar) UpdateStats(stats *photon.Stats) StatusBar {
 	if stats != nil {

--- a/internal/tui/components/statusbar_test.go
+++ b/internal/tui/components/statusbar_test.go
@@ -1,0 +1,199 @@
+package components
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cantalupo555/albion-lens/pkg/photon"
+)
+
+// ============================================
+// NewStatusBar tests
+// ============================================
+
+func TestNewStatusBarDefaults(t *testing.T) {
+	s := NewStatusBar()
+
+	if s.online {
+		t.Error("expected online=false by default")
+	}
+	if s.uptime != "00:00:00" {
+		t.Errorf("expected uptime='00:00:00', got %q", s.uptime)
+	}
+	if s.packetsTotal != 0 {
+		t.Errorf("expected packetsTotal=0, got %d", s.packetsTotal)
+	}
+}
+
+// ============================================
+// SetOnline tests
+// ============================================
+
+func TestStatusBarSetOnline(t *testing.T) {
+	s := NewStatusBar()
+
+	s = s.SetOnline(true)
+	if !s.Online() {
+		t.Error("expected online=true after SetOnline(true)")
+	}
+
+	s = s.SetOnline(false)
+	if s.Online() {
+		t.Error("expected online=false after SetOnline(false)")
+	}
+}
+
+// ============================================
+// SetWidth tests
+// ============================================
+
+func TestStatusBarSetWidth(t *testing.T) {
+	s := NewStatusBar()
+	s = s.SetWidth(120)
+
+	if s.width != 120 {
+		t.Errorf("expected width=120, got %d", s.width)
+	}
+}
+
+// ============================================
+// UpdateStats tests
+// ============================================
+
+func TestStatusBarUpdateStatsNil(t *testing.T) {
+	s := NewStatusBar()
+	s = s.SetOnline(true)
+	original := s
+
+	s = s.UpdateStats(nil)
+
+	if s.packetsTotal != original.packetsTotal {
+		t.Error("expected no change with nil stats")
+	}
+}
+
+func TestStatusBarUpdateStats(t *testing.T) {
+	stats := &photon.Stats{
+		PacketsReceived:  uint64(100),
+		EventsDecoded:    uint64(50),
+		EventsDropped:    uint64(5),
+		BufferPeakDisplay: 30,
+		BufferCapacity:   200,
+		StartTime:        time.Now(),
+	}
+
+	s := NewStatusBar()
+	s = s.UpdateStats(stats)
+
+	if s.packetsTotal != 100 {
+		t.Errorf("expected packetsTotal=100, got %d", s.packetsTotal)
+	}
+	if s.eventsDecoded != 50 {
+		t.Errorf("expected eventsDecoded=50, got %d", s.eventsDecoded)
+	}
+	if s.eventsDropped != 5 {
+		t.Errorf("expected eventsDropped=5, got %d", s.eventsDropped)
+	}
+	if s.bufferUsage != 30 {
+		t.Errorf("expected bufferUsage=30, got %d", s.bufferUsage)
+	}
+	if s.bufferCapacity != 200 {
+		t.Errorf("expected bufferCapacity=200, got %d", s.bufferCapacity)
+	}
+}
+
+// ============================================
+// View tests
+// ============================================
+
+func TestStatusBarViewOffline(t *testing.T) {
+	s := NewStatusBar()
+	s = s.SetWidth(80)
+
+	output := s.View()
+
+	if !strings.Contains(output, "Offline") {
+		t.Error("expected 'Offline' in view")
+	}
+}
+
+func TestStatusBarViewOnline(t *testing.T) {
+	s := NewStatusBar()
+	s = s.SetWidth(80)
+	s = s.SetOnline(true)
+
+	output := s.View()
+
+	if !strings.Contains(output, "Online") {
+		t.Error("expected 'Online' in view")
+	}
+}
+
+func TestStatusBarViewDroppedEvents(t *testing.T) {
+	stats := &photon.Stats{
+		EventsDecoded: uint64(100),
+		EventsDropped: uint64(5),
+		StartTime:     time.Now(),
+	}
+
+	s := NewStatusBar()
+	s = s.SetWidth(100)
+	s = s.UpdateStats(stats)
+
+	output := s.View()
+
+	if !strings.Contains(output, "Dropped") {
+		t.Error("expected 'Dropped' warning in view when events dropped > 0")
+	}
+}
+
+func TestStatusBarViewNoDroppedEvents(t *testing.T) {
+	stats := &photon.Stats{
+		EventsDecoded: uint64(100),
+		EventsDropped: uint64(0),
+		StartTime:     time.Now(),
+	}
+
+	s := NewStatusBar()
+	s = s.SetWidth(100)
+	s = s.UpdateStats(stats)
+
+	output := s.View()
+
+	if strings.Contains(output, "Dropped") {
+		t.Error("expected no 'Dropped' warning when events dropped = 0")
+	}
+}
+
+func TestStatusBarViewBufferUsage(t *testing.T) {
+	stats := &photon.Stats{
+		BufferPeakDisplay: 50,
+		BufferCapacity:    100,
+		StartTime:         time.Now(),
+	}
+
+	s := NewStatusBar()
+	s = s.SetWidth(100)
+	s = s.UpdateStats(stats)
+
+	output := s.View()
+
+	if !strings.Contains(output, "Queue") {
+		t.Error("expected 'Queue' in view when bufferCapacity > 0")
+	}
+	if !strings.Contains(output, "50/100") {
+		t.Error("expected '50/100' buffer usage in view")
+	}
+}
+
+func TestStatusBarViewNoBufferUsage(t *testing.T) {
+	s := NewStatusBar()
+	s = s.SetWidth(100)
+
+	output := s.View()
+
+	if strings.Contains(output, "Queue") {
+		t.Error("expected no 'Queue' section when bufferCapacity = 0")
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"fmt"
-	"math"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -320,16 +319,5 @@ func (m Model) renderHelpBar() string {
 // If fullNumbers is true, returns the full number (e.g., 4984)
 // If fullNumbers is false, returns abbreviated form (e.g., 4.9k)
 func formatNumber(amount int64, full bool) string {
-	if full {
-		return fmt.Sprintf("%d", amount)
-	}
-	// Abbreviated format with truncation (floor) instead of rounding
-	if amount >= 1000000 {
-		val := math.Floor(float64(amount)/100000.0) / 10.0
-		return fmt.Sprintf("%.1fM", val)
-	} else if amount >= 1000 {
-		val := math.Floor(float64(amount)/100.0) / 10.0
-		return fmt.Sprintf("%.1fk", val)
-	}
-	return fmt.Sprintf("%d", amount)
+	return components.FormatNumber(amount, full)
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,0 +1,377 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/cantalupo555/albion-lens/pkg/handlers"
+	"github.com/cantalupo555/albion-lens/pkg/photon"
+)
+
+// updateModel is a test helper that calls Update and asserts the result is a Model.
+func updateModel(m Model, msg tea.Msg) Model {
+	nm, _ := m.Update(msg)
+	return nm.(Model)
+}
+
+// readyModel creates a new Model with a WindowSizeMsg applied (ready=true).
+func readyModel() Model {
+	m := New(nil, nil, nil)
+	return updateModel(m, tea.WindowSizeMsg{Width: 80, Height: 24})
+}
+
+// ============================================
+// formatNumber tests
+// ============================================
+
+func TestFormatNumberFull(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0"},
+		{999, "999"},
+		{1000, "1000"},
+		{4984, "4984"},
+		{1000000, "1000000"},
+	}
+	for _, tt := range tests {
+		got := formatNumber(tt.input, true)
+		if got != tt.want {
+			t.Errorf("formatNumber(%d, true) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestFormatNumberAbbreviated(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0"},
+		{999, "999"},
+		{1000, "1.0k"},
+		{4984, "4.9k"},
+		{999999, "999.9k"},
+		{1000000, "1.0M"},
+		{1500000, "1.5M"},
+	}
+	for _, tt := range tests {
+		got := formatNumber(tt.input, false)
+		if got != tt.want {
+			t.Errorf("formatNumber(%d, false) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+// ============================================
+// New model tests
+// ============================================
+
+func TestNewModelDefaults(t *testing.T) {
+	m := New(nil, nil, nil)
+
+	if m.debug {
+		t.Error("expected debug=false by default")
+	}
+	if m.fullNumbers {
+		t.Error("expected fullNumbers=false by default")
+	}
+	if m.quitting {
+		t.Error("expected quitting=false by default")
+	}
+	if m.ready {
+		t.Error("expected ready=false by default")
+	}
+}
+
+// ============================================
+// Update: keyboard input tests
+// ============================================
+
+func TestUpdateKeyQuit(t *testing.T) {
+	m := New(nil, nil, nil)
+
+	newModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	m2 := newModel.(Model)
+
+	if !m2.quitting {
+		t.Error("expected quitting=true after 'q'")
+	}
+	if cmd == nil {
+		t.Error("expected non-nil command (tea.Quit)")
+	}
+}
+
+func TestUpdateKeyCtrlC(t *testing.T) {
+	m := New(nil, nil, nil)
+
+	newModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	m2 := newModel.(Model)
+
+	if !m2.quitting {
+		t.Error("expected quitting=true after ctrl+c")
+	}
+	if cmd == nil {
+		t.Error("expected non-nil command (tea.Quit)")
+	}
+}
+
+func TestUpdateKeyDebugToggle(t *testing.T) {
+	m := New(nil, nil, nil)
+
+	if m.debug {
+		t.Error("expected debug=false initially")
+	}
+
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if !m.debug {
+		t.Error("expected debug=true after pressing 'd'")
+	}
+
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if m.debug {
+		t.Error("expected debug=false after pressing 'd' again")
+	}
+}
+
+func TestUpdateKeyFullNumbersToggle(t *testing.T) {
+	m := New(nil, nil, nil)
+
+	if m.fullNumbers {
+		t.Error("expected fullNumbers=false initially")
+	}
+
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	if !m.fullNumbers {
+		t.Error("expected fullNumbers=true after pressing 'f'")
+	}
+}
+
+func TestUpdateKeyClear(t *testing.T) {
+	m := readyModel()
+
+	// Add an event first
+	m = updateModel(m, BulkEventMsg{
+		{Type: "info", Message: "test event", Timestamp: time.Now()},
+	})
+
+	// Press 'c' to clear
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+
+	// View should not contain the event text after clear
+	view := m.View()
+	if strings.Contains(view, "test event") {
+		t.Error("expected event log to be cleared after 'c'")
+	}
+}
+
+func TestUpdateKeyReset(t *testing.T) {
+	m := readyModel()
+
+	// Add some stats via events
+	m = updateModel(m, BulkEventMsg{
+		{Type: "fame", Data: &handlers.FameEventData{Gained: 100, Total: 500, Session: 200},
+			Timestamp: time.Now()},
+	})
+
+	// Press 'r' to reset
+	m = updateModel(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+
+	// Stats panel view should show 0 after reset
+	statsView := m.statsPanel.View()
+	if strings.Contains(statsView, "+200") {
+		t.Error("expected stats reset to clear fame value")
+	}
+}
+
+func TestUpdateKeyScroll(t *testing.T) {
+	m := readyModel()
+
+	// These should not panic
+	updateModel(m, tea.KeyMsg{Type: tea.KeyUp})
+	updateModel(m, tea.KeyMsg{Type: tea.KeyDown})
+	updateModel(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	updateModel(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+}
+
+// ============================================
+// Update: BulkEventMsg tests
+// ============================================
+
+func TestUpdateBulkEventFame(t *testing.T) {
+	m := readyModel()
+
+	bulkMsg := BulkEventMsg{
+		{
+			Type:      "fame",
+			Data:      &handlers.FameEventData{Gained: 100, Total: 500, Session: 200},
+			Timestamp: time.Now(),
+		},
+	}
+
+	m = updateModel(m, bulkMsg)
+
+	view := m.View()
+	if !strings.Contains(view, "Fame") {
+		t.Error("expected 'Fame' in stats panel after fame event")
+	}
+}
+
+func TestUpdateBulkEventSilver(t *testing.T) {
+	m := readyModel()
+
+	bulkMsg := BulkEventMsg{
+		{
+			Type: "silver",
+			Data: &handlers.SilverEventData{
+				Amount:     500,
+				Session:    1000,
+				LootedBy:   "Player1",
+				LootedFrom: "Mob",
+			},
+			Timestamp: time.Now(),
+		},
+	}
+
+	m = updateModel(m, bulkMsg)
+
+	view := m.View()
+	if !strings.Contains(view, "Silver") {
+		t.Error("expected 'Silver' in stats panel after silver event")
+	}
+}
+
+func TestUpdateBulkEventKillDeath(t *testing.T) {
+	m := readyModel()
+
+	bulkMsg := BulkEventMsg{
+		{
+			Type:      "kill",
+			Data:      &handlers.KillEventData{SessionKills: 1},
+			Timestamp: time.Now(),
+		},
+		{
+			Type:      "death",
+			Data:      &handlers.DeathEventData{Victim: "Player1", Killer: "Player2"},
+			Timestamp: time.Now(),
+		},
+		{
+			Type:      "loot",
+			Data:      &handlers.LootEventData{ItemName: "Sword", Quantity: 1},
+			Timestamp: time.Now(),
+		},
+	}
+
+	m = updateModel(m, bulkMsg)
+
+	statsView := m.statsPanel.View()
+	if !strings.Contains(statsView, "Kills") {
+		t.Error("expected 'Kills' in stats panel")
+	}
+	if !strings.Contains(statsView, "Deaths") {
+		t.Error("expected 'Deaths' in stats panel")
+	}
+	if !strings.Contains(statsView, "Loot") {
+		t.Error("expected 'Loot' in stats panel")
+	}
+}
+
+// ============================================
+// Update: StatsUpdateMsg tests
+// ============================================
+
+func TestUpdateStatsUpdate(t *testing.T) {
+	m := New(nil, nil, nil)
+
+	stats := photon.NewStats()
+	stats.IncrPacketsReceived()
+	stats.IncrEventsDecoded()
+
+	m = updateModel(m, StatsUpdateMsg{Stats: stats})
+
+	if !m.statusBar.Online() {
+		t.Error("expected online=true after stats update")
+	}
+}
+
+func TestUpdateOnlineMsg(t *testing.T) {
+	m := New(nil, nil, nil)
+
+	m = updateModel(m, OnlineMsg{Online: true})
+	if !m.statusBar.Online() {
+		t.Error("expected online=true after OnlineMsg")
+	}
+
+	m = updateModel(m, OnlineMsg{Online: false})
+	if m.statusBar.Online() {
+		t.Error("expected online=false after OnlineMsg{false}")
+	}
+}
+
+func TestUpdateSessionStatsMsg(t *testing.T) {
+	m := readyModel()
+
+	m = updateModel(m, SessionStatsMsg{Fame: 500, Silver: 1000})
+
+	statsView := m.statsPanel.View()
+	if !strings.Contains(statsView, "Fame") {
+		t.Error("expected Fame in stats after SessionStatsMsg")
+	}
+}
+
+func TestUpdateWindowSizeMsg(t *testing.T) {
+	m := New(nil, nil, nil)
+
+	m = updateModel(m, tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	if !m.ready {
+		t.Error("expected ready=true after WindowSizeMsg")
+	}
+	if m.width != 100 {
+		t.Errorf("expected width=100, got %d", m.width)
+	}
+	if m.height != 30 {
+		t.Errorf("expected height=30, got %d", m.height)
+	}
+}
+
+// ============================================
+// View tests
+// ============================================
+
+func TestViewQuitting(t *testing.T) {
+	m := New(nil, nil, nil)
+	m.quitting = true
+
+	view := m.View()
+	if !strings.Contains(view, "Goodbye!") {
+		t.Errorf("expected 'Goodbye!' in view, got %q", view)
+	}
+}
+
+func TestViewNotReady(t *testing.T) {
+	m := New(nil, nil, nil)
+
+	view := m.View()
+	if !strings.Contains(view, "Initializing") {
+		t.Errorf("expected 'Initializing' in view, got %q", view)
+	}
+}
+
+func TestViewReady(t *testing.T) {
+	m := readyModel()
+
+	view := m.View()
+	if strings.Contains(view, "Initializing") {
+		t.Error("expected view to be past 'Initializing' state")
+	}
+	if !strings.Contains(view, "Events") {
+		t.Error("expected 'Events' section in ready view")
+	}
+	if !strings.Contains(view, "Session Stats") {
+		t.Error("expected 'Session Stats' section in ready view")
+	}
+}


### PR DESCRIPTION
## Summary
This PR extracts hardcoded magic numbers and inline event batching logic from the TUI `main.go` into testable, reusable utilities, and adds comprehensive unit test coverage for TUI components, the main event bridge, and the model.

## Motivation
- **Issue #75**: Magic numbers (channel buffer sizes, batch size, flush interval) were hardcoded inline in `cmd/tui/main.go`, making them difficult to discover, tune, and test.
- **Issue #76**: The TUI layer lacked unit tests, especially for the event batching logic, number formatting, and component behaviors, making future refactors risky and error-prone.

## Changes Made
- Extracted named constants (`bulkEventChannelSize`, `statsChannelSize`, `eventBatchSize`, `eventFlushInterval`) in `cmd/tui/main.go`
- Extracted the inline event batching goroutine into a standalone `bridgeEvents` function for direct unit testing
- Consolidated duplicated `formatNumber` logic (previously in both `model.go` and `eventlog.go`) into a shared `FormatNumber` utility in `internal/tui/components/format.go`
- Added `Online()` getter to `StatusBar` to expose online state for assertions in tests
- Added 5 new test files covering `bridgeEvents`, `FormatNumber`, `StatsPanel`, `StatusBar`, and the TUI `Model`
- Added extensive unit tests for event message formatting, model keyboard handling, bulk event processing, and component state transitions

## Impact
- No functional changes
- Performance: same (extraction does not alter runtime behavior or throughput)
- Code quality: improved testability, reduced code duplication, clearer intent via named constants, and increased regression safety through new test coverage

## Testing
- [x] All existing tests pass
- [x] No behavioral changes

## Breaking Changes
None

## Related Issues
Resolves #75, resolves #76

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

This PR extracts hardcoded magic numbers and inline event batching from `cmd/tui/main.go` into named constants and a standalone `bridgeEvents` function, consolidates duplicated `formatNumber` logic into a shared `FormatNumber` utility, and adds comprehensive unit tests for TUI components, the event bridge, and the model — all without behavioral changes.

---
<sup>Written for commit d14c119c6de999763f2177e1d3eab4878a01e698. Summary will update on new commits.</sup>
<!-- end-auto-generated -->