### PR TITLE
fix(photon): use atomic getter for BufferPeakDisplay and remove dead LastPacketTime

### DIFF
--- a/internal/tui/components/statusbar.go
+++ b/internal/tui/components/statusbar.go
@@ -59,7 +59,7 @@ func (s StatusBar) UpdateStats(stats *photon.Stats) StatusBar {
 		s.packetsPerSec = stats.PacketsPerSecond()
 		s.eventsDecoded = stats.GetEventsDecoded()
 		s.eventsDropped = stats.GetEventsDropped()
-		s.bufferUsage = int(stats.BufferPeakDisplay)
+		s.bufferUsage = int(stats.GetBufferPeakDisplay())
 		s.bufferCapacity = stats.BufferCapacity
 		s.uptime = stats.FormatUptime()
 	}

--- a/pkg/photon/parser.go
+++ b/pkg/photon/parser.go
@@ -131,7 +131,6 @@ func (p *Parser) PendingFragmentsCount() int {
 func (p *Parser) ParsePacket(payload []byte) error {
 	p.Stats.IncrPacketsReceived()
 	p.Stats.AddBytesReceived(uint64(len(payload)))
-	p.Stats.LastPacketTime = time.Now()
 
 	if len(payload) < PhotonHeaderLength {
 		p.Stats.IncrPacketsMalformed()

--- a/pkg/photon/stats.go
+++ b/pkg/photon/stats.go
@@ -38,8 +38,7 @@ type Stats struct {
 	bufferPeakInternal int64 // Internal accumulator for peak usage
 
 	// Internal state
-	StartTime      time.Time
-	LastPacketTime time.Time
+	StartTime time.Time
 }
 
 // ... (methods) ...
@@ -69,6 +68,11 @@ func (s *Stats) UpdateBufferPeak(current int) {
 func (s *Stats) SnapshotBufferPeak() {
 	peak := atomic.SwapInt64(&s.bufferPeakInternal, 0)
 	atomic.StoreInt64(&s.BufferPeakDisplay, peak)
+}
+
+// GetBufferPeakDisplay returns the peak buffer usage from the last snapshot.
+func (s *Stats) GetBufferPeakDisplay() int64 {
+	return atomic.LoadInt64(&s.BufferPeakDisplay)
 }
 
 // NewStats creates a new Stats instance with StartTime set to now.

--- a/pkg/photon/stats_test.go
+++ b/pkg/photon/stats_test.go
@@ -186,8 +186,8 @@ func TestStatsReset(t *testing.T) {
 	if stats.GetPacketsReceived() != 2 {
 		t.Errorf("Expected PacketsReceived=2, got %d", stats.GetPacketsReceived())
 	}
-	if stats.BufferPeakDisplay != 200 {
-		t.Errorf("Expected BufferPeakDisplay=200, got %d", stats.BufferPeakDisplay)
+	if stats.GetBufferPeakDisplay() != 200 {
+		t.Errorf("Expected BufferPeakDisplay=200, got %d", stats.GetBufferPeakDisplay())
 	}
 	if stats.bufferPeakInternal != 50 {
 		t.Errorf("Expected bufferPeakInternal=50, got %d", stats.bufferPeakInternal)
@@ -208,8 +208,8 @@ func TestStatsReset(t *testing.T) {
 	}
 
 	// Verify buffer metrics are reset
-	if stats.BufferPeakDisplay != 0 {
-		t.Errorf("After reset, expected BufferPeakDisplay=0, got %d", stats.BufferPeakDisplay)
+	if stats.GetBufferPeakDisplay() != 0 {
+		t.Errorf("After reset, expected BufferPeakDisplay=0, got %d", stats.GetBufferPeakDisplay())
 	}
 	if stats.bufferPeakInternal != 0 {
 		t.Errorf("After reset, expected bufferPeakInternal=0, got %d", stats.bufferPeakInternal)
@@ -338,8 +338,8 @@ func TestSnapshotBufferPeak(t *testing.T) {
 	stats.SnapshotBufferPeak()
 
 	// BufferPeakDisplay should have the peak
-	if stats.BufferPeakDisplay != 150 {
-		t.Errorf("Expected BufferPeakDisplay=150, got %d", stats.BufferPeakDisplay)
+	if stats.GetBufferPeakDisplay() != 150 {
+		t.Errorf("Expected BufferPeakDisplay=150, got %d", stats.GetBufferPeakDisplay())
 	}
 
 	// bufferPeakInternal should be reset to 0
@@ -357,8 +357,8 @@ func TestSnapshotBufferPeak(t *testing.T) {
 	stats.SnapshotBufferPeak()
 
 	// BufferPeakDisplay should now show 80 (new interval peak)
-	if stats.BufferPeakDisplay != 80 {
-		t.Errorf("Expected BufferPeakDisplay=80 (new interval), got %d", stats.BufferPeakDisplay)
+	if stats.GetBufferPeakDisplay() != 80 {
+		t.Errorf("Expected BufferPeakDisplay=80 (new interval), got %d", stats.GetBufferPeakDisplay())
 	}
 
 	// bufferPeakInternal should be reset again


### PR DESCRIPTION
## Summary
Fixes a thread-safety bug where `BufferPeakDisplay` was being read non-atomically from the status bar while being written atomically from another goroutine, and removes the dead `LastPacketTime` field that was being set but never consumed.

## Bug Description
- **What was happening:** The TUI status bar read `stats.BufferPeakDisplay` directly (plain field access) while the parser updated it via `atomic.StoreInt64`. This is a data race detectable by `go run -race`. Additionally, `Stats.LastPacketTime` was being written on every packet parse but never read by any consumer.
- **Expected behavior:** `BufferPeakDisplay` should always be accessed through its atomic getter to guarantee safe cross-goroutine reads. Unused state like `LastPacketTime` should be removed to keep the struct minimal.
- **Root cause:** The status bar was reading the field directly, bypassing the atomic load. `LastPacketTime` accumulated as dead code because no consumer ever read it.

## Changes Made
- Added `GetBufferPeakDisplay()` in `pkg/photon/stats.go` using `atomic.LoadInt64`, matching the existing getter convention
- Replaced direct `BufferPeakDisplay` field access with `GetBufferPeakDisplay()` in `internal/tui/components/statusbar.go`
- Removed `LastPacketTime` field from the `Stats` struct
- Removed the `LastPacketTime` write in `pkg/photon/parser.go` (`ParsePacket`)
- Updated 4 test assertions in `pkg/photon/stats_test.go` to use the atomic getter

## Testing
- [x] Tested locally (`go build`, `go vet`, `go test`, `go test -race` all pass)
- [x] Unit tests updated (4 assertions now use atomic getter)
- [x] No regressions

## Related Issues
Fixes #70
Fixes #71

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

This PR fixes a thread-safety data race in the TUI status bar, which was reading `BufferPeakDisplay` non-atomically while the parser updated it via `atomic.StoreInt64`. An atomic getter `GetBufferPeakDisplay()` was added and wired into the status bar, and the unused `LastPacketTime` field was removed from `Stats` along with its write site in the parser and 4 test assertions updated accordingly.

---
<sup>Written for commit 326f6f2e0272e0f97de70471868ac1baeb8e1a02. Summary will update on new commits.</sup>
<!-- end-auto-generated -->