### PR TITLE
fix(capture): surface device open failures instead of failing silently

### DIFF
--- a/internal/tui/components/eventlog.go
+++ b/internal/tui/components/eventlog.go
@@ -181,6 +181,8 @@ func (e EventLog) renderSingleEvent(event Event) string {
 		msgStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("39"))
 	case "debug":
 		msgStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	case "warning":
+		msgStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true)
 	default:
 		msgStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("255"))
 	}

--- a/internal/tui/components/eventlog_test.go
+++ b/internal/tui/components/eventlog_test.go
@@ -378,3 +378,31 @@ func TestSetFullNumbersReRender(t *testing.T) {
 		t.Error("expected abbreviated '1.5k' with fullNumbers=false")
 	}
 }
+
+// TestAddEventsWarningRendered verifies that warning events are rendered in
+// the log with their message text and the amber+bold style defined for the
+// "warning" case in renderSingleEvent (Foreground 214 + Bold).
+func TestAddEventsWarningRendered(t *testing.T) {
+	e := NewEventLog()
+	e = e.SetSize(80, 20)
+
+	e = e.AddEvents([]Event{
+		{
+			Type:      "warning",
+			Message:   "Could not capture on eth0: permission denied",
+			Timestamp: time.Now(),
+		},
+	})
+
+	view := e.View()
+	if !strings.Contains(view, "Could not capture on eth0") {
+		t.Error("expected warning message text in view")
+	}
+	// lipgloss renders Foreground(214) + Bold() as the ANSI sequence below.
+	// Asserting it pins the visual style so a regression (e.g. dropping the
+	// case back to the white default) is caught automatically.
+	const amberBoldAnsi = "\x1b[1;38;5;214m"
+	if !strings.Contains(view, amberBoldAnsi) {
+		t.Errorf("expected warning text to be rendered with amber+bold ANSI %q, got view without it", amberBoldAnsi)
+	}
+}

--- a/internal/tui/components/statusbar.go
+++ b/internal/tui/components/statusbar.go
@@ -16,6 +16,7 @@ type StatusBar struct {
 	packetsPerSec  float64
 	eventsDecoded  uint64
 	eventsDropped  uint64
+	warningCount   uint64
 	bufferUsage    int
 	bufferCapacity int
 	uptime         string
@@ -52,6 +53,14 @@ func (s StatusBar) SetPlayerName(name string) StatusBar {
 // omitted from the status bar (before the first ChangeCluster is captured).
 func (s StatusBar) SetZone(zone string) StatusBar {
 	s.currentZone = zone
+	return s
+}
+
+// SetWarningCount updates the capture-device warning counter. When greater
+// than zero, the status bar shows a "⚠ Warnings: N" badge so the user knows
+// some capture interfaces were skipped at startup.
+func (s StatusBar) SetWarningCount(n uint64) StatusBar {
+	s.warningCount = n
 	return s
 }
 
@@ -145,6 +154,17 @@ func (s StatusBar) View() string {
 			eventsDisplay = fmt.Sprintf("Events: %d  %s",
 				s.eventsDecoded,
 				dropStyle.Render(fmt.Sprintf("⚠ Dropped: %d", s.eventsDropped)))
+		}
+
+		// Capture-device warnings (e.g. interfaces that failed to open) are
+		// shown in amber so they are visually distinct from event drops.
+		if s.warningCount > 0 {
+			warnStyle := lipgloss.NewStyle().
+				Foreground(lipgloss.Color("214")). // Yellow
+				Bold(true)
+			eventsDisplay = fmt.Sprintf("%s  %s",
+				eventsDisplay,
+				warnStyle.Render(fmt.Sprintf("⚠ Warnings: %d", s.warningCount)))
 		}
 
 		stats = statsStyle.Render(fmt.Sprintf(

--- a/internal/tui/components/statusbar_test.go
+++ b/internal/tui/components/statusbar_test.go
@@ -250,3 +250,65 @@ func TestStatusBarViewNoZoneWhenOffline(t *testing.T) {
 		t.Error("expected no zone indicator when offline")
 	}
 }
+
+// ============================================
+// SetWarningCount tests
+// ============================================
+
+func TestStatusBarSetWarningCount(t *testing.T) {
+	s := NewStatusBar()
+	s = s.SetWarningCount(3)
+
+	if s.warningCount != 3 {
+		t.Errorf("expected warningCount=3, got %d", s.warningCount)
+	}
+}
+
+func TestStatusBarViewWarningShownWhenCount(t *testing.T) {
+	s := NewStatusBar()
+	s = s.SetWidth(120)
+	s = s.SetOnline(true)
+	s = s.SetWarningCount(2)
+
+	output := s.View()
+
+	if !strings.Contains(output, "Warnings") {
+		t.Error("expected 'Warnings' badge in view when warningCount > 0")
+	}
+	if !strings.Contains(output, "2") {
+		t.Error("expected warning count '2' in view")
+	}
+}
+
+func TestStatusBarViewNoWarningWhenZero(t *testing.T) {
+	s := NewStatusBar()
+	s = s.SetWidth(120)
+	s = s.SetOnline(true)
+	// warningCount defaults to 0
+
+	output := s.View()
+
+	if strings.Contains(output, "Warnings") {
+		t.Error("expected no 'Warnings' badge when warningCount = 0")
+	}
+}
+
+// TestStatusBarViewHidesWarningWhenOffline pins the intended boundary: the
+// warning badge lives in the online-only stats line. When offline, the status
+// bar shows the waiting message instead, so the warning counter must not leak
+// through. (Warnings are still visible in the event log regardless of status.)
+func TestStatusBarViewHidesWarningWhenOffline(t *testing.T) {
+	s := NewStatusBar()
+	s = s.SetWidth(120)
+	s = s.SetOnline(false)
+	s = s.SetWarningCount(5)
+
+	output := s.View()
+
+	if strings.Contains(output, "Warnings") {
+		t.Error("expected warning badge to be hidden when offline")
+	}
+	if !strings.Contains(output, "Waiting for Albion Online traffic...") {
+		t.Error("expected offline waiting message in view")
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -49,6 +49,10 @@ type Model struct {
 	debugHidden  map[events.EventCode]bool // codes currently suppressed from the log
 	filterOpen   bool
 	filterCursor int
+
+	// Capture-device warnings accumulated from warning events (e.g. interfaces
+	// that failed to open at startup). Surfaced as a counter in the status bar.
+	warningCount uint64
 }
 
 // Tab indices for navigation. Kept as constants so the help bar and key
@@ -290,6 +294,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 
+			// Capture-device warnings are accumulated into a counter that the
+			// status bar renders next to the events drop indicator.
+			if eventMsg.Type == "warning" {
+				m.warningCount++
+			}
+
 			logEvents = append(logEvents, components.Event{
 				Type:      eventMsg.Type,
 				Message:   displayMsg,
@@ -300,6 +310,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Add all events to log at once (efficient batch render)
 		m.eventLog = m.eventLog.AddEvents(logEvents)
+
+		// Keep the status bar warning counter in sync after each batch.
+		m.statusBar = m.statusBar.SetWarningCount(m.warningCount)
 
 		// Continue listening for events
 		if m.bulkEventChan != nil {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -759,3 +759,38 @@ func TestViewHelpBarTabIndicator(t *testing.T) {
 		t.Error("expected [ZONE] indicator on zone tab")
 	}
 }
+
+// ============================================
+// BulkEventMsg warning count tests
+// ============================================
+
+// TestBulkEventWarningCountIncrement verifies that warning events emitted by
+// the backend (e.g. when a capture device fails to open) increment the model's
+// warning counter, which is then forwarded to the status bar.
+func TestBulkEventWarningCountIncrement(t *testing.T) {
+	m := readyModel()
+
+	if m.warningCount != 0 {
+		t.Fatalf("expected initial warningCount=0, got %d", m.warningCount)
+	}
+
+	bulkMsg := BulkEventMsg{
+		{Type: "warning", Message: "Could not capture on eth0", Timestamp: time.Now()},
+		{Type: "warning", Message: "Could not capture on wlan0", Timestamp: time.Now()},
+		{Type: "fame", Message: "ignored", Timestamp: time.Now()},
+	}
+
+	m = updateModel(m, bulkMsg)
+
+	if m.warningCount != 2 {
+		t.Errorf("expected warningCount=2 after batch with 2 warnings, got %d", m.warningCount)
+	}
+
+	// Forwarding to status bar is verified indirectly: setting the model
+	// online and rendering the dashboard view must surface the warning badge.
+	m = updateModel(m, OnlineMsg{Online: true})
+	dashView := m.View().Content
+	if !strings.Contains(dashView, "Warnings") {
+		t.Error("expected 'Warnings' badge in dashboard view after forwarding count to status bar")
+	}
+}

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -3,6 +3,8 @@ package backend
 import (
 	"testing"
 	"time"
+
+	"github.com/cantalupo555/albion-lens/pkg/photon"
 )
 
 // ============================================
@@ -194,6 +196,7 @@ func TestEventTypeConstants(t *testing.T) {
 		{EventTypeDeath, "death"},
 		{EventTypeRespec, "respec"},
 		{EventTypeInfo, "info"},
+		{EventTypeWarning, "warning"},
 		{EventTypeZone, "zone"},
 	}
 
@@ -433,4 +436,87 @@ func TestDefaultBufferSizeConstants(t *testing.T) {
 	if defaultStatsBufferSize != 10 {
 		t.Errorf("defaultStatsBufferSize: expected 10, got %d", defaultStatsBufferSize)
 	}
+}
+
+// ============================================
+// emitEvent helper tests
+// ============================================
+
+// newServiceWithParser builds a minimal Service suitable for exercising the
+// emitEvent helper without invoking the full Start() path. The events channel
+// is set to the requested buffer size and a real parser/stats instance is
+// attached so the dropped-events counter is exercised.
+func newServiceWithParser(t *testing.T, eventBuffer int) *Service {
+	t.Helper()
+	s := New(WithEventBufferSize(eventBuffer))
+	// Attach a parser so emitEvent can increment EventsDropped on the drop
+	// branch. We use the real photon.NewParser with a nil handler because we
+	// never feed it packets — only Stats is accessed.
+	s.parser = photon.NewParser(nil)
+	if s.parser == nil || s.parser.Stats == nil {
+		t.Fatalf("failed to construct parser with stats")
+	}
+	return s
+}
+
+// TestEmitEvent_SendsWhenSpaceAvailable verifies the happy path: with an empty
+// channel the event lands in eventsChan and nothing is dropped.
+func TestEmitEvent_SendsWhenSpaceAvailable(t *testing.T) {
+	s := newServiceWithParser(t, 2)
+
+	s.emitEvent(GameEvent{Type: EventTypeInfo, Message: "hello", Timestamp: time.Now()})
+
+	select {
+	case got := <-s.eventsChan:
+		if got.Message != "hello" {
+			t.Errorf("expected message 'hello', got %q", got.Message)
+		}
+	default:
+		t.Error("expected event to be delivered, but channel is empty")
+	}
+	if dropped := s.parser.Stats.GetEventsDropped(); dropped != 0 {
+		t.Errorf("expected 0 dropped events, got %d", dropped)
+	}
+}
+
+// TestEmitEvent_DropsWhenChannelFull exercises the default branch: when the
+// channel buffer is full the event is dropped and EventsDropped is incremented.
+func TestEmitEvent_DropsWhenChannelFull(t *testing.T) {
+	s := newServiceWithParser(t, 1)
+
+	// Fill the single-slot buffer.
+	s.emitEvent(GameEvent{Type: EventTypeInfo, Message: "first", Timestamp: time.Now()})
+	// Second emit must hit the default branch (channel full).
+	s.emitEvent(GameEvent{Type: EventTypeInfo, Message: "second", Timestamp: time.Now()})
+
+	if dropped := s.parser.Stats.GetEventsDropped(); dropped != 1 {
+		t.Errorf("expected 1 dropped event, got %d", dropped)
+	}
+
+	// Only the first event should be in the channel.
+	got := <-s.eventsChan
+	if got.Message != "first" {
+		t.Errorf("expected only 'first' to be buffered, got %q", got.Message)
+	}
+	select {
+	case extra := <-s.eventsChan:
+		t.Errorf("expected channel to be empty after one receive, got %q", extra.Message)
+	default:
+		// expected
+	}
+}
+
+// TestEmitEvent_NilParserDoesNotPanic verifies the helper tolerates a missing
+// parser/stats (e.g. when called during teardown races).
+func TestEmitEvent_NilParserDoesNotPanic(t *testing.T) {
+	s := New(WithEventBufferSize(1))
+	// s.parser is nil by default on a freshly constructed Service.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("emitEvent panicked with nil parser: %v", r)
+		}
+	}()
+	// Fill buffer then overflow to exercise the nil-stats branch of the default.
+	s.emitEvent(GameEvent{Type: EventTypeInfo, Message: "first", Timestamp: time.Now()})
+	s.emitEvent(GameEvent{Type: EventTypeInfo, Message: "dropped", Timestamp: time.Now()})
 }

--- a/pkg/backend/events.go
+++ b/pkg/backend/events.go
@@ -8,14 +8,15 @@ import "time"
 type EventType string
 
 const (
-	EventTypeFame   EventType = "fame"
-	EventTypeSilver EventType = "silver"
-	EventTypeLoot   EventType = "loot"
-	EventTypeKill   EventType = "kill"
-	EventTypeDeath  EventType = "death"
-	EventTypeRespec EventType = "respec"
-	EventTypeInfo   EventType = "info"
-	EventTypeZone   EventType = "zone"
+	EventTypeFame    EventType = "fame"
+	EventTypeSilver  EventType = "silver"
+	EventTypeLoot    EventType = "loot"
+	EventTypeKill    EventType = "kill"
+	EventTypeDeath   EventType = "death"
+	EventTypeRespec  EventType = "respec"
+	EventTypeInfo    EventType = "info"
+	EventTypeWarning EventType = "warning"
+	EventTypeZone    EventType = "zone"
 )
 
 // GameEvent represents a game event for display in frontends

--- a/pkg/backend/service.go
+++ b/pkg/backend/service.go
@@ -109,14 +109,7 @@ func (s *Service) Start() error {
 			s.parser.Stats.UpdateBufferPeak(len(s.eventsChan))
 		}
 
-		select {
-		case s.eventsChan <- event:
-		default:
-			// Channel full, drop event
-			if s.parser != nil && s.parser.Stats != nil {
-				s.parser.Stats.IncrEventsDropped()
-			}
-		}
+		s.emitEvent(event)
 	})
 
 	// Load item database (errors are non-fatal)
@@ -148,18 +141,23 @@ func (s *Service) Start() error {
 		if online {
 			msg = "Albion Online detected! Capturing packets..."
 		}
-		select {
-		case s.eventsChan <- GameEvent{
+		s.emitEvent(GameEvent{
 			Type:      EventTypeInfo,
 			Message:   msg,
 			Timestamp: time.Now(),
-		}:
-		default:
-			// Info event dropped
-			if s.parser != nil && s.parser.Stats != nil {
-				s.parser.Stats.IncrEventsDropped()
-			}
-		}
+		})
+	}
+
+	// Set device error callback: surfaces per-device open failures (partial
+	// failures during Start) as warning events so the user knows some capture
+	// interfaces were skipped. Fatal "no device opened" errors are returned
+	// from Start() instead and handled by the caller.
+	s.capture.DeviceErrorCallback = func(deviceName string, err error) {
+		s.emitEvent(GameEvent{
+			Type:      EventTypeWarning,
+			Message:   fmt.Sprintf("Could not capture on %s: %v", deviceName, err),
+			Timestamp: time.Now(),
+		})
 	}
 
 	// Start stats updater
@@ -210,6 +208,20 @@ func (s *Service) Stop() {
 	close(s.eventsChan)
 	close(s.statsChan)
 	close(s.onlineStatusChan)
+}
+
+// emitEvent sends a game event to the events channel without blocking. If the
+// channel is full the event is dropped and the parser's dropped-events counter
+// is incremented (when available). Centralized so all event sources route
+// through a single place.
+func (s *Service) emitEvent(event GameEvent) {
+	select {
+	case s.eventsChan <- event:
+	default:
+		if s.parser != nil && s.parser.Stats != nil {
+			s.parser.Stats.IncrEventsDropped()
+		}
+	}
 }
 
 // statsUpdater periodically sends stats to the channel.

--- a/pkg/capture/capture.go
+++ b/pkg/capture/capture.go
@@ -3,6 +3,7 @@
 package capture
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -34,10 +35,17 @@ const (
 // PacketHandler is a callback function for received packets
 type PacketHandler func(payload []byte, srcIP, dstIP net.IP, srcPort, dstPort uint16)
 
+// deviceOpener abstracts pcap.OpenLive so capture startup logic can be tested
+// without requiring raw-socket privileges or a real network device.
+type deviceOpener func(device string, snapshotLen int32, promisc bool, timeout time.Duration) (*pcap.Handle, error)
+
 // Capture handles Albion Online network traffic capture
 type Capture struct {
 	handles []*pcap.Handle
 	handler PacketHandler
+
+	// opener is used by openDevice. Defaults to pcap.OpenLive; injectable for tests.
+	opener deviceOpener
 
 	// Hot path: checked on every packet
 	running atomic.Bool
@@ -49,10 +57,11 @@ type Capture struct {
 	wg sync.WaitGroup
 
 	// Status tracking (updated per-packet, protected by mutex)
-	mu             sync.Mutex
-	lastPacketTime time.Time
-	isOnline       bool
-	OnlineCallback func(online bool)
+	mu                  sync.Mutex
+	lastPacketTime      time.Time
+	isOnline            bool
+	OnlineCallback      func(online bool)
+	DeviceErrorCallback func(deviceName string, err error)
 }
 
 // NewCapture creates a new network capture instance
@@ -60,7 +69,18 @@ func NewCapture(handler PacketHandler) *Capture {
 	return &Capture{
 		handler: handler,
 		handles: make([]*pcap.Handle, 0),
+		opener:  pcap.OpenLive,
 	}
+}
+
+// NewCaptureWithOpener creates a capture instance with a custom device opener.
+// Intended for tests that need to simulate open failures without a real device.
+func NewCaptureWithOpener(handler PacketHandler, opener deviceOpener) *Capture {
+	c := NewCapture(handler)
+	if opener != nil {
+		c.opener = opener
+	}
+	return c
 }
 
 // ListDevices returns all available network devices
@@ -90,7 +110,18 @@ func PrintDevices() error {
 	return nil
 }
 
-// Start begins capturing packets on all available interfaces
+// Start begins capturing packets on all available interfaces.
+//
+// Devices are opened synchronously so that an honest error can be returned
+// when none of them can be captured (e.g. missing privileges). Each device
+// that fails to open is reported via DeviceErrorCallback (when set); only the
+// "all failed" case returns an error, since partial failures still leave the
+// capture functional.
+//
+// The returned error aggregates every per-device failure so callers can
+// surface the full diagnostic context (which device failed and why) even
+// when the TUI — the usual consumer of DeviceErrorCallback — has not started
+// yet (e.g. when main.go exits immediately on Start error).
 func (s *Capture) Start() error {
 	devices, err := ListDevices()
 	if err != nil {
@@ -99,64 +130,124 @@ func (s *Capture) Start() error {
 
 	s.running.Store(true)
 
-	// Start capturing on all devices with IPv4 addresses
-	for _, device := range devices {
-		for _, addr := range device.Addresses {
-			if addr.IP.To4() != nil {
-				s.wg.Add(1)
-				go s.captureOnDevice(device.Name, addr.IP.String())
+	// Deduplicate by device name. The previous implementation spawned one
+	// goroutine per IPv4 address, opening the same device multiple times when
+	// it had several IPv4 addresses (causing duplicate packets or EBUSY).
+	deviceNames := selectDevices(devices)
+
+	// Collect per-device errors so the fatal "all failed" return value can
+	// carry the full diagnostic context, not just a generic hint. The callback
+	// still fires for each failure so partial-success callers stay informed.
+	var openErrors []error
+	for _, name := range deviceNames {
+		handle, err := s.openDevice(name)
+		if err != nil {
+			openErrors = append(openErrors, fmt.Errorf("%s: %w", name, err))
+			if s.DeviceErrorCallback != nil {
+				s.DeviceErrorCallback(name, err)
 			}
+			continue
 		}
+		s.launchDevice(handle)
 	}
 
-	// Start online status checker
+	if len(s.handles) == 0 {
+		s.running.Store(false)
+		return fmt.Errorf("failed to open any capture device: tried %d device(s), all failed (errors: %w). Common cause: insufficient permissions — try running with sudo",
+			len(deviceNames), errors.Join(openErrors...))
+	}
+
+	// Start online status checker only when at least one device is capturing.
 	s.wg.Add(1)
 	go s.checkOnlineStatus()
 
 	return nil
 }
 
-// StartOnDevice begins capturing packets on a specific device
+// StartOnDevice begins capturing packets on a specific device.
+//
+// The device is opened synchronously so callers learn immediately whether
+// capture actually started.
 func (s *Capture) StartOnDevice(deviceName string) error {
 	s.running.Store(true)
 
-	s.wg.Add(1)
-	go s.captureOnDevice(deviceName, "")
+	handle, err := s.openDevice(deviceName)
+	if err != nil {
+		s.running.Store(false)
+		if s.DeviceErrorCallback != nil {
+			s.DeviceErrorCallback(deviceName, err)
+		}
+		return fmt.Errorf("failed to open device %q: %w", deviceName, err)
+	}
 
-	// Start online status checker
+	s.launchDevice(handle)
+
 	s.wg.Add(1)
 	go s.checkOnlineStatus()
 
 	return nil
 }
 
-// captureOnDevice captures packets on a specific network device
-func (s *Capture) captureOnDevice(deviceName, ipAddr string) {
-	defer s.wg.Done()
-
-	handle, err := pcap.OpenLive(deviceName, SnapshotLen, Promiscuous, Timeout)
-	if err != nil {
-		return
+// selectDevices returns the unique device names that have at least one IPv4
+// address. It is a pure function so it can be unit-tested without pcap.
+func selectDevices(devices []pcap.Interface) []string {
+	seen := make(map[string]bool, len(devices))
+	names := make([]string, 0, len(devices))
+	for _, device := range devices {
+		if seen[device.Name] {
+			continue
+		}
+		for _, addr := range device.Addresses {
+			if addr.IP.To4() != nil {
+				names = append(names, device.Name)
+				seen[device.Name] = true
+				break
+			}
+		}
 	}
+	return names
+}
 
-	// Set BPF filter
+// openDevice opens a pcap handle on deviceName and applies the BPF filter.
+// Returns an error describing which step failed so callers can report it.
+func (s *Capture) openDevice(deviceName string) (*pcap.Handle, error) {
+	handle, err := s.opener(deviceName, SnapshotLen, Promiscuous, Timeout)
+	if err != nil {
+		return nil, fmt.Errorf("open: %w", err)
+	}
 	if err := handle.SetBPFFilter(BPFFilter); err != nil {
 		handle.Close()
-		return
+		return nil, fmt.Errorf("bpf filter: %w", err)
 	}
+	return handle, nil
+}
 
+// launchDevice registers an already-opened handle and starts its packet-read
+// goroutine. Centralized so the handle/WaitGroup/goroutine sequence stays in
+// sync between Start and StartOnDevice.
+func (s *Capture) launchDevice(handle *pcap.Handle) {
 	s.handlesMu.Lock()
 	s.handles = append(s.handles, handle)
 	s.handlesMu.Unlock()
 
-	// Use NextPacket() loop instead of Packets() channel.
-	// This avoids the 1000-packet channel buffer and background goroutine
-	// that leaks on shutdown when the channel is full.
+	s.wg.Add(1)
+	go s.readPackets(handle)
+}
+
+// readPackets runs the packet read loop on handle until s.running becomes false.
+// Uses NextPacket() instead of Packets() channel to avoid the 1000-packet
+// channel buffer and background goroutine that leaks on shutdown when full.
+//
+// The caller must balance the WaitGroup: wg.Add(1) before launching the
+// goroutine, this function calls wg.Done() on return.
+func (s *Capture) readPackets(handle *pcap.Handle) {
+	defer s.wg.Done()
+
 	packetSource := gopacket.NewPacketSource(handle, handle.LinkType())
 
 	for {
 		if !s.running.Load() {
-			break
+			return
 		}
 
 		packet, err := packetSource.NextPacket()

--- a/pkg/capture/capture_test.go
+++ b/pkg/capture/capture_test.go
@@ -1,0 +1,306 @@
+package capture
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/gopacket/pcap"
+)
+
+// failingOpener always returns an error, simulating a device that cannot be
+// opened (e.g. insufficient permissions).
+func failingOpener(_ string, _ int32, _ bool, _ time.Duration) (*pcap.Handle, error) {
+	return nil, errors.New("permission denied")
+}
+
+// noopHandler is a PacketHandler that discards every packet.
+func noopHandler(_ []byte, _, _ net.IP, _, _ uint16) {}
+
+// ============================================
+// selectDevices tests (pure function, no pcap required)
+// ============================================
+
+func TestSelectDevices_EmptyInput(t *testing.T) {
+	got := selectDevices(nil)
+	if len(got) != 0 {
+		t.Errorf("expected empty slice for nil input, got %v", got)
+	}
+}
+
+func TestSelectDevices_FiltersNonIPv4(t *testing.T) {
+	devices := []pcap.Interface{
+		{
+			Name: "ipv6only",
+			Addresses: []pcap.InterfaceAddress{
+				{IP: net.ParseIP("::1")},
+			},
+		},
+	}
+	got := selectDevices(devices)
+	if len(got) != 0 {
+		t.Errorf("expected no device for IPv6-only interface, got %v", got)
+	}
+}
+
+// TestSelectDevices_DeduplicatesMultipleIPv4 verifies the bug fix: previously
+// Start opened one handle per IPv4 address, so a device with several IPv4
+// addresses was opened multiple times. selectDevices must return the device
+// name only once.
+func TestSelectDevices_DeduplicatesMultipleIPv4(t *testing.T) {
+	devices := []pcap.Interface{
+		{
+			Name: "eth0",
+			Addresses: []pcap.InterfaceAddress{
+				{IP: net.ParseIP("192.168.1.10")},
+				{IP: net.ParseIP("10.0.0.5")},
+			},
+		},
+	}
+	got := selectDevices(devices)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 device (deduped), got %d: %v", len(got), got)
+	}
+	if got[0] != "eth0" {
+		t.Errorf("expected 'eth0', got %q", got[0])
+	}
+}
+
+func TestSelectDevices_MultipleDevicesEachOnce(t *testing.T) {
+	devices := []pcap.Interface{
+		{Name: "eth0", Addresses: []pcap.InterfaceAddress{{IP: net.ParseIP("10.0.0.1")}}},
+		{Name: "wlan0", Addresses: []pcap.InterfaceAddress{{IP: net.ParseIP("192.168.0.2")}}},
+		// duplicate eth0 entry from a second pcap.Interface (shouldn't normally
+		// happen but selectDevices must be defensive)
+		{Name: "eth0", Addresses: []pcap.InterfaceAddress{{IP: net.ParseIP("10.0.0.9")}}},
+	}
+	got := selectDevices(devices)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 unique devices, got %d: %v", len(got), got)
+	}
+}
+
+// ============================================
+// StartOnDevice tests with injected failing opener
+// ============================================
+
+func TestStartOnDevice_OpenerFails_ReturnsError(t *testing.T) {
+	c := NewCaptureWithOpener(noopHandler, failingOpener)
+	err := c.StartOnDevice("fake0")
+	if err == nil {
+		t.Fatal("expected error when opener fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "fake0") {
+		t.Errorf("expected error to mention device name 'fake0', got: %v", err)
+	}
+	if c.running.Load() {
+		t.Error("expected running=false after StartOnDevice failure")
+	}
+}
+
+func TestStartOnDevice_OpenerFails_InvokesCallback(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		calls     []struct{ name string }
+		callbacks int
+	)
+
+	c := NewCaptureWithOpener(noopHandler, failingOpener)
+	c.DeviceErrorCallback = func(deviceName string, _ error) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, struct{ name string }{deviceName})
+		callbacks++
+	}
+
+	_ = c.StartOnDevice("fake0")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if callbacks != 1 {
+		t.Errorf("expected DeviceErrorCallback called once, got %d", callbacks)
+	}
+	if len(calls) != 1 || calls[0].name != "fake0" {
+		t.Errorf("expected callback called with 'fake0', got %+v", calls)
+	}
+}
+
+func TestStartOnDevice_NoCallback_DoesNotPanic(t *testing.T) {
+	c := NewCaptureWithOpener(noopHandler, failingOpener)
+	// DeviceErrorCallback left nil; StartOnDevice must not panic.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("StartOnDevice panicked with nil callback: %v", r)
+		}
+	}()
+	_ = c.StartOnDevice("fake0")
+}
+
+// ============================================
+// Start tests with injected failing opener
+// ============================================
+
+// TestStart_AllOpenersFail_ReturnsError exercises the synchronous open path
+// when every selected device fails. It depends on pcap.FindAllDevs returning
+// at least one IPv4 device (the loopback interface qualifies on most CI
+// runners); if none is present, the test is skipped.
+//
+// (Originally planned as TestStart_NoRealDevices_ReturnsError — same intent,
+// renamed to reflect the actual mechanism: failing opens rather than missing
+// devices, since the latter is rare on dev/CI machines.)
+func TestStart_AllOpenersFail_ReturnsError(t *testing.T) {
+	devices, err := pcap.FindAllDevs()
+	if err != nil {
+		t.Skipf("pcap.FindAllDevs unavailable in this environment: %v", err)
+	}
+	if len(selectDevices(devices)) == 0 {
+		t.Skip("no IPv4 devices available; cannot exercise Start() failure path")
+	}
+
+	c := NewCaptureWithOpener(noopHandler, failingOpener)
+	err = c.Start()
+	if err == nil {
+		// Cleanup: stop any goroutines that may have started if a device
+		// unexpectedly succeeded.
+		c.Stop()
+		t.Fatal("expected error when all device opens fail, got nil")
+	}
+	if !strings.Contains(err.Error(), "sudo") {
+		t.Errorf("expected error to mention 'sudo' hint, got: %v", err)
+	}
+	// The aggregated error must carry the per-device diagnostic context so
+	// that callers (main.go) can surface which interface failed even though
+	// the TUI never starts to consume DeviceErrorCallback events.
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Errorf("expected aggregated error to include per-device failure reason, got: %v", err)
+	}
+	if c.running.Load() {
+		t.Error("expected running=false after Start() total failure")
+	}
+}
+
+// TestStart_NoDevicesAvailable exercises the corner case where pcap reports no
+// IPv4 device at all. In that scenario Start() must still fail honestly (with
+// a descriptive error) rather than silently starting zero goroutines. The test
+// is skipped on hosts that do have IPv4 devices, since that is the realistic
+// production environment.
+func TestStart_NoDevicesAvailable(t *testing.T) {
+	devices, err := pcap.FindAllDevs()
+	if err != nil {
+		t.Skipf("pcap.FindAllDevs unavailable: %v", err)
+	}
+	if len(selectDevices(devices)) > 0 {
+		t.Skip("host has IPv4 devices; cannot exercise the no-devices path")
+	}
+
+	c := NewCapture(noopHandler)
+	err = c.Start()
+	if err == nil {
+		c.Stop()
+		t.Fatal("expected error when no IPv4 devices are available, got nil")
+	}
+}
+
+// TestStart_AllOpenersFail_InvokesCallbackPerDevice verifies that partial
+// failure reporting fires for each device that fails to open.
+func TestStart_AllOpenersFail_InvokesCallbackPerDevice(t *testing.T) {
+	devices, err := pcap.FindAllDevs()
+	if err != nil {
+		t.Skipf("pcap.FindAllDevs unavailable: %v", err)
+	}
+	names := selectDevices(devices)
+	if len(names) == 0 {
+		t.Skip("no IPv4 devices available")
+	}
+
+	var (
+		mu    sync.Mutex
+		count int
+	)
+	c := NewCaptureWithOpener(noopHandler, failingOpener)
+	c.DeviceErrorCallback = func(_ string, _ error) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+	}
+
+	_ = c.Start()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if count != len(names) {
+		t.Errorf("expected callback called %d times (one per device), got %d", len(names), count)
+	}
+}
+
+// ============================================
+// Constructor tests
+// ============================================
+
+func TestNewCapture_DefaultOpenerIsPcapOpenLive(t *testing.T) {
+	c := NewCapture(noopHandler)
+	if c.opener == nil {
+		t.Fatal("expected default opener to be non-nil")
+	}
+	// We cannot compare function pointers portably, but invoking it with a
+	// bogus device must behave like pcap.OpenLive (i.e. return an error).
+	_, err := c.opener("definitely-not-a-device", SnapshotLen, Promiscuous, Timeout)
+	if err == nil {
+		t.Error("expected default opener to fail for a non-existent device")
+	}
+}
+
+func TestNewCaptureWithOpener_NilOpenerFallsBackToDefault(t *testing.T) {
+	c := NewCaptureWithOpener(noopHandler, nil)
+	if c.opener == nil {
+		t.Fatal("expected fallback to default opener when nil is injected")
+	}
+}
+
+func TestNewCaptureWithOpener_UsesInjectedOpener(t *testing.T) {
+	called := false
+	injected := func(_ string, _ int32, _ bool, _ time.Duration) (*pcap.Handle, error) {
+		called = true
+		return nil, errors.New("injected failure")
+	}
+	c := NewCaptureWithOpener(noopHandler, injected)
+	_ = c.StartOnDevice("any")
+
+	if !called {
+		t.Error("expected injected opener to be called")
+	}
+}
+
+// TestStartOnDevice_OpenerSucceeds_ReturnsNil exercises the happy path with a
+// real device: StartOnDevice must return nil and leave the Capture in the
+// running state. Uses the loopback interface ("lo" on Linux) which is usually
+// openable without elevated privileges; skipped when not available.
+func TestStartOnDevice_OpenerSucceeds_ReturnsNil(t *testing.T) {
+	const loopback = "lo"
+	// Probe whether lo can actually be opened in this environment.
+	probe, err := pcap.OpenLive(loopback, SnapshotLen, Promiscuous, Timeout)
+	if err != nil {
+		t.Skipf("cannot open loopback device %q without privileges: %v", loopback, err)
+	}
+	probe.Close()
+
+	c := NewCapture(noopHandler)
+	if err := c.StartOnDevice(loopback); err != nil {
+		t.Fatalf("expected nil error opening %s, got: %v", loopback, err)
+	}
+	if !c.running.Load() {
+		t.Error("expected running=true after successful StartOnDevice")
+	}
+	if len(c.handles) != 1 {
+		t.Errorf("expected 1 registered handle, got %d", len(c.handles))
+	}
+
+	// Cleanup must drain the readPackets goroutine and close the handle.
+	c.Stop()
+	if c.running.Load() {
+		t.Error("expected running=false after Stop()")
+	}
+}


### PR DESCRIPTION
## Summary
Fixes silent capture startup failures by surfacing device open errors to the user via warning events and an honest error return when no devices can be opened. Previously, running without root/CAP_NET_RAW caused the TUI to appear healthy while never capturing any packets.

## Bug Description
- **What was happening:** `Start()` and `StartOnDevice()` spawned goroutines to open pcap devices asynchronously, so errors were dropped on the floor. The TUI showed an online status but no packets were ever captured.
- **Expected behavior:** When all devices fail to open, `Start()` should return an aggregated error including a "sudo" hint. When individual devices fail, warnings should be visible in the event log and status bar so the user knows which interfaces were skipped.
- **Root cause:** Asynchronous device opening meant failures were never propagated. A pre-existing bug also opened one handle per IPv4 address instead of per device name, causing duplicate handles and EBUSY errors on multi-homed interfaces.

## Changes Made
- `pkg/capture/capture.go`: Refactored startup to open devices synchronously. `Start()` returns an aggregated error (via `errors.Join`) with a "sudo" hint when all devices fail. Per-device failures reported via `DeviceErrorCallback`. Added injectable `deviceOpener` for testability. Fixed pre-existing duplicate-open bug by deduplicating devices by name in `selectDevices`. Split monolithic `captureOnDevice` into `openDevice`, `launchDevice`, and `readPackets`.
- `pkg/backend/`: Added `EventTypeWarning`. Centralized non-blocking event emission with drop counting in `emitEvent` helper. Wired `DeviceErrorCallback` to emit warning events so per-device failures reach the frontend.
- `internal/tui/`: Event log renders `warning` events in amber bold (color 214). Status bar shows a warning badge when online and warnings are present. Model accumulates warning counts from `BulkEventMsg` and forwards them to the status bar.

## Testing
- [x] Tested locally
- [x] Unit tests added/updated
- [x] No regressions

## Related Issues
Fixes #53

## Breaking Changes
None for in-repo consumers. `Capture.Start()` and `Capture.StartOnDevice()` now return errors on failure instead of `nil` — this is the intended fix and the only caller (`pkg/backend/service.go`) is already adapted.

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

This PR fixes silent capture startup failures by surfacing device open errors to the user instead of dropping them asynchronously. Device opening is now synchronous, per-device warnings reach the TUI event log and status bar, and `Start()` returns an aggregated error when all devices fail. The fix also resolves a duplicate-handle bug on multi-homed interfaces by deduplicating devices by name.

---
<sup>Written for commit 3be6ab9fad3229a592cdf7c624f2fd5e675d1e37. Summary will update on new commits.</sup>
<!-- end-auto-generated -->