### PR TITLE
feat(capture): align BPF filter with Albion Photon ports and make it configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Cross-platform network analyzer for Albion Online written in Go.
 
 ## Features
 
-- UDP packet capture for Albion Online (ports 5055/5056)
+- UDP packet capture for Albion Online (ports 5055/5056/5058)
 - Photon Engine protocol parser
 - Protocol18 decoding
 - Fame (XP) tracking with session counting

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -113,6 +113,26 @@ func TestWithBPFFilter(t *testing.T) {
 	}
 }
 
+// TestWithBPFFilter_EmptyString documents the backward-compatibility
+// contract: passing an empty filter is equivalent to omitting the option,
+// because capture.NewCaptureWithFilter falls back to the default BPFFilter
+// when handed an empty string. The backend must store exactly what it
+// received so the fallback can happen at the capture layer.
+func TestWithBPFFilter_EmptyString(t *testing.T) {
+	s := New(WithBPFFilter(""))
+
+	if s.bpfFilter != "" {
+		t.Errorf("empty filter should be stored as empty string, got '%s'", s.bpfFilter)
+	}
+
+	// Omitting the option must produce the same stored state so that
+	// capture.NewCaptureWithFilter behaves identically in both cases.
+	without := New()
+	if without.bpfFilter != s.bpfFilter {
+		t.Errorf("WithBPFFilter(\"\") = %q, omitting = %q; must match", s.bpfFilter, without.bpfFilter)
+	}
+}
+
 // TestWithEventBufferSize tests event buffer size option
 func TestWithEventBufferSize(t *testing.T) {
 	s := New(WithEventBufferSize(500))

--- a/pkg/backend/service.go
+++ b/pkg/backend/service.go
@@ -123,10 +123,13 @@ func (s *Service) Start() error {
 	s.parser.Stats.BufferCapacity = cap(s.eventsChan) // Set once at startup
 	// Note: Parser debug is not enabled because it uses fmt.Printf which interferes with TUI
 
-	// Create capture
-	s.capture = capture.NewCapture(func(payload []byte, srcIP, dstIP net.IP, srcPort, dstPort uint16) {
+	// Create capture. NewCaptureWithFilter falls back to the default Albion
+	// port set when s.bpfFilter is empty, so WithBPFFilter("") and omitting
+	// the option behave identically.
+	packetHandler := func(payload []byte, srcIP, dstIP net.IP, srcPort, dstPort uint16) {
 		_ = s.parser.ParsePacket(payload)
-	})
+	}
+	s.capture = capture.NewCaptureWithFilter(packetHandler, s.bpfFilter)
 
 	// Set online/offline callback
 	s.capture.OnlineCallback = func(online bool) {

--- a/pkg/capture/capture.go
+++ b/pkg/capture/capture.go
@@ -1,5 +1,5 @@
 // Package capture handles network packet capture using gopacket/pcap.
-// It filters for Albion Online traffic on UDP ports 5055, 5056, and TCP port 4535.
+// It filters for Albion Online traffic on UDP ports 5055, 5056, and 5058.
 package capture
 
 import (
@@ -17,12 +17,12 @@ import (
 
 const (
 	// Albion Online uses these ports for game traffic
-	PortMaster = 5055 // Master/Login Server (UDP)
-	PortGame   = 5056 // Game Server (UDP)
-	PortChat   = 4535 // Chat Server (TCP)
+	PortMaster    = 5055 // Master/Login Server (UDP)
+	PortGame      = 5056 // Game Server (UDP)
+	PortPhotonAlt = 5058 // Alternative Photon Server (UDP)
 
 	// BPF filter for Albion Online traffic
-	BPFFilter = "udp and (port 5055 or port 5056)"
+	BPFFilter = "udp and (port 5055 or port 5056 or port 5058)"
 
 	// Capture settings
 	// Large enough to capture full UDP datagrams regardless of MTU/VPN/tunneling.
@@ -43,6 +43,11 @@ type deviceOpener func(device string, snapshotLen int32, promisc bool, timeout t
 type Capture struct {
 	handles []*pcap.Handle
 	handler PacketHandler
+
+	// bpfFilter is the BPF expression applied to each opened device.
+	// Defaults to BPFFilter; overridable via NewCaptureWithFilter so that
+	// the backend can forward WithBPFFilter() options down to the capture.
+	bpfFilter string
 
 	// opener is used by openDevice. Defaults to pcap.OpenLive; injectable for tests.
 	opener deviceOpener
@@ -67,9 +72,10 @@ type Capture struct {
 // NewCapture creates a new network capture instance
 func NewCapture(handler PacketHandler) *Capture {
 	return &Capture{
-		handler: handler,
-		handles: make([]*pcap.Handle, 0),
-		opener:  pcap.OpenLive,
+		handler:   handler,
+		handles:   make([]*pcap.Handle, 0),
+		opener:    pcap.OpenLive,
+		bpfFilter: BPFFilter,
 	}
 }
 
@@ -79,6 +85,18 @@ func NewCaptureWithOpener(handler PacketHandler, opener deviceOpener) *Capture {
 	c := NewCapture(handler)
 	if opener != nil {
 		c.opener = opener
+	}
+	return c
+}
+
+// NewCaptureWithFilter creates a capture instance with a custom BPF filter
+// expression. Intended for callers (e.g. the backend Service) that need to
+// override the default Albion port set. If filter is empty, the default
+// BPFFilter is used, preserving backward compatibility.
+func NewCaptureWithFilter(handler PacketHandler, filter string) *Capture {
+	c := NewCapture(handler)
+	if filter != "" {
+		c.bpfFilter = filter
 	}
 	return c
 }
@@ -215,7 +233,7 @@ func (s *Capture) openDevice(deviceName string) (*pcap.Handle, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open: %w", err)
 	}
-	if err := handle.SetBPFFilter(BPFFilter); err != nil {
+	if err := handle.SetBPFFilter(s.bpfFilter); err != nil {
 		handle.Close()
 		return nil, fmt.Errorf("bpf filter: %w", err)
 	}
@@ -354,4 +372,9 @@ func (s *Capture) IsOnline() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.isOnline
+}
+
+// BPFFilter returns the BPF expression currently applied when opening devices.
+func (s *Capture) BPFFilter() string {
+	return s.bpfFilter
 }

--- a/pkg/capture/capture_test.go
+++ b/pkg/capture/capture_test.go
@@ -24,6 +24,39 @@ func noopHandler(_ []byte, _, _ net.IP, _, _ uint16) {}
 // selectDevices tests (pure function, no pcap required)
 // ============================================
 
+// TestBPFFilter_IncludesAllPhotonUdpPorts guarantees the default filter
+// captures every Photon UDP port used by Albion Online and never regresses
+// to the legacy state (missing 5058, or mentioning the non-existent 4535).
+func TestBPFFilter_IncludesAllPhotonUdpPorts(t *testing.T) {
+	for _, port := range []string{"5055", "5056", "5058"} {
+		if !strings.Contains(BPFFilter, port) {
+			t.Errorf("BPFFilter must include port %s, got: %s", port, BPFFilter)
+		}
+	}
+	// TCP 4535 was a documentation artifact; it must never come back.
+	if strings.Contains(BPFFilter, "4535") {
+		t.Errorf("BPFFilter must not include legacy TCP port 4535, got: %s", BPFFilter)
+	}
+	// Filter must remain UDP-only — TCP parsing is not implemented.
+	if !strings.HasPrefix(BPFFilter, "udp") {
+		t.Errorf("BPFFilter must be UDP-only, got: %s", BPFFilter)
+	}
+}
+
+// TestPortConstants_NoLegacyPortChat documents the removal of the PortChat
+// constant (which referenced a non-existent Albion service port) and guards
+// against accidental reintroduction.
+func TestPortConstants_NoLegacyPortChat(t *testing.T) {
+	for _, p := range []int{PortMaster, PortGame, PortPhotonAlt} {
+		if p == 4535 {
+			t.Error("no Photon port constant should equal the legacy 4535 value")
+		}
+	}
+	if PortPhotonAlt != 5058 {
+		t.Errorf("PortPhotonAlt must be 5058, got %d", PortPhotonAlt)
+	}
+}
+
 func TestSelectDevices_EmptyInput(t *testing.T) {
 	got := selectDevices(nil)
 	if len(got) != 0 {
@@ -274,6 +307,34 @@ func TestNewCaptureWithOpener_UsesInjectedOpener(t *testing.T) {
 	}
 }
 
+// TestNewCapture_DefaultFilterMatchesConstant verifies that a capture created
+// via NewCapture uses the package-level BPFFilter as its default.
+func TestNewCapture_DefaultFilterMatchesConstant(t *testing.T) {
+	c := NewCapture(noopHandler)
+	if c.BPFFilter() != BPFFilter {
+		t.Errorf("default bpfFilter = %q, want %q", c.BPFFilter(), BPFFilter)
+	}
+}
+
+// TestNewCaptureWithFilter_OverridesDefault verifies that a non-empty custom
+// filter reaches the Capture instance and is exposed via BPFFilter().
+func TestNewCaptureWithFilter_OverridesDefault(t *testing.T) {
+	const custom = "udp port 9999"
+	c := NewCaptureWithFilter(noopHandler, custom)
+	if c.BPFFilter() != custom {
+		t.Errorf("bpfFilter = %q, want %q", c.BPFFilter(), custom)
+	}
+}
+
+// TestNewCaptureWithFilter_EmptyFallsBackToDefault verifies that an empty
+// filter string preserves backward compatibility by falling back to BPFFilter.
+func TestNewCaptureWithFilter_EmptyFallsBackToDefault(t *testing.T) {
+	c := NewCaptureWithFilter(noopHandler, "")
+	if c.BPFFilter() != BPFFilter {
+		t.Errorf("empty filter should fall back to BPFFilter; got %q", c.BPFFilter())
+	}
+}
+
 // TestStartOnDevice_OpenerSucceeds_ReturnsNil exercises the happy path with a
 // real device: StartOnDevice must return nil and leave the Capture in the
 // running state. Uses the loopback interface ("lo" on Linux) which is usually
@@ -302,5 +363,38 @@ func TestStartOnDevice_OpenerSucceeds_ReturnsNil(t *testing.T) {
 	c.Stop()
 	if c.running.Load() {
 		t.Error("expected running=false after Stop()")
+	}
+}
+
+// TestStartOnDevice_InvalidCustomFilter_Fails verifies that openDevice
+// actually consumes s.bpfFilter (the per-instance field) rather than the
+// package-level BPFFilter constant. It does so by installing an invalid BPF
+// expression via NewCaptureWithFilter: if openDevice still used the hardcoded
+// constant, the valid default filter would compile and the device would open
+// successfully — making this test fail. Conversely, when s.bpfFilter is
+// honored, SetBPFFilter rejects the invalid expression and StartOnDevice
+// returns an error wrapped with "bpf filter".
+//
+// Skipped when the loopback device cannot be opened (e.g. CI without pcap
+// privileges), matching the pattern in TestStartOnDevice_OpenerSucceeds_ReturnsNil.
+func TestStartOnDevice_InvalidCustomFilter_Fails(t *testing.T) {
+	const loopback = "lo"
+	probe, err := pcap.OpenLive(loopback, SnapshotLen, Promiscuous, Timeout)
+	if err != nil {
+		t.Skipf("cannot open loopback device %q without privileges: %v", loopback, err)
+	}
+	probe.Close()
+
+	c := NewCaptureWithFilter(noopHandler, "this is not a valid bpf expression !!!")
+	err = c.StartOnDevice(loopback)
+	if err == nil {
+		c.Stop()
+		t.Fatal("expected StartOnDevice to fail for an invalid custom BPF filter, got nil")
+	}
+	if !strings.Contains(err.Error(), "bpf filter") {
+		t.Errorf("expected error to mention 'bpf filter', got: %v", err)
+	}
+	if c.running.Load() {
+		t.Error("expected running=false after StartOnDevice failure")
 	}
 }


### PR DESCRIPTION
## Summary
Aligns the default BPF capture filter with the actual Albion Online Photon ports (adding UDP 5058, removing the dead TCP 4535) and exposes a configurable BPF filter path so the backend's `WithBPFFilter` option actually takes effect. Closes #56.

## Motivation
The default BPF filter was out of sync with Albion's real traffic: it referenced a non-existent TCP chat port (4535) while silently omitting UDP 5058, causing legitimate game traffic to be dropped. Additionally, the backend's `WithBPFFilter` option was stored but never propagated to the capture layer, leaving users with no way to customize the filter.

Investigation of the reference project [AlbionOnline-StatisticsAnalysis](https://github.com/ByteArray16/AlbionOnline-StatisticsAnalysis) confirmed:
- `4535` never appears in their codebase — the real TCP ports are `4530/4531/4533`, and even those are listed but not parsed.
- `5058` is a real Photon UDP port (listed alongside `5055/5056` in `PhotonPorts.Udp`), treated identically to the others.

## Changes Made
- Removed the dead `PortChat = 4535` constant and excluded TCP 4535 from the default BPF filter
- Added `PortPhotonAlt = 5058` and included it in the default `BPFFilter` alongside 5055/5056
- Introduced `NewCaptureWithFilter` and a per-instance `bpfFilter` field so callers can override the default filter
- Wired `Service.WithBPFFilter` through `capture.NewCaptureWithFilter` so custom filters are no longer ignored (previously a dead option)
- Added contract tests verifying the default filter, custom filter propagation, and empty-string backward compatibility
- Updated README to document the corrected port list

## Testing
- [x] Tested locally
- [x] Unit tests added
- [x] Documentation updated

7 new tests covering: filter contents, removed constant guard, constructor default/override/empty-fallback, backend empty-string option, and an integration test proving `openDevice` honors the instance-level filter.

## Breaking Changes
None. The default filter now captures additional (legitimate) traffic on UDP 5058, but no API or configuration contracts were broken. The removed `PortChat` constant had zero external references. Custom filters remain optional, and an empty filter falls back to the default behavior.

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

Aligns the default BPF capture filter with Albion Online's actual Photon ports by adding UDP 5058 and removing the defunct TCP 4535, while wiring the backend's `WithBPFFilter` option through to the capture layer so custom filters actually take effect. New contract tests and updated documentation accompany the changes, with backward compatibility preserved via an empty-string fallback to the default filter.

---
<sup>Written for commit c38aa5843250fb4f43edc4e49c92c16d1d8b503b. Summary will update on new commits.</sup>
<!-- end-auto-generated -->