### PR TITLE
feat(dungeon): track random dungeon runs with lazy classification

### DIFF
--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -25,6 +25,7 @@ func main() {
 	listDevices := flag.Bool("list", false, "List available network devices")
 	deviceName := flag.String("device", "", "Specific device to capture on (captures all if not specified)")
 	debug := flag.Bool("debug", false, "Enable debug output")
+	discover := flag.Bool("discover", false, "Enable discovery mode to log all events (dumps JSON to output/ on exit)")
 	itemsPath := flag.String("items", "", "Path to ao-bin-dumps directory for item name resolution")
 	flag.Parse()
 
@@ -46,6 +47,9 @@ func main() {
 	}
 	if *itemsPath != "" {
 		opts = append(opts, backend.WithItemDatabasePath(*itemsPath))
+	}
+	if *discover {
+		opts = append(opts, backend.WithDiscovery(true))
 	}
 
 	svc := backend.New(opts...)
@@ -92,6 +96,19 @@ func main() {
 	if _, err := p.Run(); err != nil {
 		fmt.Printf("Error running TUI: %v\n", err)
 		os.Exit(1)
+	}
+
+	// In discovery mode, persist the captured event map so unmapped events
+	// (e.g. the dungeon-closure notification) can be identified offline.
+	if *discover {
+		if handler := svc.Handler(); handler != nil {
+			dumpPath := fmt.Sprintf("output/discovered-events-%s.json", time.Now().Format("20060102-150405"))
+			if err := handler.SaveDiscoveredEvents(dumpPath); err != nil {
+				fmt.Printf("Error saving discovered events: %v\n", err)
+			} else {
+				fmt.Printf("Discovered events saved to %s\n", dumpPath)
+			}
+		}
 	}
 }
 

--- a/internal/tui/components/dungeonspanel.go
+++ b/internal/tui/components/dungeonspanel.go
@@ -1,0 +1,252 @@
+package components
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/viewport"
+	"charm.land/lipgloss/v2"
+	"github.com/cantalupo555/albion-lens/pkg/handlers"
+)
+
+// DungeonsPanel displays the active dungeon run, a 90s close countdown, and a
+// scrollable table of completed runs. It follows the immutable builder pattern.
+type DungeonsPanel struct {
+	viewport    viewport.Model
+	runs        []*handlers.DungeonRun
+	active      *handlers.DungeonRun
+	runCount    int // last seen run count, for auto-scroll detection
+	nowFunc     func() time.Time
+	width       int
+	height      int
+	ready       bool
+	fullNumbers bool
+}
+
+// NewDungeonsPanel creates a DungeonsPanel with sensible defaults.
+func NewDungeonsPanel() DungeonsPanel {
+	return DungeonsPanel{
+		nowFunc:     time.Now,
+		fullNumbers: false,
+	}
+}
+
+// SetSize updates the dimensions of the dungeons panel.
+func (d DungeonsPanel) SetSize(width, height int) DungeonsPanel {
+	d.width = width
+	d.height = height
+
+	headerHeight := 2 // title + border
+	footerHeight := 1 // border
+	infoHeight := 5   // active run info block
+
+	viewportHeight := height - headerHeight - footerHeight - infoHeight
+	if viewportHeight < 1 {
+		viewportHeight = 1
+	}
+
+	viewportWidth := width - 4 // borders + padding
+	if viewportWidth < 10 {
+		viewportWidth = 10
+	}
+
+	if !d.ready {
+		d.viewport = viewport.New(viewport.WithWidth(viewportWidth), viewport.WithHeight(viewportHeight))
+		d.ready = true
+	} else {
+		d.viewport.SetWidth(viewportWidth)
+		d.viewport.SetHeight(viewportHeight)
+	}
+
+	return d
+}
+
+// SetFullNumbers sets whether to display full or abbreviated numbers.
+func (d DungeonsPanel) SetFullNumbers(full bool) DungeonsPanel {
+	d.fullNumbers = full
+	return d
+}
+
+// SetNow sets the reference time used for the countdown display.
+func (d DungeonsPanel) SetNow(t time.Time) DungeonsPanel {
+	d.nowFunc = func() time.Time { return t }
+	return d
+}
+
+// SetRuns updates the run data displayed by the panel. The viewport
+// auto-scrolls to the bottom only when new runs have been appended since the
+// last call, so manual scroll position is preserved during periodic ticks.
+func (d DungeonsPanel) SetRuns(runs []*handlers.DungeonRun, active *handlers.DungeonRun) DungeonsPanel {
+	newRuns := len(runs)
+	d.runs = runs
+	d.active = active
+
+	if !d.ready {
+		d.runCount = newRuns
+		return d
+	}
+	d.viewport.SetContent(d.renderRunTable())
+	if newRuns != d.runCount {
+		d.viewport.GotoBottom()
+	}
+	d.runCount = newRuns
+	return d
+}
+
+// ScrollUp scrolls the runs viewport up.
+func (d DungeonsPanel) ScrollUp() DungeonsPanel {
+	d.viewport.ScrollUp(1)
+	return d
+}
+
+// ScrollDown scrolls the runs viewport down.
+func (d DungeonsPanel) ScrollDown() DungeonsPanel {
+	d.viewport.ScrollDown(1)
+	return d
+}
+
+// Clear empties the run history.
+func (d DungeonsPanel) Clear() DungeonsPanel {
+	d.runs = nil
+	d.active = nil
+	if d.ready {
+		d.viewport.SetContent(d.renderRunTable())
+	}
+	return d
+}
+
+// formatRunFields extracts and formats the common dungeon-run display fields
+// (mode, faction, tier, duration). Shared by the run table and the active-run
+// info block to keep formatting in a single place.
+func (d DungeonsPanel) formatRunFields(r *handlers.DungeonRun, now time.Time) (mode, faction, tier, dur string) {
+	mode = r.Mode.String()
+	faction = r.Faction
+	if faction == "" {
+		faction = "—"
+	}
+	tier = "—"
+	if r.Tier >= 0 {
+		tier = fmt.Sprintf("T%d", r.Tier+1)
+	}
+	dur = formatElapsed(r.Duration(now))
+	return
+}
+
+// renderRunTable builds the scrollable table of completed runs (newest first).
+func (d DungeonsPanel) renderRunTable() string {
+	if len(d.runs) == 0 {
+		emptyStyle := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("241")).
+			Italic(true)
+		return emptyStyle.Render("No dungeon runs yet...")
+	}
+
+	now := d.nowFunc()
+	headerStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("62")).
+		Bold(true)
+
+	doneStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("255"))
+	closedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+
+	header := headerStyle.Render(fmt.Sprintf(
+		"%-7s %-8s %3s  %8s  %8s  %4s  %5s",
+		"Mode", "Faction", "Tier", "Duration", "Fame", "Kills", "Loot",
+	))
+
+	lines := []string{header}
+
+	for i := len(d.runs) - 1; i >= 0; i-- {
+		r := d.runs[i]
+		if r.Status == handlers.RunStatusActive {
+			continue // active run shown in the info block, not the table
+		}
+
+		mode, faction, tier, dur := d.formatRunFields(r, now)
+		fame := FormatNumber(r.Fame, d.fullNumbers)
+		kills := fmt.Sprintf("%d", r.Kills)
+		loot := fmt.Sprintf("%d", r.Loot)
+
+		row := fmt.Sprintf("%-7s %-8s %3s  %8s  %8s  %4s  %5s",
+			mode, faction, tier, dur, fame, kills, loot)
+
+		if r.Status == handlers.RunStatusClosed {
+			lines = append(lines, closedStyle.Render(row))
+		} else {
+			lines = append(lines, doneStyle.Render(row))
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// View renders the dungeons panel.
+func (d DungeonsPanel) View() string {
+	boxStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("62")).
+		Width(d.width - 2).
+		Height(d.height - 2)
+
+	titleStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("62")).
+		Padding(0, 1)
+
+	labelStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("241"))
+
+	activeStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("119"))
+
+	countdownStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("214"))
+
+	now := d.nowFunc()
+
+	// Active run info block
+	var activeLines []string
+	if d.active != nil {
+		r := d.active
+		mode, faction, tier, dur := d.formatRunFields(r, now)
+
+		activeLines = append(activeLines, fmt.Sprintf("%s  %s (%s, %s, %s)",
+			labelStyle.Render("Active:"),
+			activeStyle.Render(mode),
+			faction, tier, dur,
+		))
+
+		// Countdown
+		remaining := r.CloseAt.Sub(now)
+		if remaining < 0 {
+			remaining = 0
+		}
+		activeLines = append(activeLines, fmt.Sprintf("%s  %s",
+			labelStyle.Render("Close in:"),
+			countdownStyle.Render(formatElapsed(remaining)),
+		))
+	} else {
+		emptyActive := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("241")).
+			Italic(true)
+		activeLines = append(activeLines, emptyActive.Render("No active dungeon run."))
+		activeLines = append(activeLines, "")
+	}
+
+	// Run history title
+	historyTitle := labelStyle.Render("Run History:")
+
+	content := lipgloss.JoinVertical(lipgloss.Left,
+		titleStyle.Render("Dungeons"),
+		activeLines[0],
+		activeLines[1],
+		"",
+		historyTitle,
+		d.viewport.View(),
+	)
+
+	return boxStyle.Render(content)
+}

--- a/internal/tui/components/dungeonspanel.go
+++ b/internal/tui/components/dungeonspanel.go
@@ -13,15 +13,15 @@ import (
 // DungeonsPanel displays the active dungeon run, a 90s close countdown, and a
 // scrollable table of completed runs. It follows the immutable builder pattern.
 type DungeonsPanel struct {
-	viewport    viewport.Model
-	runs        []*handlers.DungeonRun
-	active      *handlers.DungeonRun
-	runCount    int // last seen run count, for auto-scroll detection
-	nowFunc     func() time.Time
-	width       int
-	height      int
-	ready       bool
-	fullNumbers bool
+	viewport         viewport.Model
+	runs             []*handlers.DungeonRun
+	active           *handlers.DungeonRun
+	lastRunEnteredAt time.Time // newest run's EnteredAt, for auto-scroll detection
+	nowFunc          func() time.Time
+	width            int
+	height           int
+	ready            bool
+	fullNumbers      bool
 }
 
 // NewDungeonsPanel creates a DungeonsPanel with sensible defaults.
@@ -77,20 +77,27 @@ func (d DungeonsPanel) SetNow(t time.Time) DungeonsPanel {
 // SetRuns updates the run data displayed by the panel. The viewport
 // auto-scrolls to the bottom only when new runs have been appended since the
 // last call, so manual scroll position is preserved during periodic ticks.
+// Auto-scroll detection uses the newest run's EnteredAt timestamp, which keeps
+// working even after the 500-run cap is reached (oldest trimmed, slice length
+// stays constant but the newest run changes).
 func (d DungeonsPanel) SetRuns(runs []*handlers.DungeonRun, active *handlers.DungeonRun) DungeonsPanel {
-	newRuns := len(runs)
 	d.runs = runs
 	d.active = active
 
+	var newestEnteredAt time.Time
+	if len(runs) > 0 {
+		newestEnteredAt = runs[len(runs)-1].EnteredAt
+	}
+
 	if !d.ready {
-		d.runCount = newRuns
+		d.lastRunEnteredAt = newestEnteredAt
 		return d
 	}
 	d.viewport.SetContent(d.renderRunTable())
-	if newRuns != d.runCount {
+	if !newestEnteredAt.Equal(d.lastRunEnteredAt) {
 		d.viewport.GotoBottom()
 	}
-	d.runCount = newRuns
+	d.lastRunEnteredAt = newestEnteredAt
 	return d
 }
 

--- a/internal/tui/components/dungeonspanel_test.go
+++ b/internal/tui/components/dungeonspanel_test.go
@@ -1,0 +1,270 @@
+package components
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cantalupo555/albion-lens/pkg/handlers"
+)
+
+func TestNewDungeonsPanelDefaults(t *testing.T) {
+	d := NewDungeonsPanel()
+	if d.ready {
+		t.Error("expected ready=false initially")
+	}
+	if d.fullNumbers {
+		t.Error("expected fullNumbers=false by default")
+	}
+	if d.nowFunc == nil {
+		t.Error("expected nowFunc to be set")
+	}
+}
+
+func TestDungeonsPanelViewNoActiveRun(t *testing.T) {
+	d := NewDungeonsPanel().
+		SetSize(80, 24).
+		SetNow(time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC))
+
+	view := d.View()
+
+	if !strings.Contains(view, "No active dungeon run") {
+		t.Error("expected 'No active dungeon run' in view when no active run")
+	}
+}
+
+func TestDungeonsPanelViewWithActiveRun(t *testing.T) {
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	run := &handlers.DungeonRun{
+		EnteredAt: t0,
+		CloseAt:   t0.Add(handlers.DungeonCloseTimeout),
+		Mode:      handlers.DungeonModeSolo,
+		Faction:   "Keeper",
+		Tier:      3,
+		Status:    handlers.RunStatusActive,
+	}
+
+	d := NewDungeonsPanel().
+		SetSize(80, 24).
+		SetNow(t0.Add(30*time.Second)).
+		SetRuns(nil, run)
+
+	view := d.View()
+
+	if !strings.Contains(view, "Active:") {
+		t.Error("expected 'Active:' label in view")
+	}
+	if !strings.Contains(view, "Solo") {
+		t.Error("expected 'Solo' mode in view")
+	}
+	if !strings.Contains(view, "Close in:") {
+		t.Error("expected 'Close in:' countdown in view")
+	}
+}
+
+func TestDungeonsPanelCountdownAtZero(t *testing.T) {
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	run := &handlers.DungeonRun{
+		EnteredAt: t0,
+		CloseAt:   t0.Add(handlers.DungeonCloseTimeout),
+		Status:    handlers.RunStatusActive,
+	}
+
+	d := NewDungeonsPanel().
+		SetSize(80, 24).
+		SetNow(t0.Add(handlers.DungeonCloseTimeout+5*time.Second)).
+		SetRuns(nil, run)
+
+	view := d.View()
+
+	if !strings.Contains(view, "Close in:") {
+		t.Error("expected 'Close in:' label")
+	}
+	if !strings.Contains(view, "0s") {
+		t.Error("expected countdown clamped to 0s")
+	}
+}
+
+func TestDungeonsPanelRunTableDoneRun(t *testing.T) {
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	run := &handlers.DungeonRun{
+		EnteredAt: t0,
+		ExitedAt:  t0.Add(5 * time.Minute),
+		Mode:      handlers.DungeonModeStandard,
+		Faction:   "Heretic",
+		Tier:      4,
+		Status:    handlers.RunStatusDone,
+		Fame:      15000,
+		Kills:     2,
+		Loot:      3,
+	}
+
+	d := NewDungeonsPanel().
+		SetSize(80, 24).
+		SetNow(t0.Add(10*time.Minute)).
+		SetRuns([]*handlers.DungeonRun{run}, nil)
+
+	view := d.View()
+
+	if !strings.Contains(view, "Group") {
+		t.Error("expected 'Group' mode in run table")
+	}
+	if !strings.Contains(view, "Heretic") {
+		t.Error("expected 'Heretic' faction in run table")
+	}
+	if !strings.Contains(view, "T5") {
+		t.Error("expected 'T5' tier (tier 4 → T5) in run table")
+	}
+}
+
+func TestDungeonsPanelRunTableExcludesActiveRun(t *testing.T) {
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	activeRun := &handlers.DungeonRun{
+		EnteredAt: t0,
+		CloseAt:   t0.Add(handlers.DungeonCloseTimeout),
+		Mode:      handlers.DungeonModeSolo,
+		Status:    handlers.RunStatusActive,
+	}
+	doneRun := &handlers.DungeonRun{
+		EnteredAt: t0.Add(-10 * time.Minute),
+		ExitedAt:  t0.Add(-5 * time.Minute),
+		Mode:      handlers.DungeonModeStandard,
+		Status:    handlers.RunStatusDone,
+	}
+
+	d := NewDungeonsPanel().
+		SetSize(80, 24).
+		SetNow(t0).
+		SetRuns([]*handlers.DungeonRun{doneRun, activeRun}, activeRun)
+
+	view := d.View()
+
+	if strings.Count(view, "Solo") > 1 {
+		t.Error("active run (Solo) should not appear in the run table, only in the info block")
+	}
+}
+
+func TestDungeonsPanelEmptyRunTable(t *testing.T) {
+	d := NewDungeonsPanel().
+		SetSize(80, 24).
+		SetNow(time.Now()).
+		SetRuns(nil, nil)
+
+	view := d.View()
+
+	if !strings.Contains(view, "No dungeon runs yet") {
+		t.Error("expected empty-state message in run table")
+	}
+}
+
+func TestDungeonsPanelClear(t *testing.T) {
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	run := &handlers.DungeonRun{
+		EnteredAt: t0,
+		Status:    handlers.RunStatusDone,
+	}
+
+	d := NewDungeonsPanel().
+		SetSize(80, 24).
+		SetNow(t0).
+		SetRuns([]*handlers.DungeonRun{run}, nil)
+
+	d = d.Clear()
+	view := d.View()
+
+	if !strings.Contains(view, "No dungeon runs yet") {
+		t.Error("expected empty run table after Clear")
+	}
+	if !strings.Contains(view, "No active dungeon run") {
+		t.Error("expected no active run after Clear")
+	}
+}
+
+func TestDungeonsPanelFormatRunFields(t *testing.T) {
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		run          *handlers.DungeonRun
+		wantMode     string
+		wantFaction  string
+		wantTier     string
+		wantDuration string
+	}{
+		{
+			name: "solo keeper T4 active",
+			run: &handlers.DungeonRun{
+				EnteredAt: t0,
+				CloseAt:   t0.Add(handlers.DungeonCloseTimeout),
+				Mode:      handlers.DungeonModeSolo,
+				Faction:   "Keeper",
+				Tier:      3,
+				Status:    handlers.RunStatusActive,
+			},
+			wantMode:     "Solo",
+			wantFaction:  "Keeper",
+			wantTier:     "T4",
+			wantDuration: "5m 0s",
+		},
+		{
+			name: "unknown mode no faction",
+			run: &handlers.DungeonRun{
+				EnteredAt: t0,
+				Mode:      handlers.DungeonModeUnknown,
+				Tier:      -1,
+				Status:    handlers.RunStatusActive,
+			},
+			wantMode:     "Unknown",
+			wantFaction:  "—",
+			wantTier:     "—",
+			wantDuration: "5m 0s",
+		},
+		{
+			name: "done run with exit time",
+			run: &handlers.DungeonRun{
+				EnteredAt: t0,
+				ExitedAt:  t0.Add(3 * time.Minute),
+				Mode:      handlers.DungeonModeAvalon,
+				Faction:   "Avalon",
+				Tier:      7,
+				Status:    handlers.RunStatusDone,
+			},
+			wantMode:     "Avalon",
+			wantFaction:  "Avalon",
+			wantTier:     "T8",
+			wantDuration: "3m 0s",
+		},
+	}
+
+	d := NewDungeonsPanel().SetNow(t0.Add(5 * time.Minute))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mode, faction, tier, dur := d.formatRunFields(tt.run, t0.Add(5*time.Minute))
+			if mode != tt.wantMode {
+				t.Errorf("mode = %q, want %q", mode, tt.wantMode)
+			}
+			if faction != tt.wantFaction {
+				t.Errorf("faction = %q, want %q", faction, tt.wantFaction)
+			}
+			if tier != tt.wantTier {
+				t.Errorf("tier = %q, want %q", tier, tt.wantTier)
+			}
+			if dur != tt.wantDuration {
+				t.Errorf("duration = %q, want %q", dur, tt.wantDuration)
+			}
+		})
+	}
+}
+
+func TestDungeonsPanelSetSizeSmallDimensions(t *testing.T) {
+	d := NewDungeonsPanel().SetSize(10, 5)
+	if !d.ready {
+		t.Error("expected ready=true after SetSize")
+	}
+
+	view := d.View()
+	if view == "" {
+		t.Error("expected non-empty view even with small dimensions")
+	}
+}

--- a/internal/tui/components/eventlog_test.go
+++ b/internal/tui/components/eventlog_test.go
@@ -373,8 +373,8 @@ func TestSetFullNumbersReRender(t *testing.T) {
 	// Toggle to abbreviated
 	e = e.SetFullNumbers(false)
 
-	viewAbbrev := e.View()
-	if !strings.Contains(viewAbbrev, "1.5k") {
+	viewAbb := e.View()
+	if !strings.Contains(viewAbb, "1.5k") {
 		t.Error("expected abbreviated '1.5k' with fullNumbers=false")
 	}
 }

--- a/internal/tui/components/tabbar.go
+++ b/internal/tui/components/tabbar.go
@@ -30,10 +30,10 @@ type TabBar struct {
 	active int
 }
 
-// NewTabBar creates a TabBar with the default tabs (Dashboard, Zone).
+// NewTabBar creates a TabBar with the default tabs (Dashboard, Zone, Dungeons).
 func NewTabBar() TabBar {
 	return TabBar{
-		tabs: []string{"Dashboard", "Zone"},
+		tabs: []string{"Dashboard", "Zone", "Dungeons"},
 	}
 }
 

--- a/internal/tui/components/tabbar_test.go
+++ b/internal/tui/components/tabbar_test.go
@@ -11,8 +11,8 @@ func TestNewTabBarDefaults(t *testing.T) {
 	if tb.active != 0 {
 		t.Errorf("expected active=0 by default, got %d", tb.active)
 	}
-	if len(tb.tabs) != 2 {
-		t.Errorf("expected 2 tabs, got %d", len(tb.tabs))
+	if len(tb.tabs) != 3 {
+		t.Errorf("expected 3 tabs, got %d", len(tb.tabs))
 	}
 }
 
@@ -31,6 +31,11 @@ func TestTabBarNext(t *testing.T) {
 		t.Errorf("expected Active()=1 after Next, got %d", tb.Active())
 	}
 
+	tb = tb.Next()
+	if tb.Active() != 2 {
+		t.Errorf("expected Active()=2 after Next, got %d", tb.Active())
+	}
+
 	// Wrap around.
 	tb = tb.Next()
 	if tb.Active() != 0 {
@@ -43,8 +48,13 @@ func TestTabBarPrev(t *testing.T) {
 
 	// Wrap backward to the last tab.
 	tb = tb.Prev()
+	if tb.Active() != 2 {
+		t.Errorf("expected Active()=2 after backward wrap Prev, got %d", tb.Active())
+	}
+
+	tb = tb.Prev()
 	if tb.Active() != 1 {
-		t.Errorf("expected Active()=1 after backward wrap Prev, got %d", tb.Active())
+		t.Errorf("expected Active()=1 after Prev, got %d", tb.Active())
 	}
 
 	tb = tb.Prev()
@@ -63,8 +73,8 @@ func TestTabBarSetActive(t *testing.T) {
 
 	// Clamping above.
 	tb = tb.SetActive(99)
-	if tb.Active() != 1 {
-		t.Errorf("expected clamped Active()=1, got %d", tb.Active())
+	if tb.Active() != 2 {
+		t.Errorf("expected clamped Active()=2, got %d", tb.Active())
 	}
 
 	// Clamping below.
@@ -84,6 +94,9 @@ func TestTabBarViewContainsAllTabs(t *testing.T) {
 	}
 	if !strings.Contains(view, "Zone") {
 		t.Error("expected 'Zone' in tab bar view")
+	}
+	if !strings.Contains(view, "Dungeons") {
+		t.Error("expected 'Dungeons' in tab bar view")
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -612,7 +612,9 @@ func overlayText(background, modal string, areaW, areaH int) string {
 
 // displayOffsetToByte returns the byte index in s corresponding to the given
 // display-width position, skipping ANSI escape sequences (which have zero
-// display width). Each printable rune is counted as display width 1.
+// display width). Each rune's actual display width is measured via
+// lipgloss.Width to correctly handle CJK (width 2), emoji (width 2), and
+// combining characters (width 0).
 func displayOffsetToByte(s string, targetWidth int) int {
 	if targetWidth <= 0 {
 		return 0
@@ -636,9 +638,9 @@ func displayOffsetToByte(s string, targetWidth int) int {
 		if width >= targetWidth {
 			return i
 		}
-		// Advance one UTF-8 rune (assume display width 1 per rune).
-		_, size := utf8.DecodeRuneInString(s[i:])
-		width++
+		// Advance one UTF-8 rune, using its actual display width.
+		r, size := utf8.DecodeRuneInString(s[i:])
+		width += lipgloss.Width(string(r))
 		i += size
 	}
 	return i

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2,23 +2,28 @@ package tui
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/cantalupo555/albion-lens/internal/tui/components"
 	"github.com/cantalupo555/albion-lens/pkg/backend"
+	"github.com/cantalupo555/albion-lens/pkg/events"
 	"github.com/cantalupo555/albion-lens/pkg/handlers"
 	"github.com/cantalupo555/albion-lens/pkg/photon"
 )
 
 // Model is the main TUI model
 type Model struct {
-	statusBar  components.StatusBar
-	eventLog   components.EventLog
-	statsPanel components.StatsPanel
-	tabBar     components.TabBar
-	zonePanel  components.ZonePanel
+	statusBar     components.StatusBar
+	eventLog      components.EventLog
+	statsPanel    components.StatsPanel
+	tabBar        components.TabBar
+	zonePanel     components.ZonePanel
+	dungeonsPanel components.DungeonsPanel
 
 	// Backend service reference for runtime control
 	svc *backend.Service
@@ -37,6 +42,13 @@ type Model struct {
 
 	// Display settings
 	fullNumbers bool // Show full numbers instead of abbreviated (e.g., 4984 vs 4.9k)
+
+	// Debug event filter (interactive). High-frequency/low-signal events are
+	// hidden by default but toggleable via the filter overlay (key "/").
+	debugCounts  map[events.EventCode]int  // how many times each debug event was seen
+	debugHidden  map[events.EventCode]bool // codes currently suppressed from the log
+	filterOpen   bool
+	filterCursor int
 }
 
 // Tab indices for navigation. Kept as constants so the help bar and key
@@ -44,7 +56,12 @@ type Model struct {
 const (
 	TabDashboard = iota
 	TabZone
+	TabDungeons
 )
+
+// minFilterVisibleItems is the minimum number of rows shown in the debug event
+// filter overlay (one row for a single entry, even on very short terminals).
+const minFilterVisibleItems = 3
 
 // New creates a new TUI Model
 func New(svc *backend.Service, bulkEventChan chan BulkEventMsg, statsChan chan *photon.Stats) Model {
@@ -54,10 +71,13 @@ func New(svc *backend.Service, bulkEventChan chan BulkEventMsg, statsChan chan *
 		statsPanel:    components.NewStatsPanel(),
 		tabBar:        components.NewTabBar(),
 		zonePanel:     components.NewZonePanel(),
+		dungeonsPanel: components.NewDungeonsPanel(),
 		svc:           svc,
 		bulkEventChan: bulkEventChan,
 		statsChan:     statsChan,
 		fullNumbers:   false, // Default: abbreviated numbers (e.g., 4.9k)
+		debugCounts:   make(map[events.EventCode]int),
+		debugHidden:   defaultHiddenDebugEvents(),
 	}
 	// Sync debug state from service
 	if svc != nil {
@@ -65,6 +85,20 @@ func New(svc *backend.Service, bulkEventChan chan BulkEventMsg, statsChan chan *
 		m.onlineChan = svc.OnlineStatus
 	}
 	return m
+}
+
+// defaultHiddenDebugEvents returns the set of high-frequency / low-signal debug
+// events that are suppressed from the event log by default. They remain
+// counted and can be re-enabled interactively via the debug filter overlay.
+func defaultHiddenDebugEvents() map[events.EventCode]bool {
+	return map[events.EventCode]bool{
+		events.EventLeave:                    true, // 1 — entity leaves render range (constant spam)
+		events.EventMove:                     true, // 3 — movement updates
+		events.EventActiveSpellEffectsUpdate: true, // 11 — buff tick refresh
+		events.EventTimeSync:                 true, // 160 — periodic clock sync
+		events.EventPlayerCounts:             true, // 275 — periodic population poll
+		events.EventBattlEyeServerMessage:    true, // 406 — anti-cheat heartbeat
+	}
 }
 
 // Init initializes the model
@@ -107,6 +141,34 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// Keyboard input
 	case tea.KeyPressMsg:
+		// Filter overlay captures its own keys when open.
+		if m.filterOpen {
+			switch msg.String() {
+			case "/", "esc":
+				m.filterOpen = false
+				return m, nil
+			case "up", "k":
+				if m.filterCursor > 0 {
+					m.filterCursor--
+				}
+				return m, nil
+			case "down", "j":
+				if m.filterCursor < len(m.sortedDebugCodes())-1 {
+					m.filterCursor++
+				}
+				return m, nil
+			case "space", "enter":
+				codes := m.sortedDebugCodes()
+				if m.filterCursor >= 0 && m.filterCursor < len(codes) {
+					code := codes[m.filterCursor]
+					m.debugHidden[code] = !m.debugHidden[code]
+				}
+				return m, nil
+			}
+			// Other keys are swallowed while the filter is open.
+			return m, nil
+		}
+
 		switch msg.String() {
 		case "q", "Q", "ctrl+c":
 			m.quitting = true
@@ -123,12 +185,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "2":
 			m.tabBar = m.tabBar.SetActive(TabZone)
 			return m, nil
+		case "3":
+			m.tabBar = m.tabBar.SetActive(TabDungeons)
+			return m, nil
 		case "c", "C":
-			if m.tabBar.Active() == TabZone {
-				m.zonePanel = m.zonePanel.Clear()
-			} else {
-				m.eventLog = m.eventLog.Clear()
-			}
+			m = m.clearActivePanel()
 			return m, nil
 		case "d", "D":
 			m.debug = !m.debug
@@ -141,23 +202,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.fullNumbers = !m.fullNumbers
 			m.statsPanel = m.statsPanel.SetFullNumbers(m.fullNumbers)
 			m.eventLog = m.eventLog.SetFullNumbers(m.fullNumbers)
+			m.dungeonsPanel = m.dungeonsPanel.SetFullNumbers(m.fullNumbers)
+			return m, nil
+		case "/":
+			// Toggle the debug-event filter overlay.
+			m.filterOpen = !m.filterOpen
+			m.filterCursor = 0
 			return m, nil
 		case "r", "R":
 			m.statsPanel = m.statsPanel.Reset()
 			return m, nil
 		case "up", "k":
-			if m.tabBar.Active() == TabZone {
-				m.zonePanel = m.zonePanel.ScrollUp()
-			} else {
-				m.eventLog = m.eventLog.ScrollUp()
-			}
+			m = m.scrollActive(-1)
 			return m, nil
 		case "down", "j":
-			if m.tabBar.Active() == TabZone {
-				m.zonePanel = m.zonePanel.ScrollDown()
-			} else {
-				m.eventLog = m.eventLog.ScrollDown()
-			}
+			m = m.scrollActive(1)
 			return m, nil
 		}
 
@@ -219,6 +278,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 
+			// Debug event filtering: count every debug event by code and skip
+			// hidden ones so they never reach the log. Diagnostic debug lines
+			// (Data is not an EventCode) are always shown.
+			if eventMsg.Type == "debug" {
+				if code, ok := eventMsg.Data.(events.EventCode); ok {
+					m.debugCounts[code]++
+					if m.debugHidden[code] {
+						continue
+					}
+				}
+			}
+
 			logEvents = append(logEvents, components.Event{
 				Type:      eventMsg.Type,
 				Message:   displayMsg,
@@ -265,6 +336,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			zone := m.svc.CurrentZone()
 			m.statusBar = m.statusBar.SetZone(zone.DisplayString())
 			m.zonePanel = m.zonePanel.SetZone(zone).SetNow(time.Now())
+
+			// Refresh dungeon runs panel
+			if h := m.svc.Handler(); h != nil {
+				m.dungeonsPanel = m.dungeonsPanel.SetRuns(h.GetDungeonRuns(), h.GetActiveDungeon()).SetNow(time.Now())
+			}
 		}
 		// Refresh display periodically
 		cmds = append(cmds, TickCmd())
@@ -311,6 +387,7 @@ func (m Model) updateLayout() Model {
 	m.eventLog = m.eventLog.SetSize(eventLogWidth, mainHeight)
 	m.statsPanel = m.statsPanel.SetSize(statsPanelWidth, mainHeight)
 	m.zonePanel = m.zonePanel.SetSize(m.width, mainHeight)
+	m.dungeonsPanel = m.dungeonsPanel.SetSize(m.width, mainHeight)
 
 	return m
 }
@@ -333,14 +410,28 @@ func (m Model) View() tea.View {
 
 	// Main content depends on the active tab
 	var mainPanel string
-	if m.tabBar.Active() == TabZone {
+	switch m.tabBar.Active() {
+	case TabZone:
 		mainPanel = m.zonePanel.View()
-	} else {
+	case TabDungeons:
+		mainPanel = m.dungeonsPanel.View()
+	default:
 		mainPanel = lipgloss.JoinHorizontal(
 			lipgloss.Top,
 			m.eventLog.View(),
 			m.statsPanel.View(),
 		)
+	}
+
+	// Debug filter: overlay a centered modal ON TOP of the normal content so
+	// the dashboard stays visible behind/around the pop-up.
+	if m.filterOpen {
+		mainH := m.height - 4 /*status*/ - 1 /*tab*/ - 1 /*help*/
+		if mainH < 5 {
+			mainH = 5
+		}
+		modal := m.renderFilterPanel(m.width, mainH)
+		mainPanel = overlayText(mainPanel, modal, m.width, mainH)
 	}
 
 	// Help bar (bottom)
@@ -360,6 +451,46 @@ func (m Model) View() tea.View {
 	return v
 }
 
+// clearActivePanel dispatches a clear action to the panel matching the active
+// tab. Adding a tab requires only adding a case here.
+func (m Model) clearActivePanel() Model {
+	switch m.tabBar.Active() {
+	case TabZone:
+		m.zonePanel = m.zonePanel.Clear()
+	case TabDungeons:
+		m.dungeonsPanel = m.dungeonsPanel.Clear()
+	default:
+		m.eventLog = m.eventLog.Clear()
+	}
+	return m
+}
+
+// scrollActive dispatches a scroll action to the panel matching the active
+// tab. dir < 0 scrolls up; dir > 0 scrolls down.
+func (m Model) scrollActive(dir int) Model {
+	switch m.tabBar.Active() {
+	case TabZone:
+		if dir > 0 {
+			m.zonePanel = m.zonePanel.ScrollDown()
+		} else {
+			m.zonePanel = m.zonePanel.ScrollUp()
+		}
+	case TabDungeons:
+		if dir > 0 {
+			m.dungeonsPanel = m.dungeonsPanel.ScrollDown()
+		} else {
+			m.dungeonsPanel = m.dungeonsPanel.ScrollUp()
+		}
+	default:
+		if dir > 0 {
+			m.eventLog = m.eventLog.ScrollDown()
+		} else {
+			m.eventLog = m.eventLog.ScrollUp()
+		}
+	}
+	return m
+}
+
 // renderHelpBar renders the help bar at the bottom
 func (m Model) renderHelpBar() string {
 	keyStyle := lipgloss.NewStyle().
@@ -375,7 +506,8 @@ func (m Model) renderHelpBar() string {
 		keyStyle.Render("C"), textStyle.Render("lear  "),
 		keyStyle.Render("R"), textStyle.Render("eset stats  "),
 		keyStyle.Render("F"), textStyle.Render("ull numbers  "),
-		keyStyle.Render("D"), textStyle.Render("ebug"),
+		keyStyle.Render("D"), textStyle.Render("ebug  "),
+		keyStyle.Render("/"), textStyle.Render("Filter"),
 	)
 
 	// Show active toggles
@@ -384,9 +516,12 @@ func (m Model) renderHelpBar() string {
 		Bold(true)
 
 	// Show active tab indicator
-	if m.tabBar.Active() == TabZone {
+	switch m.tabBar.Active() {
+	case TabZone:
 		help += "  " + toggleStyle.Render("[ZONE]")
-	} else {
+	case TabDungeons:
+		help += "  " + toggleStyle.Render("[DG]")
+	default:
 		help += "  " + toggleStyle.Render("[DASH]")
 	}
 	if m.fullNumbers {
@@ -399,6 +534,203 @@ func (m Model) renderHelpBar() string {
 	return lipgloss.NewStyle().
 		Padding(0, 1).
 		Render(help)
+}
+
+// sortedDebugCodes returns the debug event codes seen so far, sorted ascending
+// by numeric code. Used by the filter overlay for both navigation and rendering.
+func (m Model) sortedDebugCodes() []events.EventCode {
+	codes := make([]events.EventCode, 0, len(m.debugCounts))
+	for c := range m.debugCounts {
+		codes = append(codes, c)
+	}
+	sort.Slice(codes, func(i, j int) bool { return int(codes[i]) < int(codes[j]) })
+	return codes
+}
+
+// renderFilterPanel returns just the bordered modal box (the caller overlays
+// it onto the background content via overlayText).
+func (m Model) renderFilterPanel(areaW, areaH int) string {
+	// Reserve: 2 border + 1 title + 1 hint + 1 blank + 2 scroll indicators + 2 margin
+	maxItems := areaH - 9
+	if maxItems < minFilterVisibleItems {
+		maxItems = minFilterVisibleItems
+	}
+	inner := m.filterListContent(maxItems)
+
+	boxStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("213")).
+		Background(lipgloss.Color("235")).
+		Padding(0, 1).
+		Width(clampInt(areaW-4, 40, 80))
+
+	return boxStyle.Render(inner)
+}
+
+// overlayText pastes the modal string centered over the background string,
+// preserving the background content visible around the modal. Both strings may
+// contain ANSI escape sequences; the overlay is performed at the display-width
+// level so styling is not corrupted.
+func overlayText(background, modal string, areaW, areaH int) string {
+	bgLines := strings.Split(background, "\n")
+	modalLines := strings.Split(modal, "\n")
+
+	modalH := len(modalLines)
+	modalW := 0
+	for _, l := range modalLines {
+		if w := lipgloss.Width(l); w > modalW {
+			modalW = w
+		}
+	}
+
+	x := (areaW - modalW) / 2
+	if x < 0 {
+		x = 0
+	}
+	y := (areaH - modalH) / 2
+	if y < 0 {
+		y = 0
+	}
+
+	result := make([]string, len(bgLines))
+	for i, bgLine := range bgLines {
+		if i >= y && i < y+modalH {
+			modalLine := modalLines[i-y]
+			leftCut := displayOffsetToByte(bgLine, x)
+			rightCut := displayOffsetToByte(bgLine, x+modalW)
+			left := bgLine[:leftCut]
+			if w := lipgloss.Width(left); w < x {
+				left += strings.Repeat(" ", x-w)
+			}
+			result[i] = left + modalLine + bgLine[rightCut:]
+		} else {
+			result[i] = bgLine
+		}
+	}
+	return strings.Join(result, "\n")
+}
+
+// displayOffsetToByte returns the byte index in s corresponding to the given
+// display-width position, skipping ANSI escape sequences (which have zero
+// display width). Each printable rune is counted as display width 1.
+func displayOffsetToByte(s string, targetWidth int) int {
+	if targetWidth <= 0 {
+		return 0
+	}
+	width := 0
+	i := 0
+	for i < len(s) {
+		// ANSI CSI escape: ESC [ ... <final byte 0x40-0x7e>
+		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
+			j := i + 2
+			for j < len(s) {
+				c := s[j]
+				j++
+				if c >= 0x40 && c <= 0x7e {
+					break
+				}
+			}
+			i = j
+			continue
+		}
+		if width >= targetWidth {
+			return i
+		}
+		// Advance one UTF-8 rune (assume display width 1 per rune).
+		_, size := utf8.DecodeRuneInString(s[i:])
+		width++
+		i += size
+	}
+	return i
+}
+
+// filterListContent builds the inner text of the debug-event filter: a title
+// with a close hint, and a scrollable window of rows. Only maxItems rows are
+// shown at once; the window follows the cursor. When rows are hidden above or
+// below, a count indicator is displayed.
+func (m Model) filterListContent(maxItems int) string {
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("213"))
+	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
+	curStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("214"))
+	onStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("119"))  // green = visible
+	offStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241")) // dim = hidden
+
+	var b strings.Builder
+	b.WriteString(titleStyle.Render("Debug Event Filter") + "\n")
+	b.WriteString(hintStyle.Render("  up/down move  -  space toggle  -  / close") + "\n\n")
+
+	codes := m.sortedDebugCodes()
+	if len(codes) == 0 {
+		b.WriteString(hintStyle.Render("No debug events captured yet.\nEnable debug with D."))
+		return b.String()
+	}
+
+	// Compute the visible scroll window centered on the cursor.
+	start, end := scrollWindow(m.filterCursor, len(codes), maxItems)
+
+	if start > 0 {
+		b.WriteString(hintStyle.Render(fmt.Sprintf("  (%d more above)", start)) + "\n")
+	}
+
+	for i := start; i < end; i++ {
+		code := codes[i]
+		name := events.EventCodeNames[code]
+		if name == "" {
+			name = "?"
+		}
+		count := m.debugCounts[code]
+
+		marker := "v" // visible
+		rowStyle := onStyle
+		if m.debugHidden[code] {
+			marker = "x" // hidden
+			rowStyle = offStyle
+		}
+
+		row := fmt.Sprintf("[%s] %3d  %-28s %d", marker, int(code), name, count)
+		if i == m.filterCursor {
+			row = curStyle.Render("> ") + rowStyle.Render(row)
+		} else {
+			row = "  " + rowStyle.Render(row)
+		}
+		b.WriteString(row + "\n")
+	}
+
+	if end < len(codes) {
+		b.WriteString(hintStyle.Render(fmt.Sprintf("  (%d more below)", len(codes)-end)) + "\n")
+	}
+
+	return b.String()
+}
+
+// scrollWindow returns the [start, end) indices of a scrollable list of length
+// n, such that the window of size maxItems contains the cursor and is clamped
+// to valid bounds.
+func scrollWindow(cursor, n, maxItems int) (int, int) {
+	if n <= maxItems {
+		return 0, n
+	}
+	start := cursor - maxItems/2
+	if start < 0 {
+		start = 0
+	}
+	if start+maxItems > n {
+		start = n - maxItems
+		if start < 0 {
+			start = 0
+		}
+	}
+	return start, start + maxItems
+}
+
+func clampInt(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
 }
 
 // formatNumber formats a number based on fullNumbers setting

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -7,6 +7,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/cantalupo555/albion-lens/pkg/backend"
+	"github.com/cantalupo555/albion-lens/pkg/events"
 	"github.com/cantalupo555/albion-lens/pkg/handlers"
 	"github.com/cantalupo555/albion-lens/pkg/photon"
 )
@@ -104,6 +105,12 @@ func TestUpdateKeyTabNext(t *testing.T) {
 	if m.tabBar.Active() != TabZone {
 		t.Errorf("expected Zone active after Tab, got %d", m.tabBar.Active())
 	}
+
+	m = updateModel(m, tea.KeyPressMsg{Code: tea.KeyTab})
+
+	if m.tabBar.Active() != TabDungeons {
+		t.Errorf("expected Dungeons active after second Tab, got %d", m.tabBar.Active())
+	}
 }
 
 func TestUpdateKeyTabPrev(t *testing.T) {
@@ -111,8 +118,8 @@ func TestUpdateKeyTabPrev(t *testing.T) {
 
 	m = updateModel(m, tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift})
 
-	if m.tabBar.Active() != TabZone {
-		t.Errorf("expected Zone active after Shift+Tab, got %d", m.tabBar.Active())
+	if m.tabBar.Active() != TabDungeons {
+		t.Errorf("expected Dungeons active after Shift+Tab, got %d", m.tabBar.Active())
 	}
 }
 
@@ -123,6 +130,12 @@ func TestUpdateKeyNumberSwitch(t *testing.T) {
 	m = updateModel(m, tea.KeyPressMsg{Code: '2'})
 	if m.tabBar.Active() != TabZone {
 		t.Errorf("expected Zone active after '2', got %d", m.tabBar.Active())
+	}
+
+	// Press '3' → Dungeons tab.
+	m = updateModel(m, tea.KeyPressMsg{Code: '3'})
+	if m.tabBar.Active() != TabDungeons {
+		t.Errorf("expected Dungeons active after '3', got %d", m.tabBar.Active())
 	}
 
 	// Press '1' → Dashboard tab.
@@ -273,6 +286,163 @@ func TestUpdateKeyFullNumbersToggle(t *testing.T) {
 	}
 }
 
+// ============================================
+// Debug event filter tests
+// ============================================
+
+func TestDebugFilterHidesNoisyByDefault(t *testing.T) {
+	m := readyModel()
+	if !m.debugHidden[events.EventMove] {
+		t.Error("expected EventMove hidden by default")
+	}
+	if !m.debugHidden[events.EventLeave] {
+		t.Error("expected EventLeave hidden by default")
+	}
+}
+
+func TestDebugFilterCountsAndSkipsHidden(t *testing.T) {
+	m := readyModel()
+	// Move is hidden by default; SimpleFeedback is not.
+	m = updateModel(m, BulkEventMsg{
+		{Type: "debug", Timestamp: time.Now(), Data: events.EventMove},
+		{Type: "debug", Timestamp: time.Now(), Data: events.EventMove},
+		{Type: "debug", Timestamp: time.Now(), Data: events.EventSimpleFeedback},
+	})
+
+	if m.debugCounts[events.EventMove] != 2 {
+		t.Errorf("expected Move counted 2, got %d", m.debugCounts[events.EventMove])
+	}
+	if m.debugCounts[events.EventSimpleFeedback] != 1 {
+		t.Errorf("expected SimpleFeedback counted 1, got %d", m.debugCounts[events.EventSimpleFeedback])
+	}
+	// The hidden Move events must not appear in the rendered log view.
+	view := m.View().Content
+	if strings.Contains(view, "Move") {
+		t.Error("hidden Move event leaked into the view")
+	}
+	if !strings.Contains(view, "SimpleFeedback") {
+		t.Error("expected SimpleFeedback to be visible in the view")
+	}
+}
+
+func TestDebugFilterToggleRevealsHidden(t *testing.T) {
+	m := readyModel()
+	m = updateModel(m, BulkEventMsg{
+		{Type: "debug", Timestamp: time.Now(), Data: events.EventMove},
+	})
+	// Open filter, move cursor onto Move (first sorted code), toggle it visible.
+	m = updateModel(m, tea.KeyPressMsg{Code: '/'})
+	m = updateModel(m, tea.KeyPressMsg{Code: tea.KeySpace}) // toggle cursor row
+
+	if m.debugHidden[events.EventMove] {
+		t.Error("expected Move to be revealed after toggling")
+	}
+}
+
+func TestDebugFilterKeyOpensOverlay(t *testing.T) {
+	m := readyModel()
+	if m.filterOpen {
+		t.Error("expected filter closed initially")
+	}
+	m = updateModel(m, tea.KeyPressMsg{Code: '/'})
+	if !m.filterOpen {
+		t.Error("expected filter open after pressing '/'")
+	}
+	// The overlay should render its title.
+	if !strings.Contains(m.View().Content, "Debug Event Filter") {
+		t.Error("expected filter overlay title in view")
+	}
+	// Closing restores the normal view.
+	m = updateModel(m, tea.KeyPressMsg{Code: '/'})
+	if m.filterOpen {
+		t.Error("expected filter closed after pressing '/' again")
+	}
+}
+
+func TestScrollWindow(t *testing.T) {
+	tests := []struct {
+		name     string
+		cursor   int
+		n        int
+		maxItems int
+		wantS    int
+		wantE    int
+	}{
+		{"fits entirely", 2, 5, 10, 0, 5},
+		{"cursor near top", 0, 20, 5, 0, 5},
+		{"cursor centered", 10, 20, 5, 8, 13},
+		{"cursor near bottom", 19, 20, 5, 15, 20},
+		{"exact fit", 4, 5, 5, 0, 5},
+		{"single item window", 3, 10, 1, 3, 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, e := scrollWindow(tt.cursor, tt.n, tt.maxItems)
+			if s != tt.wantS || e != tt.wantE {
+				t.Errorf("scrollWindow(%d,%d,%d) = [%d,%d), want [%d,%d)",
+					tt.cursor, tt.n, tt.maxItems, s, e, tt.wantS, tt.wantE)
+			}
+			// Cursor must always be within [start, end).
+			if tt.cursor < s || tt.cursor >= e {
+				t.Errorf("cursor %d outside window [%d,%d)", tt.cursor, s, e)
+			}
+			// Window must not exceed bounds.
+			if s < 0 || e > tt.n {
+				t.Errorf("window [%d,%d) out of bounds [0,%d)", s, e, tt.n)
+			}
+		})
+	}
+}
+
+// ============================================
+// Overlay tests
+// ============================================
+
+func TestOverlayPreservesBackground(t *testing.T) {
+	// 5-line background, 1-line modal.
+	bg := "aaaa\nbbbb\ncccc\ndddd\neeee"
+	modal := "MOD"
+	result := overlayText(bg, modal, 10, 5)
+
+	lines := strings.Split(result, "\n")
+	// Lines outside the modal row must be intact.
+	if lines[0] != "aaaa" {
+		t.Errorf("line 0 changed: %q", lines[0])
+	}
+	if lines[4] != "eeee" {
+		t.Errorf("line 4 changed: %q", lines[4])
+	}
+	// The modal line must contain "MOD".
+	merged := strings.Join(lines, "\n")
+	if !strings.Contains(merged, "MOD") {
+		t.Error("expected MOD in overlay result")
+	}
+	// Background content around the modal must still be visible.
+	if !strings.Contains(merged, "bbb") {
+		t.Error("expected background 'bbb' preserved around modal")
+	}
+}
+
+func TestDisplayOffsetToByte(t *testing.T) {
+	// Plain ASCII: byte offset == display offset.
+	if got := displayOffsetToByte("abcdef", 3); got != 3 {
+		t.Errorf("plain: got %d, want 3", got)
+	}
+	// With ANSI prefix: escape codes are zero-width.
+	s := "\x1b[31mABC\x1b[0m"
+	if got := displayOffsetToByte(s, 2); got != len("\x1b[31mAB") {
+		t.Errorf("ansi: got %d, want %d", got, len("\x1b[31mAB"))
+	}
+	// Target beyond end: returns full length.
+	if got := displayOffsetToByte("ab", 10); got != 2 {
+		t.Errorf("overflow: got %d, want 2", got)
+	}
+	// Zero target: returns 0.
+	if got := displayOffsetToByte("abc", 0); got != 0 {
+		t.Errorf("zero: got %d, want 0", got)
+	}
+}
+
 func TestUpdateKeyClear(t *testing.T) {
 	m := readyModel()
 
@@ -399,6 +569,30 @@ func TestUpdateBulkEventKillDeath(t *testing.T) {
 	}
 	if !strings.Contains(statsView, "Loot") {
 		t.Error("expected 'Loot' in stats panel")
+	}
+}
+
+func TestUpdateBulkEventDungeonEnter(t *testing.T) {
+	m := readyModel()
+
+	bulkMsg := BulkEventMsg{
+		{
+			Type: "zone",
+			Data: &handlers.ZoneEventData{
+				MapType:  handlers.MapTypeRandomDungeon,
+				Display:  "Random Dungeon",
+				Previous: handlers.MapTypeUnknown,
+			},
+			Timestamp: time.Now(),
+		},
+	}
+
+	m = updateModel(m, bulkMsg)
+
+	// Zone events are passed to the zone panel; the transition should appear.
+	zoneView := m.zonePanel.View()
+	if !strings.Contains(zoneView, "Random Dungeon") {
+		t.Error("expected 'Random Dungeon' in zone panel after zone event")
 	}
 }
 

--- a/pkg/backend/service.go
+++ b/pkg/backend/service.go
@@ -122,6 +122,9 @@ func (s *Service) Start() error {
 	// Load item database (errors are non-fatal)
 	_ = s.loadItemDatabase()
 
+	// Load mob database for dungeon tier classification (errors are non-fatal)
+	_ = s.loadMobDatabase()
+
 	// Create parser
 	s.parser = photon.NewParser(s.handler)
 	s.parser.Stats.BufferCapacity = cap(s.eventsChan) // Set once at startup
@@ -234,22 +237,36 @@ func (s *Service) statsUpdater() {
 	}
 }
 
+// aoBinDumpsPaths returns the common fallback paths for the ao-bin-dumps
+// directory, used when no explicit --items path is provided.
+func aoBinDumpsPaths() []string {
+	return []string{
+		"../ao-bin-dumps",
+		"../../ao-bin-dumps",
+		filepath.Join(os.Getenv("HOME"), "Documents/albion/ao-bin-dumps"),
+	}
+}
+
 // loadItemDatabase attempts to load the item database.
 func (s *Service) loadItemDatabase() error {
 	if s.itemDBPath != "" {
 		return s.handler.LoadItemDatabase(s.itemDBPath)
 	}
 
-	// Try auto-detection
-	commonPaths := []string{
-		"../ao-bin-dumps",
-		"../../ao-bin-dumps",
-		filepath.Join(os.Getenv("HOME"), "Documents/albion/ao-bin-dumps"),
-	}
-
-	for _, path := range commonPaths {
+	for _, path := range aoBinDumpsPaths() {
 		if _, err := os.Stat(filepath.Join(path, "items.json")); err == nil {
 			return s.handler.LoadItemDatabase(path)
+		}
+	}
+
+	return nil
+}
+
+// loadMobDatabase attempts to load the mob database for dungeon tier classification.
+func (s *Service) loadMobDatabase() error {
+	for _, path := range aoBinDumpsPaths() {
+		if _, err := os.Stat(filepath.Join(path, "mobs.json")); err == nil {
+			return s.handler.LoadMobDatabase(path)
 		}
 	}
 

--- a/pkg/handlers/albion.go
+++ b/pkg/handlers/albion.go
@@ -7,6 +7,8 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -16,7 +18,7 @@ import (
 )
 
 // EventCallback is called when a game event is processed
-// eventType: "fame", "silver", "loot", "respec", "combat", "info", "death", "kill", "zone"
+// eventType: "fame", "silver", "loot", "respec", "combat", "info", "death", "kill", "zone", "debug"
 // message: formatted message to display
 // data: optional structured data (FameEventData, SilverEventData, RespecEventData, ZoneEventData, etc.)
 type EventCallback func(eventType, message string, data interface{})
@@ -52,6 +54,9 @@ type AlbionHandler struct {
 	// Items database
 	itemDB *items.ItemDatabase
 
+	// Mob database for dungeon tier classification (loaded from mobs.json).
+	mobDB *MobDatabase
+
 	// Discovery mode tracking
 	discoveredEvents map[int16]*DiscoveredEvent
 	discoveryMu      sync.RWMutex
@@ -77,6 +82,13 @@ type AlbionHandler struct {
 	deathDedupWindow time.Duration
 	lastDeathsPurge  time.Time
 	nowFunc          func() time.Time
+
+	// Dungeon run tracking. Single active run detected via OpJoin and
+	// ChangeCluster transitions (MapType == RandomDungeon). Classification
+	// is lazy: mode/faction from shrine/chest events, tier from mob events.
+	dungeonMu   sync.Mutex
+	dungeonRuns []*DungeonRun
+	activeRun   *DungeonRun
 
 	// Event callback for frontend integration (TUI, Wails, etc.)
 	eventCallback EventCallback
@@ -146,29 +158,70 @@ func (h *AlbionHandler) GetCurrentZone() ZoneInfo {
 	return h.currentZone
 }
 
-// handleChangeCluster parses the ChangeCluster response, updates the current
-// zone state, and emits a zone event. Duplicate responses (same map type,
-// cluster index, and island name) are suppressed to avoid log spam.
+// handleChangeCluster parses the ChangeCluster response and forwards it to
+// processZoneTransition. ChangeCluster fires for open-world cluster changes
+// (city, overworld, island). Dungeon entries are primarily detected via OpJoin.
 func (h *AlbionHandler) handleChangeCluster(params map[byte]interface{}) {
-	newZone := parseChangeClusterResponse(params)
+	h.processZoneTransition(parseChangeClusterResponse(params))
+}
 
+// processZoneTransition updates the current zone state, detects dungeon
+// entry/exit, and emits a zone event. Called from both ChangeCluster and Join
+// handlers so that dungeon detection works regardless of which operation the
+// server sends. Duplicate transitions (same map type, cluster index, and
+// island name) are suppressed. Empty fields on the incoming ZoneInfo are
+// merged from the previous zone so that a partial update (e.g. OpJoin, which
+// only carries ClusterIndex and MapType) does not clobber richer data already
+// set by ChangeCluster (IslandName, MainClusterIndex, HasDungeonInfo).
+func (h *AlbionHandler) processZoneTransition(newZone ZoneInfo) {
 	h.zoneMu.RLock()
 	prev := h.currentZone
 	h.zoneMu.RUnlock()
 
-	// Dedup: the server may resend the same ChangeCluster response. Skip if
-	// nothing materially changed.
+	// Merge: preserve non-zero fields from prev when the incoming zone
+	// leaves them empty (OpJoin sends a partial ZoneInfo).
+	if newZone.IslandName == "" {
+		newZone.IslandName = prev.IslandName
+	}
+	if newZone.MainClusterIndex == "" {
+		newZone.MainClusterIndex = prev.MainClusterIndex
+	}
+	if !newZone.HasDungeonInfo {
+		newZone.HasDungeonInfo = prev.HasDungeonInfo
+	}
+
+	// Dedup: the server may resend the same response or deliver the same
+	// transition via both Join and ChangeCluster. Skip if nothing materially
+	// changed. HasDungeonInfo is excluded — it's metadata that may differ
+	// between Join (always false) and ChangeCluster (may be true) for the
+	// same zone, and doesn't warrant a duplicate event.
 	if newZone.MapType == prev.MapType &&
 		newZone.ClusterIndex == prev.ClusterIndex &&
 		newZone.IslandName == prev.IslandName &&
-		newZone.MainClusterIndex == prev.MainClusterIndex &&
-		newZone.HasDungeonInfo == prev.HasDungeonInfo {
+		newZone.MainClusterIndex == prev.MainClusterIndex {
+		// Silently update HasDungeonInfo if the new zone has it but the
+		// stored one doesn't (ChangeCluster arriving after OpJoin).
+		if newZone.HasDungeonInfo && !prev.HasDungeonInfo {
+			h.zoneMu.Lock()
+			h.currentZone.HasDungeonInfo = true
+			h.zoneMu.Unlock()
+		}
 		return
 	}
 
 	h.zoneMu.Lock()
 	h.currentZone = newZone
 	h.zoneMu.Unlock()
+
+	// Detect random dungeon entry/exit for run tracking. Guard against
+	// double-entry when both Join and ChangeCluster fire for the same
+	// dungeon transition (prev and new both RandomDungeon → skip).
+	now := h.nowFunc()
+	if newZone.MapType == MapTypeRandomDungeon && prev.MapType != MapTypeRandomDungeon {
+		h.EnterDungeon(now)
+	} else if newZone.MapType != MapTypeRandomDungeon && prev.MapType == MapTypeRandomDungeon {
+		h.ExitDungeon(now)
+	}
 
 	h.notifyEvent("zone", "", &ZoneEventData{
 		MapType:      newZone.MapType,
@@ -269,6 +322,17 @@ func (h *AlbionHandler) LoadItemDatabase(path string) error {
 	return h.itemDB.LoadFromPath(path)
 }
 
+// LoadMobDatabase loads the mob database from ao-bin-dumps for dungeon tier
+// classification. Errors are non-fatal (tier classification is best-effort).
+func (h *AlbionHandler) LoadMobDatabase(path string) error {
+	db, err := LoadMobDatabase(path)
+	if err != nil {
+		return err
+	}
+	h.mobDB = db
+	return nil
+}
+
 // resolveOperationCode extracts the actual operation code from param[253].
 // Albion embeds the real code in the parameter dictionary, which can differ
 // from the Photon header byte. Mirrors the reference AlbionParser which
@@ -310,6 +374,31 @@ func (h *AlbionHandler) OnResponse(operationCode byte, returnCode int16, debugMe
 			h.SetLocalPlayer(name)
 		} else {
 			h.debugNotify("OpJoin response had no player name", nil)
+		}
+
+		// The Join response also carries the map identity in param[8]
+		// (MapIndex). This is the primary signal for dungeon entry/exit —
+		// the reference project (JoinResponseHandler) calls AddDungeon from
+		// here, not from ChangeCluster. param[65]=SourceClusterIndex,
+		// param[64]=exit position.
+		if mapIndex := getString(parameters, 8); mapIndex != "" {
+			h.processZoneTransition(ZoneInfo{
+				ClusterIndex: mapIndex,
+				MapType:      ParseMapType(mapIndex),
+			})
+		}
+
+		// Debug: surface the full OpJoin map identity for live confirmation.
+		if h.debug {
+			sourceCluster := getString(parameters, 65)
+			posX, posY, hasPos := getFloatPair(parameters, 64)
+			if sourceCluster != "" || hasPos {
+				pos := "?"
+				if hasPos {
+					pos = fmt.Sprintf("(%.0f,%.0f)", posX, posY)
+				}
+				h.debugNotify(fmt.Sprintf("OpJoin source=%q pos=%s", sourceCluster, pos), nil)
+			}
 		}
 
 	case events.OperationChangeCluster:
@@ -371,10 +460,31 @@ func (h *AlbionHandler) OnEvent(eventCode byte, parameters map[byte]interface{})
 		h.handleUpdateReSpecPoints(parameters)
 		handled = true
 
+	case events.EventNewShrine:
+		h.handleNewShrine(parameters)
+		handled = true
+
+	case events.EventNewLootChest:
+		h.handleNewLootChest(parameters)
+		handled = true
+
+	case events.EventNewMob:
+		h.handleNewMob(parameters)
+		handled = true
+
+	case events.EventSimpleFeedback:
+		// Debug-only: capture params to confirm whether this is the dungeon
+		// "closed" notification. The reference defines it but does not handle it.
+		if h.debug {
+			h.debugNotify(fmt.Sprintf("SimpleFeedback %s", dumpParams(parameters)), nil)
+		}
+		handled = true
+
 	default:
 		if h.debug {
 			// Pass "debug" type and the raw event code as data.
-			// The TUI will handle visual formatting.
+			// The TUI applies interactive filtering (high-frequency events are
+			// hidden by default but toggleable); see internal/tui debug filter.
 			h.notifyEvent("debug", "", actualEventCode)
 		}
 	}
@@ -790,6 +900,59 @@ func (h *AlbionHandler) handleUpdateReSpecPoints(params map[byte]interface{}) {
 	})
 }
 
+// classifyRunFromUniqueName extracts mode and faction from a shrine/chest
+// uniqueName and updates the active run lazily. Shared by shrine and chest
+// handlers since both follow the same classification path.
+func (h *AlbionHandler) classifyRunFromUniqueName(uniqueName string) {
+	if uniqueName == "" {
+		return
+	}
+	mode := ClassifyDungeonMode(uniqueName)
+	faction := ClassifyDungeonFaction(uniqueName)
+	if mode != DungeonModeUnknown {
+		h.UpdateActiveRunMode(mode)
+	}
+	if faction != "" {
+		h.UpdateActiveRunFaction(faction)
+	}
+}
+
+// handleNewShrine handles EventNewShrine (code 395). The shrine uniqueName
+// (param[3]) is used for lazy dungeon mode classification.
+func (h *AlbionHandler) handleNewShrine(params map[byte]interface{}) {
+	uniqueName := getString(params, 3)
+	if h.debug {
+		h.debugNotify(fmt.Sprintf("NewShrine uniqueName=%q", uniqueName), nil)
+	}
+	h.classifyRunFromUniqueName(uniqueName)
+}
+
+// handleNewLootChest handles EventNewLootChest (code 391). The chest uniqueName
+// (param[3]) is used for lazy dungeon mode + faction classification.
+func (h *AlbionHandler) handleNewLootChest(params map[byte]interface{}) {
+	uniqueName := getString(params, 3)
+	if h.debug {
+		h.debugNotify(fmt.Sprintf("NewLootChest uniqueName=%q", uniqueName), nil)
+	}
+	h.classifyRunFromUniqueName(uniqueName)
+}
+
+// handleNewMob handles EventNewMob (code 123). The mob index (param[1]) is used
+// for lazy dungeon tier classification via the mob database.
+func (h *AlbionHandler) handleNewMob(params map[byte]interface{}) {
+	mobIndex := int(getInt32(params, 1))
+	if mobIndex == 0 {
+		return
+	}
+	tier := h.mobDB.GetRandomDungeonMobTier(mobIndex)
+	if h.debug {
+		h.debugNotify(fmt.Sprintf("NewMob index=%d tier=%d", mobIndex, tier), nil)
+	}
+	if tier >= 0 {
+		h.UpdateActiveRunTier(tier)
+	}
+}
+
 // Helper functions to extract typed values from parameters
 func getInt64(params map[byte]interface{}, key byte) int64 {
 	if val, ok := params[key]; ok {
@@ -839,4 +1002,89 @@ func getBool(params map[byte]interface{}, key byte) bool {
 		}
 	}
 	return false
+}
+
+// getFloatPair extracts a 2-element numeric array (X, Y) from params[key].
+// Handles the array encodings the photon decoder may produce for a world
+// position: []interface{}, []float32, []float64, []int, []int32, []int64.
+// Returns ok=false when the key is missing, not an array, or has fewer than 2
+// elements. Mirrors the reference ParseWorldPosition acceptance policy.
+func getFloatPair(params map[byte]interface{}, key byte) (x, y float64, ok bool) {
+	val, found := params[key]
+	if !found {
+		return 0, 0, false
+	}
+
+	switch arr := val.(type) {
+	case []interface{}:
+		if len(arr) < 2 {
+			return 0, 0, false
+		}
+		x, okX := toFloat(arr[0])
+		y, okY := toFloat(arr[1])
+		return x, y, okX && okY
+	case []float32:
+		if len(arr) < 2 {
+			return 0, 0, false
+		}
+		return float64(arr[0]), float64(arr[1]), true
+	case []float64:
+		if len(arr) < 2 {
+			return 0, 0, false
+		}
+		return arr[0], arr[1], true
+	case []int:
+		if len(arr) < 2 {
+			return 0, 0, false
+		}
+		return float64(arr[0]), float64(arr[1]), true
+	case []int32:
+		if len(arr) < 2 {
+			return 0, 0, false
+		}
+		return float64(arr[0]), float64(arr[1]), true
+	case []int64:
+		if len(arr) < 2 {
+			return 0, 0, false
+		}
+		return float64(arr[0]), float64(arr[1]), true
+	}
+	return 0, 0, false
+}
+
+// toFloat coerces a numeric interface{} value to float64.
+func toFloat(v interface{}) (float64, bool) {
+	switch n := v.(type) {
+	case float32:
+		return float64(n), true
+	case float64:
+		return n, true
+	case int:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	}
+	return 0, false
+}
+
+// dumpParams renders a parameter map as a compact, key-sorted string for debug
+// logging. Byte slices and large arrays are truncated to keep output readable.
+func dumpParams(params map[byte]interface{}) string {
+	keys := make([]int, 0, len(params))
+	for k := range params {
+		keys = append(keys, int(k))
+	}
+	sort.Ints(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		v := params[byte(k)]
+		s := fmt.Sprintf("%v", v)
+		if len(s) > 40 {
+			s = s[:37] + "..."
+		}
+		parts = append(parts, fmt.Sprintf("[%d]=%s", k, s))
+	}
+	return "{" + strings.Join(parts, " ") + "}"
 }

--- a/pkg/handlers/albion_test.go
+++ b/pkg/handlers/albion_test.go
@@ -1546,3 +1546,98 @@ func TestOnResponseOpJoinExitsDungeon(t *testing.T) {
 		t.Errorf("expected Done, got %v", runs[0].Status)
 	}
 }
+
+// --- Event-to-classification integration tests ---
+
+// enterDungeonHelper enters a random dungeon via OpJoin and returns the handler.
+func enterDungeonHelper(t *testing.T) *AlbionHandler {
+	t.Helper()
+	h := NewAlbionHandler()
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return t0 }
+	h.OnResponse(events.OperationJoin, 0, "", map[byte]interface{}{
+		byte(253): int16(events.OperationJoin),
+		byte(8):   "@RANDOMDUNGEON@test-guid",
+	})
+	if h.GetActiveDungeon() == nil {
+		t.Fatal("expected active dungeon run after OpJoin")
+	}
+	return h
+}
+
+func TestOnEventNewShrineClassifiesRun(t *testing.T) {
+	h := enterDungeonHelper(t)
+
+	h.OnEvent(0, map[byte]interface{}{
+		byte(252): int16(events.EventNewShrine),
+		byte(3):   "RD_SOLO_KEEPER_SHRINE",
+	})
+
+	active := h.GetActiveDungeon()
+	if active == nil {
+		t.Fatal("expected active run after NewShrine")
+	}
+	if active.Mode != DungeonModeSolo {
+		t.Errorf("expected Mode=Solo from shrine, got %v", active.Mode)
+	}
+	if active.Faction != "Keeper" {
+		t.Errorf("expected Faction=Keeper from shrine, got %q", active.Faction)
+	}
+}
+
+func TestOnEventNewLootChestClassifiesRun(t *testing.T) {
+	h := enterDungeonHelper(t)
+
+	h.OnEvent(0, map[byte]interface{}{
+		byte(252): int16(events.EventNewLootChest),
+		byte(3):   "T4_RD_VETERAN_MORGANA_CHEST",
+	})
+
+	active := h.GetActiveDungeon()
+	if active == nil {
+		t.Fatal("expected active run after NewLootChest")
+	}
+	if active.Mode != DungeonModeStandard {
+		t.Errorf("expected Mode=Standard from chest, got %v", active.Mode)
+	}
+	if active.Faction != "Morgana" {
+		t.Errorf("expected Faction=Morgana from chest, got %q", active.Faction)
+	}
+}
+
+func TestOnEventNewMobClassifiesTier(t *testing.T) {
+	h := enterDungeonHelper(t)
+	h.mobDB = &MobDatabase{
+		mobs: []mobEntry{
+			{UniqueName: "T4_MOB_RD_UNDEAD_SKELLETTON", Tier: 4},
+		},
+		loaded: true,
+	}
+
+	h.OnEvent(0, map[byte]interface{}{
+		byte(252): int16(events.EventNewMob),
+		byte(1):   int32(inGameMobIndexOffset), // server mobIndex = offset → dataIndex 0
+	})
+
+	active := h.GetActiveDungeon()
+	if active == nil {
+		t.Fatal("expected active run after NewMob")
+	}
+	if active.Tier != 3 {
+		t.Errorf("expected Tier=3 (mob tier 4 - 1), got %d", active.Tier)
+	}
+}
+
+func TestOnEventNewShrineNoActiveRun(t *testing.T) {
+	h := NewAlbionHandler()
+
+	// Should not panic when no active run exists.
+	h.OnEvent(0, map[byte]interface{}{
+		byte(252): int16(events.EventNewShrine),
+		byte(3):   "RD_SOLO_KEEPER_SHRINE",
+	})
+
+	if h.GetActiveDungeon() != nil {
+		t.Error("expected nil active run when no dungeon entered")
+	}
+}

--- a/pkg/handlers/albion_test.go
+++ b/pkg/handlers/albion_test.go
@@ -1429,3 +1429,120 @@ func TestSessionCountersConcurrent(t *testing.T) {
 		t.Errorf("sessionKills should be >= 0, got %d", k)
 	}
 }
+
+// TestGetFloatPair directly exercises the position-array helper.
+func TestGetFloatPair(t *testing.T) {
+	tests := []struct {
+		name  string
+		val   interface{}
+		expX  float64
+		expY  float64
+		expOK bool
+	}{
+		{"float32", []float32{1.5, 2.5}, 1.5, 2.5, true},
+		{"float64", []float64{3, 4}, 3, 4, true},
+		{"interface numeric", []interface{}{float64(5), int(6)}, 5, 6, true},
+		{"int", []int{7, 8}, 7, 8, true},
+		{"int32", []int32{9, 10}, 9, 10, true},
+		{"int64", []int64{11, 12}, 11, 12, true},
+		{"too short", []float64{1}, 0, 0, false},
+		{"wrong type", "not-an-array", 0, 0, false},
+		{"interface non-numeric", []interface{}{"a", "b"}, 0, 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			params := map[byte]interface{}{1: tc.val}
+			x, y, ok := getFloatPair(params, 1)
+			if ok != tc.expOK {
+				t.Errorf("ok: expected %v, got %v", tc.expOK, ok)
+			}
+			if x != tc.expX {
+				t.Errorf("x: expected %v, got %v", tc.expX, x)
+			}
+			if y != tc.expY {
+				t.Errorf("y: expected %v, got %v", tc.expY, y)
+			}
+		})
+	}
+
+	// Missing key
+	if _, _, ok := getFloatPair(map[byte]interface{}{}, 1); ok {
+		t.Error("expected ok=false for missing key")
+	}
+}
+
+func TestOnResponseOpJoinCreatesDungeonRun(t *testing.T) {
+	h := NewAlbionHandler()
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return t0 }
+
+	// No active run before OpJoin.
+	if h.GetActiveDungeon() != nil {
+		t.Fatal("expected nil active run before OpJoin")
+	}
+
+	// Simulate an OpJoin response with a random dungeon map in param[8].
+	h.OnResponse(events.OperationJoin, 0, "", map[byte]interface{}{
+		byte(253): int16(events.OperationJoin), // param[253] = real op code
+		byte(2):   "TestPlayer",                // param[2] = username
+		byte(8):   "@RANDOMDUNGEON@06a1a448-166d-4022-a4b1-ae3cc7ba1144",
+	})
+
+	// Player name should be set.
+	if h.GetLocalPlayer() != "TestPlayer" {
+		t.Errorf("expected local player 'TestPlayer', got %q", h.GetLocalPlayer())
+	}
+
+	// A dungeon run should be active.
+	active := h.GetActiveDungeon()
+	if active == nil {
+		t.Fatal("expected active dungeon run after OpJoin with @RANDOMDUNGEON@ map")
+	}
+	if active.Status != RunStatusActive {
+		t.Errorf("expected Status=Active, got %v", active.Status)
+	}
+
+	// Zone should reflect Random Dungeon.
+	zone := h.GetCurrentZone()
+	if zone.MapType != MapTypeRandomDungeon {
+		t.Errorf("expected MapType=RandomDungeon, got %v", zone.MapType)
+	}
+}
+
+func TestOnResponseOpJoinExitsDungeon(t *testing.T) {
+	h := NewAlbionHandler()
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return t0 }
+
+	// Enter dungeon via OpJoin.
+	h.OnResponse(events.OperationJoin, 0, "", map[byte]interface{}{
+		byte(253): int16(events.OperationJoin),
+		byte(8):   "@RANDOMDUNGEON@abc123",
+	})
+
+	if h.GetActiveDungeon() == nil {
+		t.Fatal("expected active run after entering dungeon")
+	}
+
+	// Exit to open world via a second OpJoin with a non-dungeon map.
+	t1 := t0.Add(5 * time.Minute)
+	h.nowFunc = func() time.Time { return t1 }
+	h.OnResponse(events.OperationJoin, 0, "", map[byte]interface{}{
+		byte(253): int16(events.OperationJoin),
+		byte(8):   "4000", // open-world cluster (Fort Sterling)
+	})
+
+	// No active run after exit.
+	if h.GetActiveDungeon() != nil {
+		t.Error("expected nil active run after exiting dungeon")
+	}
+
+	// The dungeon run should be Done.
+	runs := h.GetDungeonRuns()
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(runs))
+	}
+	if runs[0].Status != RunStatusDone {
+		t.Errorf("expected Done, got %v", runs[0].Status)
+	}
+}

--- a/pkg/handlers/dungeon.go
+++ b/pkg/handlers/dungeon.go
@@ -1,0 +1,409 @@
+package handlers
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// DungeonCloseTimeout matches the reference DungeonCloseTimer (90 seconds from
+// entry). The close countdown is computed on read, not via a goroutine.
+const DungeonCloseTimeout = 90 * time.Second
+
+// maxDungeonRuns caps the in-memory run history. Older runs are trimmed when
+// the cap is exceeded.
+const maxDungeonRuns = 500
+
+// inGameMobIndexOffset matches the reference MobsData.InGameMobIndexOffset (16).
+// The mob index sent by the server is offset by this amount relative to the
+// mobs.json array position.
+const inGameMobIndexOffset = 16
+
+// DungeonMode classifies the type of random dungeon. Matches the reference
+// DungeonMode enum (DungeonData.GetDungeonMode).
+type DungeonMode int
+
+const (
+	DungeonModeUnknown DungeonMode = iota
+	DungeonModeSolo
+	DungeonModeStandard // group / veteran
+	DungeonModeAvalon
+	DungeonModeCorrupted
+	DungeonModeHellGate
+	DungeonModeAbyssalDepths
+)
+
+// String returns a short label for the dungeon mode.
+func (m DungeonMode) String() string {
+	switch m {
+	case DungeonModeSolo:
+		return "Solo"
+	case DungeonModeStandard:
+		return "Group"
+	case DungeonModeAvalon:
+		return "Avalon"
+	case DungeonModeCorrupted:
+		return "Corrupted"
+	case DungeonModeHellGate:
+		return "HellGate"
+	case DungeonModeAbyssalDepths:
+		return "Abyssal"
+	default:
+		return "Unknown"
+	}
+}
+
+// RunStatus tracks the lifecycle of a dungeon run.
+type RunStatus int
+
+const (
+	RunStatusActive RunStatus = iota
+	RunStatusDone             // player exited normally
+	RunStatusClosed           // 90s timer elapsed without exit (disconnect, etc.)
+)
+
+// String returns a short label for the run status.
+func (s RunStatus) String() string {
+	switch s {
+	case RunStatusActive:
+		return "Active"
+	case RunStatusDone:
+		return "Done"
+	case RunStatusClosed:
+		return "Closed"
+	default:
+		return "Unknown"
+	}
+}
+
+// DungeonRun represents a single random dungeon run from entry to exit.
+type DungeonRun struct {
+	EnteredAt time.Time
+	ExitedAt  time.Time // zero while active
+	Mode      DungeonMode
+	Faction   string // "", Keeper, Heretic, Morgana, Undead, Avalon
+	Tier      int    // -1 unknown; 0-7 (mob tier - 1 per reference)
+	Level     int    // -1 unknown (deferred — needs exit-position catalog)
+	Status    RunStatus
+	CloseAt   time.Time // EnteredAt + 90s
+
+	// Per-run stat deltas (computed on exit).
+	Fame         int64
+	Silver       int64
+	Respec       int64
+	RespecSilver int64
+	Kills        int
+	Deaths       int
+	Loot         int
+
+	// Snapshot of session counters at entry (internal, for delta computation).
+	snapFame         int64
+	snapSilver       int64
+	snapRespec       int64
+	snapRespecSilver int64
+	snapKills        int
+	snapDeaths       int
+	snapLoot         int
+}
+
+// IsClosedNow reports whether the 90s close timer has elapsed. Computed on
+// read — no background goroutine needed.
+func (r *DungeonRun) IsClosedNow(now time.Time) bool {
+	return r.Status == RunStatusActive && !now.Before(r.CloseAt)
+}
+
+// Duration returns the effective run duration. For active runs this is
+// time-since-entry; for completed runs it's exit-minus-entry.
+func (r *DungeonRun) Duration(now time.Time) time.Duration {
+	end := r.ExitedAt
+	if end.IsZero() {
+		end = now
+	}
+	return end.Sub(r.EnteredAt)
+}
+
+// --- Classification helpers (Phase 2a/2b) ---
+
+// ClassifyDungeonMode determines the dungeon mode from a shrine or loot chest
+// uniqueName. Mirrors DungeonData.GetDungeonMode from the reference project.
+func ClassifyDungeonMode(uniqueName string) DungeonMode {
+	upper := strings.ToUpper(uniqueName)
+	switch {
+	case strings.Contains(upper, "GENERAL_SHRINE_COMBAT_BUFF"):
+		return DungeonModeSolo
+	case strings.Contains(upper, "_SOLO_"):
+		return DungeonModeSolo
+	case strings.Contains(upper, "_VETERAN_"), strings.Contains(upper, "_HALLOWEEN"):
+		return DungeonModeStandard
+	case strings.Contains(upper, "AVALON"):
+		return DungeonModeAvalon
+	case strings.Contains(upper, "CORRUPTED"):
+		return DungeonModeCorrupted
+	case strings.Contains(upper, "HELL_"), strings.Contains(upper, "HELLGATE"):
+		return DungeonModeHellGate
+	case strings.Contains(upper, "HD_SHRINE_WRATH_BUFF"):
+		return DungeonModeAbyssalDepths
+	}
+	return DungeonModeUnknown
+}
+
+// ClassifyDungeonFaction determines the dungeon faction from a shrine, loot
+// chest, or mob uniqueName. Mirrors DungeonData.GetFaction from the reference.
+func ClassifyDungeonFaction(uniqueName string) string {
+	upper := strings.ToUpper(uniqueName)
+	switch {
+	case strings.Contains(upper, "KEEPER"):
+		return "Keeper"
+	case strings.Contains(upper, "HERETIC"):
+		return "Heretic"
+	case strings.Contains(upper, "MORGANA"):
+		return "Morgana"
+	case strings.Contains(upper, "UNDEAD"):
+		return "Undead"
+	case strings.Contains(upper, "AVALON"):
+		return "Avalon"
+	}
+	return ""
+}
+
+// --- Mob database (Phase 2b) ---
+
+// mobEntry holds the fields needed for tier classification.
+type mobEntry struct {
+	UniqueName string
+	Tier       int
+}
+
+// MobDatabase maps server mob indices to mob data for tier classification.
+// The index is the position in mobs.json + InGameMobIndexOffset.
+type MobDatabase struct {
+	mobs   []mobEntry
+	loaded bool
+}
+
+// LoadMobDatabase loads mobs.json from the ao-bin-dumps directory.
+func LoadMobDatabase(path string) (*MobDatabase, error) {
+	fullPath := filepath.Join(path, "mobs.json")
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var raw struct {
+		Mobs struct {
+			Mob []map[string]interface{} `json:"Mob"`
+		} `json:"Mobs"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+
+	db := &MobDatabase{
+		mobs:   make([]mobEntry, len(raw.Mobs.Mob)),
+		loaded: true,
+	}
+	for i, m := range raw.Mobs.Mob {
+		entry := mobEntry{}
+		if v, ok := m["@uniquename"].(string); ok {
+			entry.UniqueName = v
+		}
+		if v, ok := m["@tier"].(string); ok {
+			entry.Tier = atoiSafe(v)
+		} else if v, ok := m["@tier"].(float64); ok {
+			entry.Tier = int(v)
+		}
+		db.mobs[i] = entry
+	}
+	return db, nil
+}
+
+// GetRandomDungeonMobTier looks up a mob by server index and returns its
+// dungeon tier (mob.Tier - 1) if the mob is a reliable RD tier indicator.
+// Returns -1 when the mob is not a reliable indicator or the index is out of
+// range. Mirrors MobsData.GetRandomDungeonMobTierByIndex.
+func (db *MobDatabase) GetRandomDungeonMobTier(mobIndex int) int {
+	if db == nil || !db.loaded {
+		return -1
+	}
+	dataIndex := mobIndex - inGameMobIndexOffset
+	if dataIndex < 0 || dataIndex >= len(db.mobs) {
+		return -1
+	}
+	mob := db.mobs[dataIndex]
+	if !isReliableRandomDungeonTierMob(mob) {
+		return -1
+	}
+	return mob.Tier - 1
+}
+
+// isReliableRandomDungeonTierMob mirrors MobsData.IsReliableRandomDungeonTierMob.
+func isReliableRandomDungeonTierMob(mob mobEntry) bool {
+	if mob.Tier < 1 || mob.Tier > 8 || mob.UniqueName == "" {
+		return false
+	}
+	upper := strings.ToUpper(mob.UniqueName)
+	if !strings.Contains(upper, "_MOB_RD_") {
+		return false
+	}
+	return !strings.Contains(upper, "_BOSS") &&
+		!strings.Contains(upper, "_MINIBOSS") &&
+		!strings.Contains(upper, "_SUMMON") &&
+		!strings.Contains(upper, "_UNATTACKABLE") &&
+		!strings.Contains(upper, "_TRAP")
+}
+
+// atoiSafe parses a decimal string to int, returning 0 on failure.
+func atoiSafe(s string) int {
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}
+
+// --- Dungeon run lifecycle (Phase 1) ---
+
+// EnterDungeon starts a new dungeon run. If a run is already active, it is
+// closed (deltas computed, Status=Done) before the new run is created.
+// Session counters are snapshotted for per-run delta attribution.
+func (h *AlbionHandler) EnterDungeon(now time.Time) {
+	h.dungeonMu.Lock()
+	defer h.dungeonMu.Unlock()
+
+	if h.activeRun != nil {
+		h.closeActiveRunLocked(now, RunStatusDone)
+	}
+
+	run := &DungeonRun{
+		EnteredAt:        now,
+		Mode:             DungeonModeUnknown,
+		Tier:             -1,
+		Level:            -1,
+		Status:           RunStatusActive,
+		CloseAt:          now.Add(DungeonCloseTimeout),
+		snapFame:         h.sessionFame.Load(),
+		snapSilver:       h.sessionSilver.Load(),
+		snapRespec:       h.sessionRespec.Load(),
+		snapRespecSilver: h.sessionRespecSilver.Load(),
+		snapKills:        int(h.sessionKills.Load()),
+		snapDeaths:       int(h.sessionDeaths.Load()),
+		snapLoot:         int(h.sessionLoot.Load()),
+	}
+	h.activeRun = run
+	h.dungeonRuns = append(h.dungeonRuns, run)
+
+	// Trim oldest runs when the cap is exceeded.
+	if len(h.dungeonRuns) > maxDungeonRuns {
+		h.dungeonRuns = h.dungeonRuns[len(h.dungeonRuns)-maxDungeonRuns:]
+	}
+}
+
+// ExitDungeon closes the active dungeon run and computes stat deltas.
+// No-op when there is no active run.
+func (h *AlbionHandler) ExitDungeon(now time.Time) {
+	h.dungeonMu.Lock()
+	defer h.dungeonMu.Unlock()
+
+	if h.activeRun == nil {
+		return
+	}
+	h.closeActiveRunLocked(now, RunStatusDone)
+}
+
+// closeActiveRunLocked finalizes the active run. Caller must hold dungeonMu.
+func (h *AlbionHandler) closeActiveRunLocked(now time.Time, status RunStatus) {
+	r := h.activeRun
+	if r == nil {
+		return
+	}
+	r.ExitedAt = now
+	r.Status = status
+	r.Fame = h.sessionFame.Load() - r.snapFame
+	r.Silver = h.sessionSilver.Load() - r.snapSilver
+	r.Respec = h.sessionRespec.Load() - r.snapRespec
+	r.RespecSilver = h.sessionRespecSilver.Load() - r.snapRespecSilver
+	r.Kills = int(h.sessionKills.Load()) - r.snapKills
+	r.Deaths = int(h.sessionDeaths.Load()) - r.snapDeaths
+	r.Loot = int(h.sessionLoot.Load()) - r.snapLoot
+	h.activeRun = nil
+}
+
+// UpdateActiveRunMode sets the mode on the active run if it is currently
+// Unknown. Thread-safe.
+func (h *AlbionHandler) UpdateActiveRunMode(mode DungeonMode) {
+	h.dungeonMu.Lock()
+	defer h.dungeonMu.Unlock()
+	if h.activeRun != nil && h.activeRun.Mode == DungeonModeUnknown && mode != DungeonModeUnknown {
+		h.activeRun.Mode = mode
+	}
+}
+
+// UpdateActiveRunFaction sets the faction on the active run if it is currently
+// empty. Thread-safe.
+func (h *AlbionHandler) UpdateActiveRunFaction(faction string) {
+	if faction == "" {
+		return
+	}
+	h.dungeonMu.Lock()
+	defer h.dungeonMu.Unlock()
+	if h.activeRun != nil && h.activeRun.Faction == "" {
+		h.activeRun.Faction = faction
+	}
+}
+
+// UpdateActiveRunTier sets the tier on the active run. The tier is
+// monotonically increasing: a lower or equal value is ignored. Thread-safe.
+func (h *AlbionHandler) UpdateActiveRunTier(tier int) {
+	if tier < 0 {
+		return
+	}
+	h.dungeonMu.Lock()
+	defer h.dungeonMu.Unlock()
+	if h.activeRun != nil && tier > h.activeRun.Tier {
+		h.activeRun.Tier = tier
+	}
+}
+
+// closeExpiredLocked transitions the active run to RunStatusClosed if the 90s
+// timer has elapsed. Deltas are computed once (frozen on close). Caller must
+// hold dungeonMu.
+func (h *AlbionHandler) closeExpiredLocked(now time.Time) {
+	if h.activeRun != nil && h.activeRun.IsClosedNow(now) {
+		h.closeActiveRunLocked(now, RunStatusClosed)
+	}
+}
+
+// GetActiveDungeon returns a snapshot of the active dungeon run, or nil if
+// the player is not in a dungeon (or the 90s close timer just elapsed). The
+// returned pointer is to a copy — callers may freely read all fields without
+// holding the handler lock.
+func (h *AlbionHandler) GetActiveDungeon() *DungeonRun {
+	h.dungeonMu.Lock()
+	defer h.dungeonMu.Unlock()
+	h.closeExpiredLocked(h.nowFunc())
+	if h.activeRun == nil {
+		return nil
+	}
+	run := *h.activeRun
+	return &run
+}
+
+// GetDungeonRuns returns snapshots of all recorded dungeon runs (oldest first).
+// Each pointer is to a copy — callers may freely read, reorder, or retain the
+// slice without holding the handler lock.
+func (h *AlbionHandler) GetDungeonRuns() []*DungeonRun {
+	h.dungeonMu.Lock()
+	defer h.dungeonMu.Unlock()
+	h.closeExpiredLocked(h.nowFunc())
+	result := make([]*DungeonRun, len(h.dungeonRuns))
+	for i, r := range h.dungeonRuns {
+		cp := *r
+		result[i] = &cp
+	}
+	return result
+}

--- a/pkg/handlers/dungeon_test.go
+++ b/pkg/handlers/dungeon_test.go
@@ -1,0 +1,456 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+)
+
+func TestClassifyDungeonMode(t *testing.T) {
+	cases := []struct {
+		name string
+		want DungeonMode
+	}{
+		{"GENERAL_SHRINE_COMBAT_BUFF", DungeonModeSolo},
+		{"KEEPER_SOLO_BOOKCHEST_STANDARD", DungeonModeSolo},
+		{"T4_VETERAN_LOOTCHEST_STANDARD", DungeonModeStandard},
+		{"T4_HALLOWEEN_CHEST", DungeonModeStandard},
+		{"AVALONIAN_CACHE", DungeonModeAvalon},
+		{"CORRUPTED_SHRINE", DungeonModeCorrupted},
+		{"HELLGATE_CHEST", DungeonModeHellGate},
+		{"HD_SHRINE_WRATH_BUFF", DungeonModeAbyssalDepths},
+		{"SOME_UNKNOWN_CHEST", DungeonModeUnknown},
+		{"", DungeonModeUnknown},
+	}
+	for _, tc := range cases {
+		got := ClassifyDungeonMode(tc.name)
+		if got != tc.want {
+			t.Errorf("ClassifyDungeonMode(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestClassifyDungeonFaction(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"KEEPER_SOLO_BOOKCHEST_STANDARD", "Keeper"},
+		{"HERETIC_CHEST", "Heretic"},
+		{"MORGANA_CHEST", "Morgana"},
+		{"UNDEAD_SHRINE", "Undead"},
+		{"AVALON_CACHE", "Avalon"},
+		{"UNKNOWN_FACTION", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		got := ClassifyDungeonFaction(tc.name)
+		if got != tc.want {
+			t.Errorf("ClassifyDungeonFaction(%q) = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestEnterExitDungeonLifecycle(t *testing.T) {
+	h := NewAlbionHandler()
+	base := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return base }
+
+	// No active run initially
+	if h.GetActiveDungeon() != nil {
+		t.Fatal("expected nil active run before entry")
+	}
+
+	// Enter
+	h.EnterDungeon(base)
+	active := h.GetActiveDungeon()
+	if active == nil {
+		t.Fatal("expected active run after EnterDungeon")
+	}
+	if active.Status != RunStatusActive {
+		t.Errorf("expected Status=Active, got %v", active.Status)
+	}
+	if active.Mode != DungeonModeUnknown {
+		t.Errorf("expected Mode=Unknown initially, got %v", active.Mode)
+	}
+	if active.Tier != -1 {
+		t.Errorf("expected Tier=-1 initially, got %d", active.Tier)
+	}
+	if !active.CloseAt.Equal(base.Add(DungeonCloseTimeout)) {
+		t.Errorf("CloseAt: expected %v, got %v", base.Add(DungeonCloseTimeout), active.CloseAt)
+	}
+
+	// Exit — deltas should be zero (no stats gained)
+	h.sessionFame.Add(500)
+	h.sessionKills.Add(1)
+	exitTime := base.Add(2 * time.Minute)
+	h.nowFunc = func() time.Time { return exitTime }
+	h.ExitDungeon(exitTime)
+
+	active = h.GetActiveDungeon()
+	if active != nil {
+		t.Fatal("expected nil active run after exit")
+	}
+
+	runs := h.GetDungeonRuns()
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run in history, got %d", len(runs))
+	}
+	r := runs[0]
+	if r.Status != RunStatusDone {
+		t.Errorf("expected Status=Done, got %v", r.Status)
+	}
+	if r.Fame != 500 {
+		t.Errorf("expected Fame delta 500, got %d", r.Fame)
+	}
+	if r.Kills != 1 {
+		t.Errorf("expected Kills delta 1, got %d", r.Kills)
+	}
+}
+
+func TestEnterDungeonClosesPrevious(t *testing.T) {
+	h := NewAlbionHandler()
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+
+	h.nowFunc = func() time.Time { return t0 }
+	h.EnterDungeon(t0)
+
+	// Gain some fame during first run
+	h.sessionFame.Add(1000)
+
+	// Enter a second dungeon without exiting the first
+	t1 := t0.Add(3 * time.Minute)
+	h.nowFunc = func() time.Time { return t1 }
+	h.EnterDungeon(t1)
+
+	runs := h.GetDungeonRuns()
+	if len(runs) != 2 {
+		t.Fatalf("expected 2 runs, got %d", len(runs))
+	}
+
+	// First run should be Done with Fame delta 1000
+	if runs[0].Status != RunStatusDone {
+		t.Errorf("first run: expected Done, got %v", runs[0].Status)
+	}
+	if runs[0].Fame != 1000 {
+		t.Errorf("first run: expected Fame 1000, got %d", runs[0].Fame)
+	}
+
+	// Second run should be Active
+	if runs[1].Status != RunStatusActive {
+		t.Errorf("second run: expected Active, got %v", runs[1].Status)
+	}
+	active := h.GetActiveDungeon()
+	if active == nil || !active.EnteredAt.Equal(runs[1].EnteredAt) {
+		t.Error("active run should be the second run")
+	}
+}
+
+func TestExitDungeonNoActiveIsNoOp(t *testing.T) {
+	h := NewAlbionHandler()
+	h.ExitDungeon(time.Now())
+
+	if len(h.GetDungeonRuns()) != 0 {
+		t.Error("expected 0 runs when exiting with no active run")
+	}
+}
+
+func TestUpdateActiveRunMode(t *testing.T) {
+	h := NewAlbionHandler()
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return t0 }
+	h.EnterDungeon(t0)
+
+	h.UpdateActiveRunMode(DungeonModeSolo)
+	if h.GetActiveDungeon().Mode != DungeonModeSolo {
+		t.Errorf("expected Mode=Solo, got %v", h.GetActiveDungeon().Mode)
+	}
+
+	// Second call with a different mode should NOT overwrite (already classified)
+	h.UpdateActiveRunMode(DungeonModeStandard)
+	if h.GetActiveDungeon().Mode != DungeonModeSolo {
+		t.Errorf("mode should not change after first classification, got %v", h.GetActiveDungeon().Mode)
+	}
+}
+
+func TestUpdateActiveRunModeNoActiveRun(t *testing.T) {
+	h := NewAlbionHandler()
+	h.UpdateActiveRunMode(DungeonModeSolo) // should not panic
+}
+
+func TestUpdateActiveRunFaction(t *testing.T) {
+	h := NewAlbionHandler()
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return t0 }
+	h.EnterDungeon(t0)
+
+	h.UpdateActiveRunFaction("Keeper")
+	if h.GetActiveDungeon().Faction != "Keeper" {
+		t.Errorf("expected Faction=Keeper, got %q", h.GetActiveDungeon().Faction)
+	}
+
+	// Second call with different faction should NOT overwrite
+	h.UpdateActiveRunFaction("Heretic")
+	if h.GetActiveDungeon().Faction != "Keeper" {
+		t.Errorf("faction should not change, got %q", h.GetActiveDungeon().Faction)
+	}
+}
+
+func TestUpdateActiveRunTierMonotonic(t *testing.T) {
+	h := NewAlbionHandler()
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return t0 }
+	h.EnterDungeon(t0)
+
+	h.UpdateActiveRunTier(3)
+	if h.GetActiveDungeon().Tier != 3 {
+		t.Errorf("expected Tier=3, got %d", h.GetActiveDungeon().Tier)
+	}
+
+	// Lower tier should be ignored
+	h.UpdateActiveRunTier(2)
+	if h.GetActiveDungeon().Tier != 3 {
+		t.Errorf("tier should not decrease, got %d", h.GetActiveDungeon().Tier)
+	}
+
+	// Higher tier should be accepted
+	h.UpdateActiveRunTier(5)
+	if h.GetActiveDungeon().Tier != 5 {
+		t.Errorf("expected Tier=5, got %d", h.GetActiveDungeon().Tier)
+	}
+}
+
+func TestUpdateActiveRunTierNegative(t *testing.T) {
+	h := NewAlbionHandler()
+	t0 := time.Now()
+	h.nowFunc = func() time.Time { return t0 }
+	h.EnterDungeon(t0)
+	h.UpdateActiveRunTier(-1)
+	if h.GetActiveDungeon().Tier != -1 {
+		t.Errorf("negative tier should be ignored, got %d", h.GetActiveDungeon().Tier)
+	}
+}
+
+func TestDungeonRunIsClosedNow(t *testing.T) {
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	r := &DungeonRun{
+		EnteredAt: t0,
+		CloseAt:   t0.Add(DungeonCloseTimeout),
+		Status:    RunStatusActive,
+	}
+
+	// Before close time — not closed
+	if r.IsClosedNow(t0.Add(30 * time.Second)) {
+		t.Error("should not be closed before CloseAt")
+	}
+
+	// After close time — closed
+	if !r.IsClosedNow(t0.Add(DungeonCloseTimeout + time.Second)) {
+		t.Error("should be closed after CloseAt")
+	}
+
+	// Done runs are never "closed by timer"
+	r.Status = RunStatusDone
+	if r.IsClosedNow(t0.Add(DungeonCloseTimeout * 2)) {
+		t.Error("Done runs should not report IsClosedNow")
+	}
+}
+
+func TestDungeonRunDuration(t *testing.T) {
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	t1 := t0.Add(5 * time.Minute)
+
+	// Active run: duration = now - entry
+	r := &DungeonRun{EnteredAt: t0, Status: RunStatusActive}
+	d := r.Duration(t0.Add(2 * time.Minute))
+	if d != 2*time.Minute {
+		t.Errorf("active duration: expected 2m, got %v", d)
+	}
+
+	// Done run: duration = exit - entry
+	r2 := &DungeonRun{EnteredAt: t0, ExitedAt: t1, Status: RunStatusDone}
+	d2 := r2.Duration(t0.Add(10 * time.Minute))
+	if d2 != 5*time.Minute {
+		t.Errorf("done duration: expected 5m, got %v", d2)
+	}
+}
+
+func TestIsReliableRandomDungeonTierMob(t *testing.T) {
+	cases := []struct {
+		mob  mobEntry
+		want bool
+	}{
+		{mobEntry{UniqueName: "T4_MOB_RD_UNDEAD_SOLDIER", Tier: 4}, true},
+		{mobEntry{UniqueName: "T6_MOB_RD_KEEPER_MAGE", Tier: 6}, true},
+		{mobEntry{UniqueName: "T4_MOB_RD_UNDEAD_BOSS", Tier: 4}, false},
+		{mobEntry{UniqueName: "T4_MOB_RD_KEEPER_MINIBOSS", Tier: 4}, false},
+		{mobEntry{UniqueName: "T4_MOB_RD_SUMMON", Tier: 4}, false},
+		{mobEntry{UniqueName: "T4_MOB_RD_TRAP", Tier: 4}, false},
+		{mobEntry{UniqueName: "T4_MOB_NOTRD_SOLDIER", Tier: 4}, false},
+		{mobEntry{UniqueName: "", Tier: 4}, false},
+		{mobEntry{UniqueName: "T0_MOB_RD_X", Tier: 0}, false},
+		{mobEntry{UniqueName: "T9_MOB_RD_X", Tier: 9}, false},
+	}
+	for _, tc := range cases {
+		got := isReliableRandomDungeonTierMob(tc.mob)
+		if got != tc.want {
+			t.Errorf("isReliable(%+v) = %v, want %v", tc.mob, got, tc.want)
+		}
+	}
+}
+
+func TestMobDatabaseGetRandomDungeonMobTier(t *testing.T) {
+	// Build a minimal in-memory database
+	db := &MobDatabase{
+		mobs: []mobEntry{
+			// index 16 (offset) → dataIndex 0
+			{UniqueName: "T4_MOB_RD_UNDEAD_SOLDIER", Tier: 4},
+			// index 17 → dataIndex 1
+			{UniqueName: "T4_MOB_RD_UNDEAD_BOSS", Tier: 4},
+			// index 18 → dataIndex 2
+			{UniqueName: "T6_MOB_RD_KEEPER_MAGE", Tier: 6},
+			// index 19 → dataIndex 3
+			{UniqueName: "T4_MOB_NOTRD_X", Tier: 4},
+		},
+		loaded: true,
+	}
+
+	// Valid RD mob: tier 4 → returns 3 (tier - 1)
+	if tier := db.GetRandomDungeonMobTier(inGameMobIndexOffset + 0); tier != 3 {
+		t.Errorf("index 16: expected tier 3, got %d", tier)
+	}
+
+	// Boss: not reliable → -1
+	if tier := db.GetRandomDungeonMobTier(inGameMobIndexOffset + 1); tier != -1 {
+		t.Errorf("boss: expected -1, got %d", tier)
+	}
+
+	// Valid RD mob tier 6 → returns 5
+	if tier := db.GetRandomDungeonMobTier(inGameMobIndexOffset + 2); tier != 5 {
+		t.Errorf("index 18: expected tier 5, got %d", tier)
+	}
+
+	// Non-RD mob → -1
+	if tier := db.GetRandomDungeonMobTier(inGameMobIndexOffset + 3); tier != -1 {
+		t.Errorf("non-RD: expected -1, got %d", tier)
+	}
+
+	// Out of range → -1
+	if tier := db.GetRandomDungeonMobTier(inGameMobIndexOffset + 100); tier != -1 {
+		t.Errorf("out-of-range: expected -1, got %d", tier)
+	}
+
+	// Negative index → -1
+	if tier := db.GetRandomDungeonMobTier(0); tier != -1 {
+		t.Errorf("zero index: expected -1, got %d", tier)
+	}
+}
+
+func TestMobDatabaseNilSafe(t *testing.T) {
+	var db *MobDatabase
+	if tier := db.GetRandomDungeonMobTier(100); tier != -1 {
+		t.Errorf("nil db: expected -1, got %d", tier)
+	}
+}
+
+func TestDungeonModeString(t *testing.T) {
+	cases := []struct {
+		mode DungeonMode
+		want string
+	}{
+		{DungeonModeSolo, "Solo"},
+		{DungeonModeStandard, "Group"},
+		{DungeonModeAvalon, "Avalon"},
+		{DungeonModeCorrupted, "Corrupted"},
+		{DungeonModeHellGate, "HellGate"},
+		{DungeonModeAbyssalDepths, "Abyssal"},
+		{DungeonModeUnknown, "Unknown"},
+	}
+	for _, tc := range cases {
+		if got := tc.mode.String(); got != tc.want {
+			t.Errorf("%v.String() = %q, want %q", tc.mode, got, tc.want)
+		}
+	}
+}
+
+func TestRunStatusString(t *testing.T) {
+	cases := []struct {
+		status RunStatus
+		want   string
+	}{
+		{RunStatusActive, "Active"},
+		{RunStatusDone, "Done"},
+		{RunStatusClosed, "Closed"},
+	}
+	for _, tc := range cases {
+		if got := tc.status.String(); got != tc.want {
+			t.Errorf("%v.String() = %q, want %q", tc.status, got, tc.want)
+		}
+	}
+}
+
+func TestGetDungeonRunsReturnsCopy(t *testing.T) {
+	h := NewAlbionHandler()
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return t0 }
+	h.EnterDungeon(t0)
+
+	runs := h.GetDungeonRuns()
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(runs))
+	}
+
+	// Mutate the returned slice — original should be unaffected
+	runs[0] = nil
+	runs2 := h.GetDungeonRuns()
+	if runs2[0] == nil {
+		t.Error("GetDungeonRuns should return a copy, not the original slice")
+	}
+}
+
+func TestGetActiveDungeonClosesOnRead(t *testing.T) {
+	h := NewAlbionHandler()
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return t0 }
+	h.EnterDungeon(t0)
+
+	// Before close time — active run exists
+	if active := h.GetActiveDungeon(); active == nil {
+		t.Fatal("expected active run before close time")
+	}
+
+	// After close time — run should auto-close on read
+	h.nowFunc = func() time.Time { return t0.Add(DungeonCloseTimeout + time.Second) }
+
+	if active := h.GetActiveDungeon(); active != nil {
+		t.Error("expected nil active run after close timer elapsed")
+	}
+
+	runs := h.GetDungeonRuns()
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(runs))
+	}
+	if runs[0].Status != RunStatusClosed {
+		t.Errorf("expected Closed status, got %v", runs[0].Status)
+	}
+}
+
+func TestGetActiveDungeonReturnsCopy(t *testing.T) {
+	h := NewAlbionHandler()
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return t0 }
+	h.EnterDungeon(t0)
+
+	a1 := h.GetActiveDungeon()
+	a2 := h.GetActiveDungeon()
+	if a1 == nil || a2 == nil {
+		t.Fatal("expected non-nil active runs")
+	}
+	// Each call must return a distinct copy (different pointers)
+	if a1 == a2 {
+		t.Error("GetActiveDungeon should return a new copy each call, not the same pointer")
+	}
+	// But same field values
+	if !a1.EnteredAt.Equal(a2.EnteredAt) {
+		t.Error("copies should have same EnteredAt")
+	}
+}


### PR DESCRIPTION
## Summary
Implements a dungeon-run tracker that detects random dungeon entry/exit, lazily classifies solo/group mode, faction, and tier from in-dungeon events, and displays runs in a dedicated TUI tab with a live 90s close countdown.

## Motivation
Players need visibility into dungeon run history (mode, faction, tier, duration, fame) to track farming efficiency. The reference project (AlbionOnline-StatisticsAnalysis) has this feature; this ports it to the Go TUI. Closes #86.

## Changes Made
- Add `DungeonRun` model with lifecycle (enter/exit/close-on-read), lazy mode/faction/tier classification from shrine/chest/mob events, 90s close timer, 500-run history cap
- Detect dungeon entry/exit via OpJoin `param[8]` map index (primary signal, matching reference `JoinResponseHandler`) and ChangeCluster, unified through `processZoneTransition` with dedup and partial-zone merge
- Load `mobs.json` from ao-bin-dumps for mob-tier classification
- Add `DungeonsPanel` TUI component: active run info, 90s countdown, scrollable history table with smart auto-scroll
- Add "Dungeons" as 3rd tab (key `3`), wire into model tick polling
- Add interactive debug event filter overlay (`/` key) for high-frequency events
- Add `--discover` CLI flag for event discovery mode

## Testing
- [x] Tested locally (in-game dungeon entry confirmed)
- [x] Unit tests added (lifecycle, classification, close-on-read, copy semantics, OpJoin integration, panel rendering)
- [ ] Documentation updated

## Breaking Changes
None — all changes are additive. No public APIs removed or renamed.

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

This PR adds a dungeon run tracker to the Go TUI that detects random dungeon entry/exit events, lazily classifies solo/group mode, faction, and tier from in-dungeon events, and displays runs in a dedicated "Dungeons" tab with a live 90-second close countdown. It introduces a `DungeonRun` model with lifecycle management, a `DungeonsPanel` component with scrollable history and auto-scroll, and a debug event filter overlay. Supporting changes include loading `mobs.json` for mob-tier classification, a `--discover` CLI flag for event discovery, and wiring the new tab into the model's tick polling.

---
<sup>Written for commit a6eecac54abfe2db2ccab7a3c2586d47c514b70a. Summary will update on new commits.</sup>
<!-- end-auto-generated -->