### PR TITLE
feat(tui): surface online status and local player identity in status bar

### DIFF
--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -6,15 +6,15 @@ import (
 	"os"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/cantalupo555/albion-lens/internal/tui"
 	"github.com/cantalupo555/albion-lens/pkg/backend"
 	"github.com/cantalupo555/albion-lens/pkg/capture"
 	"github.com/cantalupo555/albion-lens/pkg/photon"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 const (
-	bulkEventChannelSize = 5                       // 5 batches × eventBatchSize = 250 events buffered
+	bulkEventChannelSize = 5 // 5 batches × eventBatchSize = 250 events buffered
 	statsChannelSize     = 10
 	eventBatchSize       = 50
 	eventFlushInterval   = 50 * time.Millisecond

--- a/internal/tui/components/statusbar.go
+++ b/internal/tui/components/statusbar.go
@@ -3,13 +3,14 @@ package components
 import (
 	"fmt"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/cantalupo555/albion-lens/pkg/photon"
+	"github.com/charmbracelet/lipgloss"
 )
 
 // StatusBar displays connection status, packet stats, and uptime
 type StatusBar struct {
 	online         bool
+	playerName     string
 	packetsTotal   uint64
 	packetsPerSec  float64
 	eventsDecoded  uint64
@@ -36,6 +37,13 @@ func (s StatusBar) SetWidth(width int) StatusBar {
 // SetOnline updates the online status
 func (s StatusBar) SetOnline(online bool) StatusBar {
 	s.online = online
+	return s
+}
+
+// SetPlayerName updates the local player name. When empty and online, the
+// status bar shows a warning prompting the user to change maps or relog.
+func (s StatusBar) SetPlayerName(name string) StatusBar {
+	s.playerName = name
 	return s
 }
 
@@ -74,6 +82,20 @@ func (s StatusBar) View() string {
 			Render("● Offline")
 	}
 
+	// Player identification indicator
+	if s.online {
+		if s.playerName != "" {
+			status += "  " + lipgloss.NewStyle().
+				Foreground(lipgloss.Color("42")).
+				Render("👤 "+s.playerName)
+		} else {
+			status += "  " + lipgloss.NewStyle().
+				Foreground(lipgloss.Color("214")).
+				Bold(true).
+				Render("⚠ Player not identified — change map or relog")
+		}
+	}
+
 	// Buffer Stats Logic
 	var bufStatus string
 	if s.bufferCapacity > 0 {
@@ -84,7 +106,7 @@ func (s StatusBar) View() string {
 		} else if pct >= 50 {
 			bufColor = "214" // Yellow
 		}
-		
+
 		bufStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(bufColor))
 		bufStatus = fmt.Sprintf("│  Queue: %s", bufStyle.Render(fmt.Sprintf("%d/%d (%.0f%%)", s.bufferUsage, s.bufferCapacity, pct)))
 	}
@@ -92,26 +114,33 @@ func (s StatusBar) View() string {
 	// Stats
 	statsStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("255"))
 
-	// Format events with drop warning if needed
-	eventsDisplay := fmt.Sprintf("Events: %d", s.eventsDecoded)
-	if s.eventsDropped > 0 {
-		// RED with warning icon when drops detected
-		dropStyle := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("196")). // Red
-			Bold(true)
-		eventsDisplay = fmt.Sprintf("Events: %d  %s",
-			s.eventsDecoded,
-			dropStyle.Render(fmt.Sprintf("⚠ Dropped: %d", s.eventsDropped)))
-	}
+	var stats string
+	if !s.online {
+		// When offline, show a simple waiting message instead of zeroes.
+		stats = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("241")).
+			Render("Waiting for Albion Online traffic...")
+	} else {
+		// Format events with drop warning if needed
+		eventsDisplay := fmt.Sprintf("Events: %d", s.eventsDecoded)
+		if s.eventsDropped > 0 {
+			dropStyle := lipgloss.NewStyle().
+				Foreground(lipgloss.Color("196")). // Red
+				Bold(true)
+			eventsDisplay = fmt.Sprintf("Events: %d  %s",
+				s.eventsDecoded,
+				dropStyle.Render(fmt.Sprintf("⚠ Dropped: %d", s.eventsDropped)))
+		}
 
-	stats := statsStyle.Render(fmt.Sprintf(
-		"Packets: %d (%.1f/s)  │  %s  │  %s  %s",
-		s.packetsTotal,
-		s.packetsPerSec,
-		eventsDisplay,
-		s.uptime,
-		bufStatus, // Append buffer status at the end
-	))
+		stats = statsStyle.Render(fmt.Sprintf(
+			"Packets: %d (%.1f/s)  │  %s  │  %s  %s",
+			s.packetsTotal,
+			s.packetsPerSec,
+			eventsDisplay,
+			s.uptime,
+			bufStatus,
+		))
+	}
 
 	// Combine
 	content := fmt.Sprintf("%s  │  %s", status, stats)

--- a/internal/tui/components/statusbar_test.go
+++ b/internal/tui/components/statusbar_test.go
@@ -75,12 +75,12 @@ func TestStatusBarUpdateStatsNil(t *testing.T) {
 
 func TestStatusBarUpdateStats(t *testing.T) {
 	stats := &photon.Stats{
-		PacketsReceived:  uint64(100),
-		EventsDecoded:    uint64(50),
-		EventsDropped:    uint64(5),
+		PacketsReceived:   uint64(100),
+		EventsDecoded:     uint64(50),
+		EventsDropped:     uint64(5),
 		BufferPeakDisplay: 30,
-		BufferCapacity:   200,
-		StartTime:        time.Now(),
+		BufferCapacity:    200,
+		StartTime:         time.Now(),
 	}
 
 	s := NewStatusBar()
@@ -139,6 +139,7 @@ func TestStatusBarViewDroppedEvents(t *testing.T) {
 
 	s := NewStatusBar()
 	s = s.SetWidth(100)
+	s = s.SetOnline(true)
 	s = s.UpdateStats(stats)
 
 	output := s.View()
@@ -157,6 +158,7 @@ func TestStatusBarViewNoDroppedEvents(t *testing.T) {
 
 	s := NewStatusBar()
 	s = s.SetWidth(100)
+	s = s.SetOnline(true)
 	s = s.UpdateStats(stats)
 
 	output := s.View()
@@ -175,6 +177,7 @@ func TestStatusBarViewBufferUsage(t *testing.T) {
 
 	s := NewStatusBar()
 	s = s.SetWidth(100)
+	s = s.SetOnline(true)
 	s = s.UpdateStats(stats)
 
 	output := s.View()

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -3,8 +3,8 @@ package tui
 import (
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/cantalupo555/albion-lens/pkg/photon"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // EventMsg represents a game event to display in the log
@@ -68,5 +68,18 @@ func WaitForStats(ch <-chan *photon.Stats) tea.Cmd {
 	return func() tea.Msg {
 		stats := <-ch
 		return StatsUpdateMsg{Stats: stats}
+	}
+}
+
+// WaitForOnline returns a command that waits for an online status change from
+// the channel. This gives instant feedback when the capture layer detects or
+// loses Albion traffic, without waiting for the 1-second tick.
+func WaitForOnline(ch <-chan bool) tea.Cmd {
+	return func() tea.Msg {
+		online, ok := <-ch
+		if !ok {
+			return nil // channel closed — stop listening
+		}
+		return OnlineMsg{Online: online}
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3,12 +3,12 @@ package tui
 import (
 	"fmt"
 
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/cantalupo555/albion-lens/internal/tui/components"
 	"github.com/cantalupo555/albion-lens/pkg/backend"
 	"github.com/cantalupo555/albion-lens/pkg/handlers"
 	"github.com/cantalupo555/albion-lens/pkg/photon"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 // Model is the main TUI model
@@ -23,6 +23,7 @@ type Model struct {
 	// Channels for receiving data from parser
 	bulkEventChan chan BulkEventMsg
 	statsChan     chan *photon.Stats
+	onlineChan    <-chan bool
 
 	// UI state
 	width    int
@@ -49,6 +50,7 @@ func New(svc *backend.Service, bulkEventChan chan BulkEventMsg, statsChan chan *
 	// Sync debug state from service
 	if svc != nil {
 		m.debug = svc.IsDebug()
+		m.onlineChan = svc.OnlineStatus
 	}
 	return m
 }
@@ -67,6 +69,11 @@ func (m Model) Init() tea.Cmd {
 	// Listen for stats if channel provided
 	if m.statsChan != nil {
 		cmds = append(cmds, WaitForStats(m.statsChan))
+	}
+
+	// Listen for online status changes if channel provided
+	if m.onlineChan != nil {
+		cmds = append(cmds, WaitForOnline(m.onlineChan))
 	}
 
 	return tea.Batch(cmds...)
@@ -187,7 +194,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Stats update from parser
 	case StatsUpdateMsg:
 		m.statusBar = m.statusBar.UpdateStats(msg.Stats)
-		m.statusBar = m.statusBar.SetOnline(true)
 
 		// Continue listening for stats
 		if m.statsChan != nil {
@@ -198,10 +204,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Online status change
 	case OnlineMsg:
 		m.statusBar = m.statusBar.SetOnline(msg.Online)
-		return m, nil
+		// Continue listening for status changes
+		if m.onlineChan != nil {
+			cmds = append(cmds, WaitForOnline(m.onlineChan))
+		}
+		return m, tea.Batch(cmds...)
 
 	// Periodic tick
 	case TickMsg:
+		// Refresh player identification and online status from the backend
+		if m.svc != nil {
+			m.statusBar = m.statusBar.SetPlayerName(m.svc.LocalPlayerName())
+			m.statusBar = m.statusBar.SetOnline(m.svc.IsOnline())
+		}
 		// Refresh display periodically
 		cmds = append(cmds, TickCmd())
 		return m, tea.Batch(cmds...)

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/cantalupo555/albion-lens/pkg/handlers"
 	"github.com/cantalupo555/albion-lens/pkg/photon"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // updateModel is a test helper that calls Update and asserts the result is a Model.
@@ -292,8 +292,10 @@ func TestUpdateStatsUpdate(t *testing.T) {
 
 	m = updateModel(m, StatsUpdateMsg{Stats: stats})
 
-	if !m.statusBar.Online() {
-		t.Error("expected online=true after stats update")
+	// StatsUpdateMsg should NOT change online status — that is owned by the
+	// tick handler (polling svc.IsOnline()) and OnlineMsg.
+	if m.statusBar.Online() {
+		t.Error("expected online=false after stats update (online status is set by tick/OnlineMsg)")
 	}
 }
 


### PR DESCRIPTION
## Summary
Surfaces the local player identity and online connection status directly in the TUI status bar, replacing the removed `-player` CLI flag with automatic detection via OpJoin events from the capture layer.

## Motivation
The previous approach required users to manually pass a `-player` flag, which was brittle and inconvenient. By leveraging the OpJoin event (fixed in the backend in PR #90), the TUI now auto-detects the player name. Additionally, the status bar previously showed zeroed-out stats while offline — this update introduces a clear "waiting for traffic" message and proper online/offline state transitions so users always understand what the TUI is doing.

## Changes Made
- Removed `-player` CLI flag from `cmd/tui/main.go`; player identity is now resolved automatically by the backend service
- Added `playerName` field and `SetPlayerName()` getter to `StatusBar`; renders `👤 PlayerName` when identified, or `⚠ Player not identified — change map or relog` when online but no OpJoin received yet
- Status bar now shows "Waiting for Albion Online traffic..." instead of zeroed packet/event stats when offline
- Introduced `WaitForOnline` command in `messages.go` that listens on `svc.OnlineStatus` for instant online/offline feedback
- `model.go` `Init()` batches `WaitForOnline` alongside existing commands; `Update()` handles `OnlineMsg` by re-subscribing; `TickMsg` handler polls `svc.LocalPlayerName()` and `svc.IsOnline()` for periodic refresh
- Removed unconditional `SetOnline(true)` from `StatsUpdateMsg` handler — online state is now owned by `OnlineMsg` and tick polling, preventing premature "online" indication
- Updated tests in `statusbar_test.go` to explicitly call `SetOnline(true)` where stats view assertions require it; updated `model_test.go` to assert that `StatsUpdateMsg` no longer flips online status

## Testing
- [ ] Tested locally
- [ ] Unit tests added
- [ ] Documentation updated

## Breaking Changes
None for users of master. The `-player` flag never existed on master (added and removed within this development cycle). `StatsUpdateMsg` no longer sets `online=true` (bug fix — stats arrival does not mean online). `OnlineMsg` handler re-subscribes for continuous monitoring.

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

This PR replaces the removed `-player` CLI flag with automatic player name detection via OpJoin events from the capture layer, and introduces clear online/offline state transitions in the TUI status bar. The status bar now shows "Waiting for Albion Online traffic..." when offline, renders the identified player name once detected, and properly owns online state through `OnlineMsg` and periodic polling instead of incorrectly setting online on stats arrival. These changes make the TUI more intuitive by always informing users what it is doing, without requiring manual configuration.

---
<sup>Written for commit d985fbae765c3b0e305ccc206de3224eda35b408. Summary will update on new commits.</sup>
<!-- end-auto-generated -->