### PR TITLE
fix(photon): count truncated command streams as malformed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ output/*
 
 # Debug files
 __debug_bin*
+
+# Workflow artifacts (local planning, never committed)
+PLANNING.md
+REMAINING_GAPS.md

--- a/pkg/photon/parser.go
+++ b/pkg/photon/parser.go
@@ -170,9 +170,25 @@ func (p *Parser) ParsePacket(payload []byte) error {
 		}
 	}
 
-	// Process each command
-	for i := 0; i < int(commandCount) && !r.IsEmpty(); i++ {
+	// malformed tracks whether the command stream was truncated. A packet
+	// with a valid Photon header but missing/incomplete commands is still
+	// malformed: the counter choice must reflect that for accurate telemetry.
+	// Any future break-point added to the command loop MUST set this flag.
+	malformed := false
+
+	// Process each command.
+	// Note: !r.IsEmpty() is intentionally NOT in the loop condition. When
+	// remaining bytes run out before commandCount is reached, the inner
+	// `Remaining() < CommandHeaderLength` check catches it and sets the
+	// malformed flag, so a truncated command stream is reported accurately
+	// instead of silently counted as processed.
+	for i := 0; i < int(commandCount); i++ {
 		if r.Remaining() < CommandHeaderLength {
+			malformed = true
+			if p.debug {
+				fmt.Printf("  [Photon] Command header truncated: remaining=%d, need=%d\n",
+					r.Remaining(), CommandHeaderLength)
+			}
 			break
 		}
 
@@ -187,8 +203,9 @@ func (p *Parser) ParsePacket(payload []byte) error {
 		dataLength := int(commandLength) - CommandHeaderLength
 
 		if r.Remaining() < dataLength {
+			malformed = true
 			if p.debug {
-				fmt.Printf("  [Photon] Command length exceeds packet: remaining=%d, need=%d\n", r.Remaining(), dataLength)
+				fmt.Printf("  [Photon] Command data truncated: remaining=%d, need=%d\n", r.Remaining(), dataLength)
 			}
 			break
 		}
@@ -198,6 +215,9 @@ func (p *Parser) ParsePacket(payload []byte) error {
 			if p.debug {
 				fmt.Println("  [Photon] Disconnect command")
 			}
+			// Disconnect is an intentional successful termination: count
+			// it as processed before returning.
+			p.Stats.IncrPacketsProcessed()
 			return nil
 
 		case CommandTypeSendUnreliable:
@@ -220,7 +240,11 @@ func (p *Parser) ParsePacket(payload []byte) error {
 		}
 	}
 
-	p.Stats.IncrPacketsProcessed()
+	if malformed {
+		p.Stats.IncrPacketsMalformed()
+	} else {
+		p.Stats.IncrPacketsProcessed()
+	}
 
 	return nil
 }

--- a/pkg/photon/parser_test.go
+++ b/pkg/photon/parser_test.go
@@ -150,3 +150,144 @@ func TestFragmentTTLConstants(t *testing.T) {
 		t.Errorf("expected FragmentCleanupInterval to be 10s, got %v", FragmentCleanupInterval)
 	}
 }
+
+// photonHeader builds a 12-byte Photon header for tests.
+// Layout: peerId[0:2] | flags | commandCount | timestamp[4] | challenge[4]
+func photonHeader(flags byte, commandCount byte) []byte {
+	h := make([]byte, PhotonHeaderLength)
+	h[2] = flags
+	h[3] = commandCount
+	return h
+}
+
+// commandHeader builds a 12-byte Photon command header for tests.
+// commandLength is the total length INCLUDING the 12-byte header itself,
+// matching the parser's interpretation (dataLength = commandLength - CommandHeaderLength).
+func commandHeader(commandType byte, commandLength uint32) []byte {
+	h := make([]byte, CommandHeaderLength)
+	h[0] = commandType
+	h[4] = byte(commandLength >> 24)
+	h[5] = byte(commandLength >> 16)
+	h[6] = byte(commandLength >> 8)
+	h[7] = byte(commandLength)
+	return h
+}
+
+// TestParsePacket_CommandHeaderTruncated verifies that a packet with a valid
+// Photon header but no command bytes (commandCount > 0 but buffer empty) is
+// counted as malformed, not processed.
+func TestParsePacket_CommandHeaderTruncated(t *testing.T) {
+	handler := &mockHandler{}
+	parser := NewParser(handler)
+	defer parser.Close()
+
+	// 12-byte header claims 1 command, but no command bytes follow.
+	payload := photonHeader(0, 1)
+
+	if err := parser.ParsePacket(payload); err != nil {
+		t.Fatalf("ParsePacket returned error: %v", err)
+	}
+
+	if got := parser.Stats.GetPacketsMalformed(); got != 1 {
+		t.Errorf("PacketsMalformed = %d, want 1", got)
+	}
+	if got := parser.Stats.GetPacketsProcessed(); got != 0 {
+		t.Errorf("PacketsProcessed = %d, want 0", got)
+	}
+}
+
+// TestParsePacket_CommandDataTruncated verifies that a packet whose command
+// header advertises more data bytes than actually present is counted as
+// malformed.
+func TestParsePacket_CommandDataTruncated(t *testing.T) {
+	handler := &mockHandler{}
+	parser := NewParser(handler)
+	defer parser.Close()
+
+	// Header (commandCount=1) + command header claiming commandLength=100
+	// (dataLength=88) but no data bytes follow.
+	payload := append(photonHeader(0, 1), commandHeader(0, 100)...)
+
+	if err := parser.ParsePacket(payload); err != nil {
+		t.Fatalf("ParsePacket returned error: %v", err)
+	}
+
+	if got := parser.Stats.GetPacketsMalformed(); got != 1 {
+		t.Errorf("PacketsMalformed = %d, want 1", got)
+	}
+	if got := parser.Stats.GetPacketsProcessed(); got != 0 {
+		t.Errorf("PacketsProcessed = %d, want 0", got)
+	}
+}
+
+// TestParsePacket_NoCommands_Processed verifies that a packet with commandCount=0
+// (ack-only) is counted as processed, not malformed.
+func TestParsePacket_NoCommands_Processed(t *testing.T) {
+	handler := &mockHandler{}
+	parser := NewParser(handler)
+	defer parser.Close()
+
+	payload := photonHeader(0, 0)
+
+	if err := parser.ParsePacket(payload); err != nil {
+		t.Fatalf("ParsePacket returned error: %v", err)
+	}
+
+	if got := parser.Stats.GetPacketsProcessed(); got != 1 {
+		t.Errorf("PacketsProcessed = %d, want 1", got)
+	}
+	if got := parser.Stats.GetPacketsMalformed(); got != 0 {
+		t.Errorf("PacketsMalformed = %d, want 0", got)
+	}
+}
+
+// TestParsePacket_ValidUnknownCommand_Processed verifies that a well-formed
+// packet with an unknown command type (hits the default branch) is counted
+// as processed. commandLength=12 means dataLength=0, so no payload bytes
+// are expected.
+func TestParsePacket_ValidUnknownCommand_Processed(t *testing.T) {
+	handler := &mockHandler{}
+	parser := NewParser(handler)
+	defer parser.Close()
+
+	// Header (commandCount=1) + command header with commandType=99 (unknown,
+	// hits default branch) and commandLength=12 (dataLength=0).
+	payload := append(photonHeader(0, 1), commandHeader(99, uint32(CommandHeaderLength))...)
+
+	if err := parser.ParsePacket(payload); err != nil {
+		t.Fatalf("ParsePacket returned error: %v", err)
+	}
+
+	if got := parser.Stats.GetPacketsProcessed(); got != 1 {
+		t.Errorf("PacketsProcessed = %d, want 1", got)
+	}
+	if got := parser.Stats.GetPacketsMalformed(); got != 0 {
+		t.Errorf("PacketsMalformed = %d, want 0", got)
+	}
+}
+
+// TestParsePacket_Disconnect_Processed verifies that a well-formed packet
+// carrying a Disconnect command is counted as processed. This guards the
+// IncrPacketsProcessed() call before the early return in the Disconnect
+// case (parser.go:220): if that line is accidentally removed, the processed
+// counter would silently under-count disconnect packets.
+func TestParsePacket_Disconnect_Processed(t *testing.T) {
+	handler := &mockHandler{}
+	parser := NewParser(handler)
+	defer parser.Close()
+
+	// Header (commandCount=1) + command header with commandType=Disconnect
+	// and commandLength=12 (dataLength=0).
+	payload := append(photonHeader(0, 1), commandHeader(CommandTypeDisconnect, uint32(CommandHeaderLength))...)
+
+	if err := parser.ParsePacket(payload); err != nil {
+		t.Fatalf("ParsePacket returned error: %v", err)
+	}
+
+	if got := parser.Stats.GetPacketsProcessed(); got != 1 {
+		t.Errorf("PacketsProcessed = %d, want 1 (Disconnect must be counted as processed)", got)
+	}
+	if got := parser.Stats.GetPacketsMalformed(); got != 0 {
+		t.Errorf("PacketsMalformed = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary
Fixes a telemetry accuracy bug in the Photon packet parser where packets with valid headers but truncated command streams were incorrectly counted as processed rather than malformed. Also corrects a pre-existing gap where intentional `Disconnect` commands were not counted as processed due to an early return bypassing the counter increment.

## Bug Description
- **What was happening:** `ParsePacket` unconditionally incremented `PacketsProcessed` at the end, even when the command loop exited early via `break` due to a truncated command header or truncated command data. The `!r.IsEmpty()` loop condition further masked truncation by short-circuiting before the inner length checks could run. Separately, the `CommandTypeDisconnect` case returned `nil` early without incrementing any counter.
- **Expected behavior:** Packets whose command stream is incomplete should increment `PacketsMalformed`; fully valid packets (including intentional Disconnect terminations) should increment `PacketsProcessed`.
- **Root cause:** (1) No `malformed` flag existed to communicate truncation from the inner loop back to the final counter increment. (2) `!r.IsEmpty()` in the loop condition prevented the inner `Remaining() < CommandHeaderLength` guard from ever triggering when the payload was exactly 12 bytes with `commandCount > 0`. (3) The Disconnect early return skipped `IncrPacketsProcessed()`.

## Changes Made
- Introduced a `malformed` boolean flag in `ParsePacket`, set to `true` whenever the command header or command data is truncated inside the loop
- Removed `!r.IsEmpty()` from the loop condition so truncation is reliably detected by the inner length checks rather than being short-circuited
- Added `IncrPacketsProcessed()` immediately before the `Disconnect` early return so intentional disconnects are counted as processed
- Replaced the unconditional `IncrPacketsProcessed()` call with conditional logic: increment `PacketsMalformed` when `malformed == true`, otherwise increment `PacketsProcessed`
- Added 5 unit tests covering truncated header, truncated data, empty command list, unknown command, and Disconnect early-return paths
- Added test helpers `photonHeader` and `commandHeader` for building deterministic Photon packet payloads
- Updated `.gitignore` to exclude local workflow artifacts (`PLANNING.md`, `REMAINING_GAPS.md`)

## Testing
- [x] Tested locally (`go vet`, `go test ./...`, `go test -race ./pkg/photon/`)
- [x] Unit tests added/updated (5 new tests)
- [x] No regressions (all 9 packages pass)

## Breaking Changes
None. The change aligns counter semantics with their documented intent (`PacketsProcessed` = "successfully processed"). Internal behavior correction; no exported API, struct field, or type changes.

## Related Issues
Closes #72

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

This PR fixes telemetry accuracy in the Photon packet parser by correctly counting packets with truncated command streams as malformed instead of processed, and ensuring intentional `Disconnect` commands increment `PacketsProcessed`. Key changes include a `malformed` flag to track truncation, removing the short-circuiting `!r.IsEmpty()` loop condition, and adding conditional counter logic with 5 new unit tests for the affected paths.

---
<sup>Written for commit 39a3b00bf47900d29059c000a70fa54f037e1338. Summary will update on new commits.</sup>
<!-- end-auto-generated -->