### PR TITLE
fix(handlers): deduplicate kills and exclude foreign silver from session totals

### DIFF
--- a/pkg/backend/service.go
+++ b/pkg/backend/service.go
@@ -103,7 +103,7 @@ func (s *Service) Start() error {
 			Timestamp: time.Now(),
 			Data:      data,
 		}
-		
+
 		// Update peak buffer usage stats before sending
 		if s.parser != nil && s.parser.Stats != nil {
 			s.parser.Stats.UpdateBufferPeak(len(s.eventsChan))
@@ -325,6 +325,15 @@ func (s *Service) SessionLoot() int {
 		return 0
 	}
 	return s.handler.GetSessionLoot()
+}
+
+// LocalPlayerName returns the auto-detected local player name, or "" if the
+// OpJoin response has not been captured yet.
+func (s *Service) LocalPlayerName() string {
+	if s.handler == nil {
+		return ""
+	}
+	return s.handler.GetLocalPlayer()
 }
 
 // ParserStats returns the current parser statistics.

--- a/pkg/events/codes.go
+++ b/pkg/events/codes.go
@@ -711,6 +711,16 @@ const (
 	ParamOperationCode = 253 // 253 - Operation code parameter key
 )
 
+// Operation codes (client/server requests and responses).
+// These are distinct from EventCode values above; Photon operation codes share
+// the byte space but identify request/response types rather than events.
+const (
+	// OperationJoin is the server response sent when the local player joins a
+	// game server. Its parameters carry the local player's identity, notably
+	// parameters[2] (Username). Used to identify the local player.
+	OperationJoin = 2
+)
+
 // EventCodeNames maps event codes to their string representation
 var EventCodeNames = map[EventCode]string{
 	EventUnused: "Unused",

--- a/pkg/handlers/albion.go
+++ b/pkg/handlers/albion.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cantalupo555/albion-lens/pkg/events"
@@ -20,26 +21,33 @@ import (
 // data: optional structured data (FameEventData, SilverEventData, RespecEventData, etc.)
 type EventCallback func(eventType, message string, data interface{})
 
+// defaultDeathDedupWindow is how long a (victim, killer) death signature is
+// remembered so that redundant copies of the same death (delivered when the local
+// player is the killer) are collapsed into a single event. Short enough that two
+// legitimate kills this far apart are both counted. Overridable per-handler for
+// testing via AlbionHandler.deathDedupWindow.
+const defaultDeathDedupWindow = 5 * time.Second
+
 // AlbionHandler handles Albion Online game events
 type AlbionHandler struct {
 	debug     bool
 	discovery bool
 
 	// Fame tracking
-	totalFame   int64
-	sessionFame int64
+	totalFame   atomic.Int64
+	sessionFame atomic.Int64
 
 	// Silver tracking
-	sessionSilver int64
+	sessionSilver atomic.Int64
 
 	// Combat Fame Credits (respec) tracking
-	sessionRespec       int64
-	sessionRespecSilver int64
+	sessionRespec       atomic.Int64
+	sessionRespecSilver atomic.Int64
 
 	// Kill/Death tracking
-	sessionKills  int
-	sessionDeaths int
-	sessionLoot   int
+	sessionKills  atomic.Int64
+	sessionDeaths atomic.Int64
+	sessionLoot   atomic.Int64
 
 	// Items database
 	itemDB *items.ItemDatabase
@@ -48,24 +56,42 @@ type AlbionHandler struct {
 	discoveredEvents map[int16]*DiscoveredEvent
 	discoveryMu      sync.RWMutex
 
+	// Local player identity, auto-detected from the OpJoin response (operation
+	// code 2, parameters[2] = Username). Used to filter foreign loot and attribute
+	// kills/deaths to the local player. Empty until the first OpJoin is captured.
+	localPlayer   string
+	localPlayerMu sync.RWMutex
+
+	// Recent death deduplication. When the local player kills someone, the server
+	// delivers EventDied redundantly (multiple copies within the same second).
+	// We dedup by a (victim, killer) signature within deathDedupWindow.
+	recentDeaths     map[string]time.Time
+	deathsMu         sync.Mutex
+	deathDedupWindow time.Duration
+	lastDeathsPurge  time.Time
+	nowFunc          func() time.Time
+
 	// Event callback for frontend integration (TUI, Wails, etc.)
 	eventCallback EventCallback
 }
 
 // DiscoveredEvent tracks unknown events in discovery mode
 type DiscoveredEvent struct {
-	Code       int16                  `json:"code"`
-	Count      int                    `json:"count"`
-	FirstSeen  time.Time              `json:"first_seen"`
-	LastSeen   time.Time              `json:"last_seen"`
-	SampleData map[byte]interface{}   `json:"sample_data"`
-	ParamTypes map[byte]string        `json:"param_types"`
+	Code       int16                `json:"code"`
+	Count      int                  `json:"count"`
+	FirstSeen  time.Time            `json:"first_seen"`
+	LastSeen   time.Time            `json:"last_seen"`
+	SampleData map[byte]interface{} `json:"sample_data"`
+	ParamTypes map[byte]string      `json:"param_types"`
 }
 
 // NewAlbionHandler creates a new Albion event handler
 func NewAlbionHandler() *AlbionHandler {
 	return &AlbionHandler{
 		discoveredEvents: make(map[int16]*DiscoveredEvent),
+		recentDeaths:     make(map[string]time.Time),
+		deathDedupWindow: defaultDeathDedupWindow,
+		nowFunc:          time.Now,
 	}
 }
 
@@ -84,10 +110,39 @@ func (h *AlbionHandler) SetEventCallback(callback EventCallback) {
 	h.eventCallback = callback
 }
 
+// SetLocalPlayer records the local player's name, auto-detected from the OpJoin
+// response. An empty argument is ignored.
+func (h *AlbionHandler) SetLocalPlayer(name string) {
+	if name == "" {
+		return
+	}
+	h.localPlayerMu.Lock()
+	h.localPlayer = name
+	h.localPlayerMu.Unlock()
+}
+
+// GetLocalPlayer returns the local player's name, or "" if the OpJoin response
+// has not been received yet (e.g. the tool was started after the game was
+// already running and no map change / relog has occurred since).
+func (h *AlbionHandler) GetLocalPlayer() string {
+	h.localPlayerMu.RLock()
+	defer h.localPlayerMu.RUnlock()
+	return h.localPlayer
+}
+
 // notifyEvent calls the event callback if set
 func (h *AlbionHandler) notifyEvent(eventType, message string, data interface{}) {
 	if h.eventCallback != nil {
 		h.eventCallback(eventType, message, data)
+	}
+}
+
+// debugNotify emits a debug event only when debug mode is enabled. Used for
+// diagnostic signals (identity capture, kill routing, override decisions) that
+// should not pollute the normal event log.
+func (h *AlbionHandler) debugNotify(message string, data interface{}) {
+	if h.debug {
+		h.notifyEvent("debug", message, data)
 	}
 }
 
@@ -104,6 +159,7 @@ type SilverEventData struct {
 	Session    int64  // Total silver gained this session
 	LootedBy   string // Player who looted
 	LootedFrom string // Source of the loot
+	Counted    bool   // Whether this amount was added to the session total
 }
 
 // LootEventData contains loot-specific event data
@@ -136,17 +192,17 @@ type RespecEventData struct {
 
 // GetSessionKills returns the number of kills in this session
 func (h *AlbionHandler) GetSessionKills() int {
-	return h.sessionKills
+	return int(h.sessionKills.Load())
 }
 
 // GetSessionDeaths returns the number of deaths in this session
 func (h *AlbionHandler) GetSessionDeaths() int {
-	return h.sessionDeaths
+	return int(h.sessionDeaths.Load())
 }
 
 // GetSessionLoot returns the number of loot items in this session
 func (h *AlbionHandler) GetSessionLoot() int {
-	return h.sessionLoot
+	return int(h.sessionLoot.Load())
 }
 
 // LoadItemDatabase loads the item database from ao-bin-dumps
@@ -162,7 +218,17 @@ func (h *AlbionHandler) OnRequest(operationCode byte, parameters map[byte]interf
 
 // OnResponse handles operation responses (server -> client)
 func (h *AlbionHandler) OnResponse(operationCode byte, returnCode int16, debugMessage string, parameters map[byte]interface{}) {
-	// Responses are not logged to avoid polluting TUI output
+	switch operationCode {
+	case events.OperationJoin:
+		// The Join response carries the local player's identity.
+		// parameters[2] is the Username (character name).
+		if name := getString(parameters, 2); name != "" {
+			h.debugNotify("local player detected from OpJoin", name)
+			h.SetLocalPlayer(name)
+		} else {
+			h.debugNotify("OpJoin response had no player name", nil)
+		}
+	}
 }
 
 // OnEvent handles incoming game events
@@ -266,7 +332,7 @@ func (h *AlbionHandler) trackDiscoveredEvent(code int16, params map[byte]interfa
 func (h *AlbionHandler) GetDiscoveredEvents() map[int16]*DiscoveredEvent {
 	h.discoveryMu.RLock()
 	defer h.discoveryMu.RUnlock()
-	
+
 	// Return a copy
 	result := make(map[int16]*DiscoveredEvent)
 	for k, v := range h.discoveredEvents {
@@ -333,22 +399,22 @@ func (h *AlbionHandler) isKnownEventCode(code int16) bool {
 
 // GetSessionFame returns the total fame gained in this session
 func (h *AlbionHandler) GetSessionFame() int64 {
-	return h.sessionFame
+	return h.sessionFame.Load()
 }
 
 // GetSessionSilver returns the total silver looted in this session
 func (h *AlbionHandler) GetSessionSilver() int64 {
-	return h.sessionSilver
+	return h.sessionSilver.Load()
 }
 
 // GetSessionRespec returns the total combat fame credits gained in this session
 func (h *AlbionHandler) GetSessionRespec() int64 {
-	return h.sessionRespec
+	return h.sessionRespec.Load()
 }
 
 // GetSessionRespecSilver returns the total silver spent on auto-respec this session
 func (h *AlbionHandler) GetSessionRespecSilver() int64 {
-	return h.sessionRespecSilver
+	return h.sessionRespecSilver.Load()
 }
 
 // handleUpdateFame handles fame/XP gain events
@@ -369,7 +435,7 @@ func (h *AlbionHandler) handleUpdateFame(params map[byte]interface{}) {
 
 	// Deduplication: Server sends both Event #81 and #82 for the same fame gain
 	// Skip if we already processed an event with this exact totalFame
-	if totalFame == h.totalFame {
+	if totalFame == h.totalFame.Load() {
 		return
 	}
 
@@ -388,14 +454,14 @@ func (h *AlbionHandler) handleUpdateFame(params map[byte]interface{}) {
 
 	// Validation: Total fame should not decrease significantly
 	// This helps filter out events with similar structure but different purpose
-	if h.totalFame > 0 && totalFame < h.totalFame {
+	if prev := h.totalFame.Load(); prev > 0 && totalFame < prev {
 		return
 	}
-	
+
 	// Calculate values (divide by 10000 for FixPoint format)
 	// Use Floor (truncate) to match game's display behavior
 	totalFameVal := math.Floor(float64(totalFame) / 10000.0)
-	
+
 	if hasDetailedFormat {
 		// Detailed format: we have the actual gained fame
 		fameGainedVal := math.Floor(float64(fameGained) / 10000.0)
@@ -403,33 +469,33 @@ func (h *AlbionHandler) handleUpdateFame(params map[byte]interface{}) {
 
 		// Only notify if fame was actually gained
 		if fameGainedVal > 0 {
-			h.sessionFame += int64(fameGainedVal)
-			h.totalFame = totalFame // Update tracked total
+			h.sessionFame.Add(int64(fameGainedVal))
+			h.totalFame.Store(totalFame) // Update tracked total
 
 			// Message formatting is now handled by the frontend (TUI)
 			h.notifyEvent("fame", "", &FameEventData{
 				Gained:  int64(fameGainedVal),
 				Total:   int64(totalFameVal),
-				Session: h.sessionFame,
+				Session: h.sessionFame.Load(),
 			})
 		}
 	} else {
 		// Simple format: we only have total fame
 		// Calculate gained by comparing with previous total
-		if h.totalFame > 0 {
-			gained := totalFame - h.totalFame
+		if h.totalFame.Load() > 0 {
+			gained := totalFame - h.totalFame.Load()
 			if gained > 0 {
 				gainedVal := math.Floor(float64(gained) / 10000.0)
-				h.sessionFame += int64(gainedVal)
+				h.sessionFame.Add(int64(gainedVal))
 				// Message formatting is now handled by the frontend (TUI)
 				h.notifyEvent("fame", "", &FameEventData{
 					Gained:  int64(gainedVal),
 					Total:   int64(totalFameVal),
-					Session: h.sessionFame,
+					Session: h.sessionFame.Load(),
 				})
 			}
 		}
-		h.totalFame = totalFame
+		h.totalFame.Store(totalFame)
 	}
 }
 
@@ -494,14 +560,25 @@ func (h *AlbionHandler) handleOtherGrabbedLoot(params map[byte]interface{}) {
 		silverAmountRaw := getInt64(params, 5)
 		// Silver also uses FixPoint format (divide by 10000)
 		silverAmount := int64(math.Floor(float64(silverAmountRaw) / 10000.0))
-		h.sessionSilver += silverAmount
+
+		// Only silver looted by the local player counts toward the session total.
+		// The event is still notified (so other players' loot stays visible in the
+		// log), but it is excluded from the running total when looted by someone
+		// else. Before the local player is known (local == ""), we count everything
+		// to preserve the previous behavior.
+		local := h.GetLocalPlayer()
+		counted := local == "" || lootedBy == local
+		if counted {
+			h.sessionSilver.Add(silverAmount)
+		}
 		// Message formatting is now handled by the frontend (TUI)
 		// We just pass the raw data
 		h.notifyEvent("silver", "", &SilverEventData{
 			Amount:     silverAmount,
-			Session:    h.sessionSilver,
+			Session:    h.sessionSilver.Load(),
 			LootedBy:   lootedBy,
 			LootedFrom: lootedFrom,
+			Counted:    counted,
 		})
 	} else {
 		// Try to get item name from database
@@ -510,7 +587,11 @@ func (h *AlbionHandler) handleOtherGrabbedLoot(params map[byte]interface{}) {
 			itemName = h.itemDB.GetItemName(itemID)
 		}
 
-		h.sessionLoot++
+		// Item loot counts every event the client sees (not just the local
+		// player's loot), because the total volume of nearby loot is useful
+		// context. Silver is different — only the local player's silver
+		// contributes to the session total (see the silver branch above).
+		h.sessionLoot.Add(1)
 
 		// Message formatting is now handled by the frontend (TUI)
 		h.notifyEvent("loot", "", &LootEventData{
@@ -527,35 +608,107 @@ func (h *AlbionHandler) handleNewLoot(params map[byte]interface{}) {
 	// New loot events are informational only
 }
 
-// handleKilledPlayer handles player kill events
+// handleKilledPlayer handles player kill events.
+//
+// EventKilledPlayer (164) is only ever delivered to the local player when they are
+// the killer, and it carries no victim identifier. When the local player kills
+// someone, the server delivers it redundantly alongside EventDied. Because it has
+// no distinguishable payload, it cannot be deduped per-kill.
+//
+// Kill counting is therefore owned by handleDied (EventDied carries both victim and
+// killer names, so distinct kills are distinguishable and can be deduped correctly).
+// This handler is intentionally a no-op.
 func (h *AlbionHandler) handleKilledPlayer(params map[byte]interface{}) {
-	h.sessionKills++
-
-	// Message formatting is now handled by the frontend (TUI)
-	h.notifyEvent("kill", "", &KillEventData{
-		SessionKills: h.sessionKills,
-	})
+	// No-op: see method comment. Kills are counted via EventDied. Emit a debug
+	// signal so the receipt of this event stays traceable in debug mode.
+	h.debugNotify("EventKilledPlayer received (counted via EventDied)", nil)
 }
 
-// handleDied handles death events
+// isDuplicateDeath reports whether the given death signature was already seen
+// within deathDedupWindow. Otherwise it records the signature and returns false.
+// Expired entries are purged at most once per dedup window (lazy cleanup) to
+// avoid O(n) iteration on every call during high-frequency combat (e.g., ZvZ).
+func (h *AlbionHandler) isDuplicateDeath(key string) bool {
+	now := h.nowFunc()
+
+	h.deathsMu.Lock()
+	defer h.deathsMu.Unlock()
+
+	if now.Sub(h.lastDeathsPurge) >= h.deathDedupWindow {
+		cutoff := now.Add(-h.deathDedupWindow)
+		for k, t := range h.recentDeaths {
+			if t.Before(cutoff) {
+				delete(h.recentDeaths, k)
+			}
+		}
+		h.lastDeathsPurge = now
+	}
+
+	if _, ok := h.recentDeaths[key]; ok {
+		return true
+	}
+	h.recentDeaths[key] = now
+	return false
+}
+
+// handleDied handles death events.
+//
+// EventDied (165) is a world broadcast delivered once when other players die, but
+// delivered redundantly (multiple copies within the same second) when the local
+// player is the killer. We dedup by a (victim, killer) signature so each death is
+// processed exactly once.
+//
+// This handler is the single source of truth for both kills and deaths:
+//   - a kill is counted when the local player is the killer;
+//   - a death is counted when the local player is the victim.
 func (h *AlbionHandler) handleDied(params map[byte]interface{}) {
 	victim := getString(params, 2)
 	killer := getString(params, 10)
 
+	local := h.GetLocalPlayer()
+
+	// Dedup redundant copies of the same death. The server delivers EventDied
+	// multiple times when the local player is the killer. Only apply dedup in
+	// that case — for other deaths each EventDied is a distinct event, and
+	// applying dedup before the local player is known would consume the dedup
+	// window and permanently lose a legitimate kill.
+	if local != "" && killer == local {
+		key := victim + "\x00" + killer // use raw victim name (before "Someone" default)
+		if h.isDuplicateDeath(key) {
+			return
+		}
+	}
+
+	// Default display name for anonymous victims
 	if victim == "" {
 		victim = "Someone"
 	}
 
-	// We only increment session deaths if WE died, but we don't have local player tracking yet.
-	// For now, let's just log the event.
-	h.sessionDeaths++
+	isLocalKill := local != "" && killer == local
 
-	// Message formatting is now handled by the frontend (TUI)
-	h.notifyEvent("death", "", &DeathEventData{
-		Victim:        victim,
-		Killer:        killer,
-		SessionDeaths: h.sessionDeaths,
-	})
+	// Count a kill when the local player is the killer.
+	if isLocalKill {
+		h.sessionKills.Add(1)
+		h.notifyEvent("kill", "", &KillEventData{
+			SessionKills: int(h.sessionKills.Load()),
+		})
+	}
+
+	// Count a death only when the local player is the victim.
+	if local != "" && victim == local {
+		h.sessionDeaths.Add(1)
+	}
+
+	// Emit a death event for the local player's death or for nearby deaths
+	// (neither party is the local player). Skip when the local player is the
+	// killer — the kill event already covers it and avoids a duplicate entry.
+	if !isLocalKill {
+		h.notifyEvent("death", "", &DeathEventData{
+			Victim:        victim,
+			Killer:        killer,
+			SessionDeaths: int(h.sessionDeaths.Load()),
+		})
+	}
 }
 
 // handleUpdateReSpecPoints handles combat fame credit (respec) gain events
@@ -571,14 +724,14 @@ func (h *AlbionHandler) handleUpdateReSpecPoints(params map[byte]interface{}) {
 	gainedVal := int64(math.Floor(float64(gainedReSpec) / 10000.0))
 	silverVal := int64(math.Floor(float64(paidSilver) / 10000.0))
 
-	h.sessionRespec += gainedVal
-	h.sessionRespecSilver += silverVal
+	h.sessionRespec.Add(gainedVal)
+	h.sessionRespecSilver.Add(silverVal)
 
 	h.notifyEvent("respec", "", &RespecEventData{
 		Gained:             gainedVal,
 		PaidSilver:         silverVal,
-		SessionTotal:       h.sessionRespec,
-		SessionSilverTotal: h.sessionRespecSilver,
+		SessionTotal:       h.sessionRespec.Load(),
+		SessionSilverTotal: h.sessionRespecSilver.Load(),
 	})
 }
 

--- a/pkg/handlers/albion_test.go
+++ b/pkg/handlers/albion_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -89,6 +90,7 @@ func TestNotifyEventNoCallback(t *testing.T) {
 // TestSessionCounters tests kill/death/loot counters
 func TestSessionCounters(t *testing.T) {
 	handler := NewAlbionHandler()
+	handler.SetLocalPlayer("Hero")
 
 	// Initial values should be 0
 	if handler.GetSessionKills() != 0 {
@@ -101,14 +103,26 @@ func TestSessionCounters(t *testing.T) {
 		t.Error("initial loot should be 0")
 	}
 
-	// Simulate kill event
+	// EventKilledPlayer is a no-op; kills are counted via EventDied.
 	handler.OnEvent(byte(events.EventKilledPlayer), map[byte]interface{}{})
+	if handler.GetSessionKills() != 0 {
+		t.Errorf("EventKilledPlayer should not count kills, got %d", handler.GetSessionKills())
+	}
+
+	// Local player kills someone -> kill counted.
+	handler.OnEvent(byte(events.EventDied), map[byte]interface{}{
+		2:  "Enemy",
+		10: "Hero",
+	})
 	if handler.GetSessionKills() != 1 {
 		t.Errorf("expected 1 kill, got %d", handler.GetSessionKills())
 	}
 
-	// Simulate death event
-	handler.OnEvent(byte(events.EventDied), map[byte]interface{}{})
+	// Local player dies -> death counted.
+	handler.OnEvent(byte(events.EventDied), map[byte]interface{}{
+		2:  "Hero",
+		10: "Enemy",
+	})
 	if handler.GetSessionDeaths() != 1 {
 		t.Errorf("expected 1 death, got %d", handler.GetSessionDeaths())
 	}
@@ -172,7 +186,7 @@ func TestHandleUpdateFameDetailedFormat(t *testing.T) {
 func TestHandleUpdateFameSimpleFormat(t *testing.T) {
 	handler := NewAlbionHandler()
 	// Set initial total fame
-	handler.totalFame = int64(40000000000) // 4M in FixPoint
+	handler.totalFame.Store(int64(40000000000)) // 4M in FixPoint
 
 	var receivedData *FameEventData
 	handler.SetEventCallback(func(eventType, message string, data interface{}) {
@@ -311,11 +325,11 @@ func TestHandleOtherGrabbedLootItem(t *testing.T) {
 	// Simulate item loot event
 	// Note: EventOtherGrabbedLoot (275) > 255, so we pass it via ParamEventCode
 	params := map[byte]interface{}{
-		1:                     "Chest",       // Looted from
-		2:                     "Player1",     // Looted by
-		3:                     false,         // Is silver (false = item)
-		4:                     int32(12345),  // Item ID
-		5:                     int32(3),      // Quantity
+		1:                     "Chest",      // Looted from
+		2:                     "Player1",    // Looted by
+		3:                     false,        // Is silver (false = item)
+		4:                     int32(12345), // Item ID
+		5:                     int32(3),     // Quantity
 		events.ParamEventCode: int16(events.EventOtherGrabbedLoot),
 	}
 
@@ -342,35 +356,32 @@ func TestHandleOtherGrabbedLootItem(t *testing.T) {
 	}
 }
 
-// TestHandleKilledPlayer tests kill event handling
+// TestHandleKilledPlayer tests that EventKilledPlayer is a no-op. Kills are
+// counted via EventDied (where killer == localPlayer), which carries a victim
+// identifier and can be deduped per kill.
 func TestHandleKilledPlayer(t *testing.T) {
 	handler := NewAlbionHandler()
+	handler.SetLocalPlayer("Hero")
 
-	var receivedData *KillEventData
+	called := false
 	handler.SetEventCallback(func(eventType, message string, data interface{}) {
 		if eventType == "kill" {
-			if killData, ok := data.(*KillEventData); ok {
-				receivedData = killData
-			}
+			called = true
 		}
 	})
 
 	handler.OnEvent(byte(events.EventKilledPlayer), map[byte]interface{}{})
 
-	if receivedData == nil {
-		t.Fatal("kill callback was not called")
+	if called {
+		t.Error("EventKilledPlayer should not produce a kill callback")
 	}
 
-	if receivedData.SessionKills != 1 {
-		t.Errorf("expected SessionKills 1, got %d", receivedData.SessionKills)
-	}
-
-	if handler.GetSessionKills() != 1 {
-		t.Errorf("expected 1 kill, got %d", handler.GetSessionKills())
+	if handler.GetSessionKills() != 0 {
+		t.Errorf("expected 0 kills (no-op), got %d", handler.GetSessionKills())
 	}
 }
 
-// TestHandleDied tests death event handling
+// TestHandleDied tests death event handling and the victim name default.
 func TestHandleDied(t *testing.T) {
 	handler := NewAlbionHandler()
 
@@ -383,6 +394,7 @@ func TestHandleDied(t *testing.T) {
 		}
 	})
 
+	// Empty victim name defaults to "Someone".
 	handler.OnEvent(byte(events.EventDied), map[byte]interface{}{})
 
 	if receivedData == nil {
@@ -393,12 +405,13 @@ func TestHandleDied(t *testing.T) {
 		t.Errorf("expected Victim 'Someone', got %s", receivedData.Victim)
 	}
 
-	if receivedData.SessionDeaths != 1 {
-		t.Errorf("expected SessionDeaths 1, got %d", receivedData.SessionDeaths)
+	// Without a known local player, deaths are not counted.
+	if receivedData.SessionDeaths != 0 {
+		t.Errorf("expected SessionDeaths 0 (no local player), got %d", receivedData.SessionDeaths)
 	}
 
-	if handler.GetSessionDeaths() != 1 {
-		t.Errorf("expected 1 death, got %d", handler.GetSessionDeaths())
+	if handler.GetSessionDeaths() != 0 {
+		t.Errorf("expected 0 deaths (no local player), got %d", handler.GetSessionDeaths())
 	}
 }
 
@@ -542,15 +555,21 @@ func TestIsKnownEventCode(t *testing.T) {
 // TestOnEventWithParamEventCode tests that event code is read from param 252
 func TestOnEventWithParamEventCode(t *testing.T) {
 	handler := NewAlbionHandler()
-	handler.SetDiscoveryMode(true)
+
+	called := false
+	handler.SetEventCallback(func(eventType, message string, data interface{}) {
+		if eventType == "death" {
+			called = true
+		}
+	})
 
 	// Send event with event code in param 252
 	params := map[byte]interface{}{
-		events.ParamEventCode: int16(events.EventKilledPlayer),
+		events.ParamEventCode: int16(events.EventDied),
 	}
 	handler.OnEvent(0, params) // byte code is 0, but actual code is in param 252
 
-	if handler.GetSessionKills() != 1 {
+	if !called {
 		t.Error("event code from param 252 was not used")
 	}
 }
@@ -558,24 +577,29 @@ func TestOnEventWithParamEventCode(t *testing.T) {
 // TestOnEventParamEventCodeConversion tests different types for param event code
 func TestOnEventParamEventCodeConversion(t *testing.T) {
 	testCases := []struct {
-		name     string
-		codeVal  interface{}
-		expected int
+		name    string
+		codeVal interface{}
 	}{
-		{"int16", int16(events.EventKilledPlayer), 1},
-		{"int32", int32(events.EventKilledPlayer), 1},
-		{"int64", int64(events.EventKilledPlayer), 1},
+		{"int16", int16(events.EventDied)},
+		{"int32", int32(events.EventDied)},
+		{"int64", int64(events.EventDied)},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			h := NewAlbionHandler()
+			called := false
+			h.SetEventCallback(func(eventType, message string, data interface{}) {
+				if eventType == "death" {
+					called = true
+				}
+			})
 			params := map[byte]interface{}{
 				events.ParamEventCode: tc.codeVal,
 			}
 			h.OnEvent(0, params)
-			if h.GetSessionKills() != tc.expected {
-				t.Errorf("expected %d kills with %s, got %d", tc.expected, tc.name, h.GetSessionKills())
+			if !called {
+				t.Errorf("expected death callback with %s, got none", tc.name)
 			}
 		})
 	}
@@ -957,5 +981,496 @@ func TestDiscoveredEventStructure(t *testing.T) {
 	}
 	if len(event.ParamTypes) != 1 {
 		t.Errorf("ParamTypes field incorrect")
+	}
+}
+
+// TestSetLocalPlayer tests that SetLocalPlayer ignores empty values and
+// overwrites the previous name (used internally by OpJoin auto-detection).
+func TestSetLocalPlayer(t *testing.T) {
+	handler := NewAlbionHandler()
+
+	if got := handler.GetLocalPlayer(); got != "" {
+		t.Errorf("expected empty local player initially, got %q", got)
+	}
+
+	// Empty value is ignored.
+	handler.SetLocalPlayer("")
+	if got := handler.GetLocalPlayer(); got != "" {
+		t.Errorf("empty SetLocalPlayer should be ignored, got %q", got)
+	}
+
+	handler.SetLocalPlayer("Hero")
+
+	if got := handler.GetLocalPlayer(); got != "Hero" {
+		t.Errorf("expected 'Hero', got %q", got)
+	}
+
+	// A subsequent call overwrites (e.g. relog with a different character).
+	handler.SetLocalPlayer("Hero2")
+	if got := handler.GetLocalPlayer(); got != "Hero2" {
+		t.Errorf("expected 'Hero2' after overwrite, got %q", got)
+	}
+}
+
+// TestOpJoinSetsLocalPlayer tests that the OpJoin response captures the local
+// player name from parameters[2].
+func TestOpJoinSetsLocalPlayer(t *testing.T) {
+	handler := NewAlbionHandler()
+
+	handler.OnResponse(events.OperationJoin, 0, "", map[byte]interface{}{
+		2: "cantalupo",
+	})
+
+	if got := handler.GetLocalPlayer(); got != "cantalupo" {
+		t.Errorf("expected local player 'cantalupo', got %q", got)
+	}
+}
+
+// TestOpJoinIgnoredForUnknownOpCode tests that other operation codes do not set
+// the local player.
+func TestOpJoinIgnoredForUnknownOpCode(t *testing.T) {
+	handler := NewAlbionHandler()
+
+	handler.OnResponse(99, 0, "", map[byte]interface{}{
+		2: "Someone",
+	})
+
+	if got := handler.GetLocalPlayer(); got != "" {
+		t.Errorf("non-Join response must not set local player, got %q", got)
+	}
+}
+
+// TestOpJoinIgnoresEmptyName tests that an OpJoin response with an empty or
+// missing player name does not set the local player.
+func TestOpJoinIgnoresEmptyName(t *testing.T) {
+	handler := NewAlbionHandler()
+
+	// Missing parameter 2 entirely.
+	handler.OnResponse(events.OperationJoin, 0, "", map[byte]interface{}{})
+	if got := handler.GetLocalPlayer(); got != "" {
+		t.Errorf("missing OpJoin name must not set local player, got %q", got)
+	}
+
+	// Empty string parameter.
+	handler.OnResponse(events.OperationJoin, 0, "", map[byte]interface{}{
+		2: "",
+	})
+	if got := handler.GetLocalPlayer(); got != "" {
+		t.Errorf("empty OpJoin name must not set local player, got %q", got)
+	}
+}
+
+// TestDiedNoKillCountedWhenLocalUnknown tests that, before the local player is
+// known, kills are not counted even when EventDied arrives. This guards against
+// reintroducing unconditional kill counting.
+func TestDiedNoKillCountedWhenLocalUnknown(t *testing.T) {
+	handler := NewAlbionHandler()
+
+	killCount := 0
+	handler.SetEventCallback(func(eventType, message string, data interface{}) {
+		if eventType == "kill" {
+			killCount++
+		}
+	})
+
+	// No local player set: a death where someone happens to be the killer must
+	// not be attributed as the local player's kill.
+	handler.OnEvent(byte(events.EventDied), map[byte]interface{}{
+		2:  "Victim",
+		10: "Someone",
+	})
+
+	if handler.GetSessionKills() != 0 {
+		t.Errorf("expected 0 kills when local player unknown, got %d", handler.GetSessionKills())
+	}
+	if killCount != 0 {
+		t.Errorf("expected 0 kill callbacks when local player unknown, got %d", killCount)
+	}
+}
+
+// TestDiedCountsKillWhenLocalPlayerIsKiller tests that a kill is counted once when
+// the local player is the killer, and that redundant copies are collapsed.
+func TestDiedCountsKillWhenLocalPlayerIsKiller(t *testing.T) {
+	handler := NewAlbionHandler()
+	handler.SetLocalPlayer("cantalupo")
+
+	killCount := 0
+	deathCount := 0
+	handler.SetEventCallback(func(eventType, message string, data interface{}) {
+		switch eventType {
+		case "kill":
+			killCount++
+		case "death":
+			deathCount++
+		}
+	})
+
+	// The server delivers EventDied redundantly when the local player is the killer.
+	deathParams := map[byte]interface{}{
+		2:  "TNTAbyss",
+		10: "cantalupo",
+	}
+	for i := 0; i < 3; i++ {
+		handler.OnEvent(byte(events.EventDied), deathParams)
+	}
+
+	if handler.GetSessionKills() != 1 {
+		t.Errorf("expected 1 kill (deduped), got %d", handler.GetSessionKills())
+	}
+	if killCount != 1 {
+		t.Errorf("expected 1 kill callback, got %d", killCount)
+	}
+	if deathCount != 0 {
+		t.Errorf("expected 0 death callbacks for a local kill, got %d", deathCount)
+	}
+
+	// Local player was the killer, not the victim: deaths must not be counted.
+	if handler.GetSessionDeaths() != 0 {
+		t.Errorf("expected 0 deaths, got %d", handler.GetSessionDeaths())
+	}
+}
+
+// TestDiedDedupByVictimKiller tests that distinct victims within the dedup window
+// are counted separately (rapid multi-kills are preserved), while the same
+// victim+killer is collapsed.
+func TestDiedDedupByVictimKiller(t *testing.T) {
+	handler := NewAlbionHandler()
+	handler.SetLocalPlayer("Hero")
+
+	// Two different victims back-to-back: both counted.
+	handler.OnEvent(byte(events.EventDied), map[byte]interface{}{
+		2:  "VictimA",
+		10: "Hero",
+	})
+	handler.OnEvent(byte(events.EventDied), map[byte]interface{}{
+		2:  "VictimB",
+		10: "Hero",
+	})
+
+	if handler.GetSessionKills() != 2 {
+		t.Errorf("expected 2 kills for distinct victims, got %d", handler.GetSessionKills())
+	}
+
+	// A duplicate of the first kill is collapsed.
+	handler.OnEvent(byte(events.EventDied), map[byte]interface{}{
+		2:  "VictimA",
+		10: "Hero",
+	})
+
+	if handler.GetSessionKills() != 2 {
+		t.Errorf("expected deduped 2 kills, got %d", handler.GetSessionKills())
+	}
+}
+
+// TestDiedOnlyCountsLocalDeaths tests that a death is counted only when the local
+// player is the victim; deaths of other players do not increment sessionDeaths.
+func TestDiedOnlyCountsLocalDeaths(t *testing.T) {
+	handler := NewAlbionHandler()
+	handler.SetLocalPlayer("Hero")
+
+	// Another player dies: not counted.
+	handler.OnEvent(byte(events.EventDied), map[byte]interface{}{
+		2:  "Stranger",
+		10: "SomeoneElse",
+	})
+	if handler.GetSessionDeaths() != 0 {
+		t.Errorf("foreign death must not count, got %d", handler.GetSessionDeaths())
+	}
+
+	// Local player dies: counted.
+	handler.OnEvent(byte(events.EventDied), map[byte]interface{}{
+		2:  "Hero",
+		10: "Killer",
+	})
+	if handler.GetSessionDeaths() != 1 {
+		t.Errorf("expected 1 local death, got %d", handler.GetSessionDeaths())
+	}
+}
+
+// silverEventParams builds a silver loot event parameter map for tests.
+// silverAmountRaw is in FixPoint format (value * 10000).
+func silverEventParams(lootedBy, lootedFrom string, silverAmountRaw int64) map[byte]interface{} {
+	return map[byte]interface{}{
+		1:                     lootedFrom,
+		2:                     lootedBy,
+		3:                     true, // is silver
+		4:                     int32(0),
+		5:                     silverAmountRaw,
+		events.ParamEventCode: int16(events.EventOtherGrabbedLoot),
+	}
+}
+
+// TestSilverExcludesForeignLoot tests that silver looted by another player is
+// notified (still visible) but not added to the session total, while silver looted
+// by the local player is both notified and counted.
+func TestSilverExcludesForeignLoot(t *testing.T) {
+	handler := NewAlbionHandler()
+	handler.SetLocalPlayer("Hero")
+
+	var events []SilverEventData
+	handler.SetEventCallback(func(eventType, message string, data interface{}) {
+		if eventType == "silver" {
+			if sd, ok := data.(*SilverEventData); ok {
+				events = append(events, *sd)
+			}
+		}
+	})
+
+	// 5000 silver looted by the local player.
+	handler.OnEvent(0, silverEventParams("Hero", "Monster", 5000*10000))
+	// 420000 silver looted by someone else (foreign).
+	handler.OnEvent(0, silverEventParams("Stranger", "Monster", 420000*10000))
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 silver callbacks, got %d", len(events))
+	}
+
+	if events[0].Amount != 5000 || events[0].LootedBy != "Hero" || !events[0].Counted {
+		t.Errorf("local silver event mismatch: %+v", events[0])
+	}
+	if events[1].Amount != 420000 || events[1].LootedBy != "Stranger" || events[1].Counted {
+		t.Errorf("foreign silver should not be counted: %+v", events[1])
+	}
+
+	// Only the local player's 5000 silver counts toward the session total.
+	if handler.GetSessionSilver() != 5000 {
+		t.Errorf("expected session silver 5000, got %d", handler.GetSessionSilver())
+	}
+}
+
+// TestSilverCountsAllWhenLocalUnknown tests that, before the local player is known,
+// all silver is counted (backward compatible).
+func TestSilverCountsAllWhenLocalUnknown(t *testing.T) {
+	handler := NewAlbionHandler()
+
+	countedCount := 0
+	handler.SetEventCallback(func(eventType, message string, data interface{}) {
+		if eventType == "silver" {
+			if sd, ok := data.(*SilverEventData); ok && sd.Counted {
+				countedCount++
+			}
+		}
+	})
+
+	handler.OnEvent(0, silverEventParams("Stranger", "Monster", 5000*10000))
+	handler.OnEvent(0, silverEventParams("OtherGuy", "Monster", 3000*10000))
+
+	if countedCount != 2 {
+		t.Errorf("expected 2 counted events when local unknown, got %d", countedCount)
+	}
+	if handler.GetSessionSilver() != 8000 {
+		t.Errorf("expected session silver 8000 (count all), got %d", handler.GetSessionSilver())
+	}
+}
+
+// TestSilverEmptyLootedWithKnownLocal tests the malformed-packet edge case where
+// lootedBy is empty while a local player is known. Such silver must NOT be counted
+// toward the session total (it does not match the local player).
+func TestSilverEmptyLootedWithKnownLocal(t *testing.T) {
+	handler := NewAlbionHandler()
+	handler.SetLocalPlayer("Hero")
+
+	var received *SilverEventData
+	handler.SetEventCallback(func(eventType, message string, data interface{}) {
+		if eventType == "silver" {
+			if sd, ok := data.(*SilverEventData); ok {
+				received = sd
+			}
+		}
+	})
+
+	handler.OnEvent(0, silverEventParams("", "Monster", 5000*10000))
+
+	if received == nil {
+		t.Fatal("silver callback was not called")
+	}
+	if received.Counted {
+		t.Error("empty LootedBy must not be counted toward the session total")
+	}
+	if handler.GetSessionSilver() != 0 {
+		t.Errorf("expected session silver 0, got %d", handler.GetSessionSilver())
+	}
+}
+
+// TestDiedDedupWindowExpiry tests that a death signature stops being considered a
+// duplicate once deathDedupWindow has elapsed, so two legitimately separate kills of
+// the same victim far enough apart are both counted.
+func TestDiedDedupWindowExpiry(t *testing.T) {
+	handler := NewAlbionHandler()
+	handler.SetLocalPlayer("Hero")
+
+	// Use a virtual clock so the test does not have to sleep.
+	base := time.Now()
+	handler.nowFunc = func() time.Time { return base }
+	handler.deathDedupWindow = 100 * time.Millisecond
+
+	deathParams := map[byte]interface{}{
+		2:  "Victim",
+		10: "Hero",
+	}
+
+	// First kill: counted.
+	handler.OnEvent(byte(events.EventDied), deathParams)
+	if handler.GetSessionKills() != 1 {
+		t.Fatalf("expected 1 kill after first death, got %d", handler.GetSessionKills())
+	}
+
+	// Immediate duplicate: suppressed.
+	handler.OnEvent(byte(events.EventDied), deathParams)
+	if handler.GetSessionKills() != 1 {
+		t.Fatalf("expected duplicate to be suppressed, got %d", handler.GetSessionKills())
+	}
+
+	// Advance time past the dedup window: the same victim+killer is counted again.
+	base = base.Add(handler.deathDedupWindow + time.Second)
+	handler.OnEvent(byte(events.EventDied), deathParams)
+	if handler.GetSessionKills() != 2 {
+		t.Errorf("expected 2 kills after window expiry, got %d", handler.GetSessionKills())
+	}
+}
+
+// TestDiedDedupNotConsumedBeforeIdentity tests that a death arriving before the
+// local player is identified does NOT consume the dedup window. Without this
+// guard, the first real kill after identity capture would be permanently lost
+// because the dedup key was already recorded during the unknown-player phase.
+func TestDiedDedupNotConsumedBeforeIdentity(t *testing.T) {
+	handler := NewAlbionHandler()
+	// local player NOT set yet (simulating tool started mid-session)
+
+	deathParams := map[byte]interface{}{
+		2:  "Victim",
+		10: "Hero",
+	}
+
+	// Death arrives while identity is unknown: not counted, not deduped.
+	handler.OnEvent(byte(events.EventDied), deathParams)
+	if handler.GetSessionKills() != 0 {
+		t.Fatalf("expected 0 kills before identity, got %d", handler.GetSessionKills())
+	}
+
+	// Identity captured (e.g. from OpJoin). The same victim+killer death arrives
+	// again — it must NOT be treated as a duplicate because the dedup key was
+	// never recorded during the unknown phase.
+	handler.SetLocalPlayer("Hero")
+	handler.OnEvent(byte(events.EventDied), deathParams)
+	if handler.GetSessionKills() != 1 {
+		t.Errorf("expected 1 kill after identity (dedup not pre-consumed), got %d", handler.GetSessionKills())
+	}
+}
+
+// TestDebugNotifyOnLocalPlayerCapture tests that debug traces are emitted for local
+// player identity capture (only in debug mode).
+func TestDebugNotifyOnLocalPlayerCapture(t *testing.T) {
+	handler := NewAlbionHandler()
+	handler.SetDebug(true)
+
+	debugMsgs := []string{}
+	handler.SetEventCallback(func(eventType, message string, data interface{}) {
+		if eventType == "debug" {
+			debugMsgs = append(debugMsgs, message)
+		}
+	})
+
+	// OpJoin auto-detection emits a debug trace.
+	handler.OnResponse(events.OperationJoin, 0, "", map[byte]interface{}{
+		2: "Hero",
+	})
+
+	found := false
+	for _, m := range debugMsgs {
+		if m == "local player detected from OpJoin" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected OpJoin debug trace, got %v", debugMsgs)
+	}
+}
+
+// TestDebugNotifySuppressedWhenDebugOff tests that debug traces are NOT emitted when
+// debug mode is disabled.
+func TestDebugNotifySuppressedWhenDebugOff(t *testing.T) {
+	handler := NewAlbionHandler()
+	// debug is off by default
+
+	debugCount := 0
+	handler.SetEventCallback(func(eventType, message string, data interface{}) {
+		if eventType == "debug" {
+			debugCount++
+		}
+	})
+
+	handler.OnResponse(events.OperationJoin, 0, "", map[byte]interface{}{
+		2: "Hero",
+	})
+	handler.OnEvent(byte(events.EventKilledPlayer), map[byte]interface{}{})
+
+	if debugCount != 0 {
+		t.Errorf("expected no debug events when debug off, got %d", debugCount)
+	}
+}
+
+// TestSessionCountersConcurrent verifies that session counters are safe for
+// concurrent access: one goroutine writes via OnEvent while another reads via the
+// GetSession* getters. Under `go test -race` this would flag a data race if the
+// counters were still plain int/int64 fields.
+func TestSessionCountersConcurrent(t *testing.T) {
+	handler := NewAlbionHandler()
+	handler.SetLocalPlayer("Hero")
+	handler.deathDedupWindow = 0 // collapse nothing — each victim is unique anyway
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Reader goroutine: polls all getters continuously until the writer is done.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = handler.GetSessionKills()
+				_ = handler.GetSessionDeaths()
+				_ = handler.GetSessionLoot()
+				_ = handler.GetSessionFame()
+				_ = handler.GetSessionSilver()
+				_ = handler.GetSessionRespec()
+				_ = handler.GetSessionRespecSilver()
+			}
+		}
+	}()
+
+	// Writer goroutine: fires events that mutate every counter, then signals stop.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(stop)
+		for i := 0; i < 200; i++ {
+			handler.OnEvent(0, map[byte]interface{}{
+				0: int32(1),
+				1: int64(40_000_010_000 + i), // increasing total fame
+			})
+			handler.OnEvent(0, map[byte]interface{}{
+				1:                     "Hero",      // looted by
+				2:                     "Monster",   // looted from
+				3:                     true,        // is silver
+				4:                     int32(9999), // item id (silver)
+				5:                     int32(1000), // quantity
+				events.ParamEventCode: int16(events.EventOtherGrabbedLoot),
+			})
+			handler.OnEvent(byte(events.EventDied), map[byte]interface{}{
+				2:  fmt.Sprintf("Victim%d", i),
+				10: "Hero",
+			})
+		}
+	}()
+
+	wg.Wait()
+
+	// Final sanity: getters return sensible non-negative values.
+	if k := handler.GetSessionKills(); k < 0 {
+		t.Errorf("sessionKills should be >= 0, got %d", k)
 	}
 }


### PR DESCRIPTION
## Summary
Fixes two distinct counting bugs: kills were over-counted because the server delivers redundant `EventDied` copies when the local player is the killer, and silver session totals included loot picked up by other players. Introduces local-player auto-detection from the OpJoin response to enable accurate attribution. Also migrates all session counters to `atomic.Int64` to eliminate data races.

## Bug Description
- **What was happening:** Kill counts were inflated because `handleKilledPlayer` incremented on every delivery, and the server sends it redundantly alongside `EventDied` with no victim identifier to distinguish duplicates. Silver totals included other players' loot.
- **Expected behavior:** Each unique kill counted once; only the local player's silver contributes to the session total.
- **Root cause:** No mechanism to identify the local player, so the handler could not attribute kills/deaths/loot.

## Changes Made
- OpJoin auto-detection (`parameters[2] = Username`), exposed via `SetLocalPlayer`/`GetLocalPlayer` and `Service.LocalPlayerName()`
- Session counters migrated to `atomic.Int64` for concurrent safety
- Kill counting moved exclusively into `handleDied`; `handleKilledPlayer` is now a no-op
- `(victim, killer)` dedup with 5s expiry window to collapse redundant server deliveries
- Kills counted only when `killer == localPlayer`; deaths only when `victim == localPlayer`
- Silver excluded from session total when `lootedBy != localPlayer` (new `Counted` field on `SilverEventData`)
- Comprehensive tests: identity capture, dedup semantics, silver filtering, concurrent counter stress test

## Testing
- [x] Tested locally
- [x] Unit tests added/updated
- [x] No regressions

## Related Issues
Fixes #88

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

This PR fixes two session-counting bugs: kill counts were inflated by redundant server events, and silver totals incorrectly included other players' loot. It introduces local-player auto-detection from OpJoin responses, migrates counters to `atomic.Int64` for thread safety, and deduplicates kill events with a 5-second expiry window. Foreign silver is now excluded by checking the loot owner against the local player.

---
<sup>Written for commit 6719e4809061841e79f8a862b01ec0c0aace6124. Summary will update on new commits.</sup>
<!-- end-auto-generated -->