### PR TITLE
fix(backend): wait for goroutines before closing channels

### DIFF
--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -540,3 +540,88 @@ func TestEmitEvent_NilParserDoesNotPanic(t *testing.T) {
 	s.emitEvent(GameEvent{Type: EventTypeInfo, Message: "first", Timestamp: time.Now()})
 	s.emitEvent(GameEvent{Type: EventTypeInfo, Message: "dropped", Timestamp: time.Now()})
 }
+
+// ============================================
+// Tests for goroutine lifecycle (Start/Stop)
+// ============================================
+
+// newServiceWithStatsUpdater builds a minimal Service with a parser and the
+// statsUpdater goroutine running, without invoking the full Start() path
+// (which requires pcap). Suitable for exercising Stop() lifecycle.
+func newServiceWithStatsUpdater(t *testing.T) *Service {
+	t.Helper()
+	s := New()
+	s.parser = photon.NewParser(nil)
+	if s.parser == nil || s.parser.Stats == nil {
+		t.Fatalf("failed to construct parser with stats")
+	}
+	s.mu.Lock()
+	s.running = true
+	s.mu.Unlock()
+	s.wg.Add(1)
+	go s.statsUpdater()
+	return s
+}
+
+// TestServiceStopClosesAllChannels verifies that Stop() closes all three
+// public-facing channels (Events, Stats, OnlineStatus).
+func TestServiceStopClosesAllChannels(t *testing.T) {
+	s := newServiceWithStatsUpdater(t)
+
+	s.Stop()
+
+	_, ok := <-s.Events
+	if ok {
+		t.Error("Events channel not closed after Stop()")
+	}
+
+	_, ok = <-s.Stats
+	if ok {
+		t.Error("Stats channel not closed after Stop()")
+	}
+
+	_, ok = <-s.OnlineStatus
+	if ok {
+		t.Error("OnlineStatus channel not closed after Stop()")
+	}
+}
+
+// TestServiceStatsUpdaterExitsCleanly verifies that the statsUpdater goroutine
+// has fully exited after Stop() returns. Stop() blocks on wg.Wait(), so
+// returning here means statsUpdater called wg.Done(). Calling wg.Wait() again
+// is a no-op that confirms the counter is zero.
+func TestServiceStatsUpdaterExitsCleanly(t *testing.T) {
+	s := newServiceWithStatsUpdater(t)
+
+	s.Stop()
+
+	// Should return immediately — statsUpdater already called Done().
+	s.wg.Wait()
+}
+
+// TestServiceStopIdempotent verifies that calling Stop() multiple times does
+// not panic (the running flag guards re-entry).
+func TestServiceStopIdempotent(t *testing.T) {
+	s := newServiceWithStatsUpdater(t)
+
+	s.Stop()
+	s.Stop()
+	s.Stop()
+}
+
+// TestServiceStopNoPanicOnRapidTeardown exercises the scenario from issue #73:
+// Stop() called while statsUpdater may still be active. The WaitGroup ensures
+// channels are only closed after the goroutine exits, preventing any
+// send-on-closed-channel panic. Run with -race for definitive detection.
+func TestServiceStopNoPanicOnRapidTeardown(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		s := newServiceWithStatsUpdater(t)
+
+		// Fill statsChan so the non-blocking send exercises the default path.
+		for j := 0; j < cap(s.statsChan); j++ {
+			s.statsChan <- s.parser.Stats
+		}
+
+		s.Stop()
+	}
+}

--- a/pkg/backend/service.go
+++ b/pkg/backend/service.go
@@ -37,6 +37,7 @@ type Service struct {
 	parser   *photon.Parser
 	capture  *capture.Capture
 	stopChan chan struct{}
+	wg       sync.WaitGroup // Tracks statsUpdater goroutine
 
 	// Public channels (read-only for frontends)
 	Events       <-chan GameEvent
@@ -164,6 +165,7 @@ func (s *Service) Start() error {
 	}
 
 	// Start stats updater
+	s.wg.Add(1)
 	go s.statsUpdater()
 
 	// Start capture
@@ -184,7 +186,9 @@ func (s *Service) Start() error {
 	return nil
 }
 
-// Stop stops the service and cleans up resources.
+// Stop stops the service and cleans up resources. It blocks until the
+// statsUpdater goroutine has fully exited, then closes all public channels.
+// Safe to call multiple times (subsequent calls are no-ops).
 func (s *Service) Stop() {
 	s.mu.Lock()
 	if !s.running {
@@ -206,6 +210,10 @@ func (s *Service) Stop() {
 	if s.parser != nil {
 		s.parser.Close()
 	}
+
+	// Wait for statsUpdater to exit before closing channels,
+	// preventing send-on-closed-channel panics during shutdown.
+	s.wg.Wait()
 
 	// Close channels
 	close(s.eventsChan)
@@ -229,6 +237,8 @@ func (s *Service) emitEvent(event GameEvent) {
 
 // statsUpdater periodically sends stats to the channel.
 func (s *Service) statsUpdater() {
+	defer s.wg.Done()
+
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 

--- a/pkg/photon/parser.go
+++ b/pkg/photon/parser.go
@@ -46,6 +46,8 @@ type Parser struct {
 	fragmentsMu      sync.RWMutex // Protects pendingFragments
 	debug            bool
 	stopCleanup      chan struct{} // Signal to stop cleanup goroutine
+	closeOnce        sync.Once     // Ensures Close is idempotent
+	wg               sync.WaitGroup // Tracks cleanupLoop goroutine
 	Stats            *Stats        // Parser statistics
 }
 
@@ -68,6 +70,7 @@ func NewParser(handler PhotonHandler) *Parser {
 	}
 
 	// Start background cleanup goroutine
+	p.wg.Add(1)
 	go p.cleanupLoop()
 
 	return p
@@ -79,13 +82,18 @@ func (p *Parser) SetDebug(debug bool) {
 }
 
 // Close stops the cleanup goroutine and releases resources.
-// Should be called when the parser is no longer needed.
+// Safe to call multiple times. Blocks until the cleanup goroutine has exited.
 func (p *Parser) Close() {
-	close(p.stopCleanup)
+	p.closeOnce.Do(func() {
+		close(p.stopCleanup)
+		p.wg.Wait()
+	})
 }
 
 // cleanupLoop periodically removes expired fragments
 func (p *Parser) cleanupLoop() {
+	defer p.wg.Done()
+
 	ticker := time.NewTicker(FragmentCleanupInterval)
 	defer ticker.Stop()
 

--- a/pkg/photon/parser_test.go
+++ b/pkg/photon/parser_test.go
@@ -46,11 +46,9 @@ func TestParserClose(t *testing.T) {
 	handler := &mockHandler{}
 	parser := NewParser(handler)
 
-	// Close should not panic
+	// Close blocks until cleanupLoop has exited; returning here means the
+	// WaitGroup was satisfied — the goroutine called Done().
 	parser.Close()
-
-	// Give goroutine time to stop
-	time.Sleep(50 * time.Millisecond)
 }
 
 func TestPendingFragmentsCount(t *testing.T) {
@@ -131,13 +129,51 @@ func TestCleanupLoopStops(t *testing.T) {
 	handler := &mockHandler{}
 	parser := NewParser(handler)
 
-	// Close immediately
+	// Close blocks until cleanupLoop exits — no sleep needed.
 	parser.Close()
 
-	// Wait a bit to ensure goroutine has time to stop
-	time.Sleep(100 * time.Millisecond)
+	// Verify stopCleanup was actually closed (proves Close ran).
+	select {
+	case <-parser.stopCleanup:
+		// expected — channel is closed
+	default:
+		t.Error("stopCleanup not closed after Close()")
+	}
+}
 
-	// If we get here without hanging, the test passes
+func TestParserDoubleCloseNoPanic(t *testing.T) {
+	handler := &mockHandler{}
+	parser := NewParser(handler)
+
+	parser.Close()
+	// Second close must not panic (sync.Once guards it).
+	parser.Close()
+}
+
+func TestParserCloseBlocksUntilGoroutineExits(t *testing.T) {
+	handler := &mockHandler{}
+	parser := NewParser(handler)
+
+	// Before Close, stopCleanup must be open.
+	select {
+	case <-parser.stopCleanup:
+		t.Fatal("stopCleanup closed before Close()")
+	default:
+	}
+
+	// Close blocks until cleanupLoop has called wg.Done().
+	parser.Close()
+
+	// After Close, stopCleanup is closed.
+	select {
+	case <-parser.stopCleanup:
+		// expected
+	default:
+		t.Error("stopCleanup not closed after Close()")
+	}
+
+	// wg.Wait() should return immediately — goroutine already exited.
+	parser.wg.Wait()
 }
 
 func TestFragmentTTLConstants(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixed a race condition in backend `Service.Stop()` and photon `Parser.Close()` where background goroutines were not synchronized with channel closure. Without `sync.WaitGroup` tracking, shutdown could race with in-flight sends on `Events`, `Stats`, `OnlineStatus`, and `stopCleanup`, causing intermittent `send on closed channel` panics during rapid teardown. The fix ensures `Stop()` and `Close()` block until their respective goroutines have fully exited before closing any channels, and makes both methods safe to call multiple times.

## Bug Description
- **What was happening:** Calling `Service.Stop()` or `Parser.Close()` closed output channels immediately while `statsUpdater` and `cleanupLoop` could still be running. If a goroutine attempted to send on a channel after it had been closed, the application panicked with `send on closed channel`. This was especially reproducible during rapid teardown (issue #73).
- **Expected behavior:** `Stop()` and `Close()` should wait for their background goroutines to finish all pending work before closing channels, and should tolerate repeated calls without panicking.
- **Root cause:** The goroutines were launched without `sync.WaitGroup` tracking, so the shutdown path had no synchronization point to guarantee the goroutines had exited before channel closure.

## Changes Made
- `pkg/backend/service.go`: Added a `sync.WaitGroup` to `Service`, calling `wg.Add(1)` before launching `statsUpdater` and `defer wg.Done()` inside the goroutine. `Stop()` now calls `wg.Wait()` before closing public channels.
- `pkg/photon/parser.go`: Applied the same WaitGroup pattern to `cleanupLoop`. Added `sync.Once` to make `Parser.Close()` idempotent, preventing double-close panics on `stopCleanup`.
- `pkg/backend/backend_test.go`: Added deterministic regression tests verifying channel closure, goroutine exit via WaitGroup, idempotent `Stop()` behavior, and rapid teardown stress loops.
- `pkg/photon/parser_test.go`: Replaced flaky `time.Sleep`-based assertions with deterministic channel-state and WaitGroup checks; added tests for double-close safety and blocking-until-exit behavior.

## Testing
- [x] Tested locally
- [x] Unit tests added/updated
- [x] No regressions

## Related Issues
Fixes #73

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

Fixed a race condition in `Service.Stop()` and `Parser.Close()` where background goroutines could outlive their output channels, causing `send on closed channel` panics. Added `sync.WaitGroup` synchronization to both `statsUpdater` and `cleanupLoop` so channels are only closed after goroutines fully exit, and made `Close()` idempotent with `sync.Once`. Replaced flaky `time.Sleep`-based tests with deterministic channel-state and WaitGroup assertions.

---
<sup>Written for commit 74395bf2eeb07c48bcf24a2a16fc3f61d000a824. Summary will update on new commits.</sup>
<!-- end-auto-generated -->