### PR TITLE
feat: persist dungeon runs and session stats to disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,3 @@ output/*
 
 # Debug files
 __debug_bin*
-
-# Workflow artifacts (local planning, never committed)
-PLANNING.md
-REMAINING_GAPS.md

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -86,25 +86,32 @@ func main() {
 	defer svc.Stop()
 
 	// --- Persistence (issues #103, #104): restore state, then keep it warm. ---
-	// Resolve XDG data paths first (the directory is created if missing).
+	// Resolve XDG data paths first (the directory is created if missing). If
+	// resolution fails (e.g. HOME unset or data dir read-only), persistence is
+	// disabled entirely: we never pass an empty path to Load/Save, which would
+	// otherwise silently no-op on Load and emit confusing "periodic save
+	// failed" warnings on Save.
 	dungeonPath, err := storage.DataFile("dungeon-runs.json")
 	if err != nil {
-		fmt.Printf("Warning: could not resolve dungeon data path: %v\n", err)
+		fmt.Printf("Warning: persistence disabled, could not resolve dungeon data path: %v\n", err)
 	}
 	statsPath, err := storage.DataFile("session-stats.json")
 	if err != nil {
-		fmt.Printf("Warning: could not resolve stats data path: %v\n", err)
+		fmt.Printf("Warning: persistence disabled, could not resolve stats data path: %v\n", err)
 	}
+	persistenceEnabled := dungeonPath != "" && statsPath != ""
 
 	// Load-on-startup. The handler is created by Start(), so this must run
 	// after it. A missing file is the first-run case (handled as empty state
 	// inside Load); a corrupt file leaves the in-memory state unchanged.
-	if h := svc.Handler(); h != nil {
-		if err := h.LoadDungeonRuns(dungeonPath); err != nil {
-			fmt.Printf("Warning: could not load dungeon history: %v\n", err)
-		}
-		if err := h.LoadSessionStats(statsPath); err != nil {
-			fmt.Printf("Warning: could not load session stats: %v\n", err)
+	if persistenceEnabled {
+		if h := svc.Handler(); h != nil {
+			if err := h.LoadDungeonRuns(dungeonPath); err != nil {
+				fmt.Printf("Warning: could not load dungeon history: %v\n", err)
+			}
+			if err := h.LoadSessionStats(statsPath); err != nil {
+				fmt.Printf("Warning: could not load session stats: %v\n", err)
+			}
 		}
 	}
 
@@ -113,6 +120,9 @@ func main() {
 	saveCtx, saveCancel := context.WithCancel(context.Background())
 	defer saveCancel()
 	go periodicSave(saveCtx, saveInterval, func() error {
+		if !persistenceEnabled {
+			return nil
+		}
 		h := svc.Handler()
 		if h == nil {
 			return nil
@@ -144,12 +154,14 @@ func main() {
 	// Stop the periodic flush, then do a final save-on-exit so the on-disk
 	// state reflects the very last in-memory values.
 	saveCancel()
-	if h := svc.Handler(); h != nil {
-		if err := h.SaveDungeonRuns(dungeonPath); err != nil {
-			fmt.Printf("Warning: could not save dungeon history: %v\n", err)
-		}
-		if err := h.SaveSessionStats(statsPath); err != nil {
-			fmt.Printf("Warning: could not save session stats: %v\n", err)
+	if persistenceEnabled {
+		if h := svc.Handler(); h != nil {
+			if err := h.SaveDungeonRuns(dungeonPath); err != nil {
+				fmt.Printf("Warning: could not save dungeon history: %v\n", err)
+			}
+			if err := h.SaveSessionStats(statsPath); err != nil {
+				fmt.Printf("Warning: could not save session stats: %v\n", err)
+			}
 		}
 	}
 

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/cantalupo555/albion-lens/internal/storage"
 	"github.com/cantalupo555/albion-lens/internal/tui"
 	"github.com/cantalupo555/albion-lens/pkg/backend"
 	"github.com/cantalupo555/albion-lens/pkg/capture"
@@ -18,6 +20,9 @@ const (
 	statsChannelSize     = 10
 	eventBatchSize       = 50
 	eventFlushInterval   = 50 * time.Millisecond
+	// saveInterval is how often the in-memory state is flushed to disk while
+	// the TUI runs, bounding data loss on crash or kill to this window.
+	saveInterval = 5 * time.Minute
 )
 
 func main() {
@@ -80,6 +85,44 @@ func main() {
 	}
 	defer svc.Stop()
 
+	// --- Persistence (issues #103, #104): restore state, then keep it warm. ---
+	// Resolve XDG data paths first (the directory is created if missing).
+	dungeonPath, err := storage.DataFile("dungeon-runs.json")
+	if err != nil {
+		fmt.Printf("Warning: could not resolve dungeon data path: %v\n", err)
+	}
+	statsPath, err := storage.DataFile("session-stats.json")
+	if err != nil {
+		fmt.Printf("Warning: could not resolve stats data path: %v\n", err)
+	}
+
+	// Load-on-startup. The handler is created by Start(), so this must run
+	// after it. A missing file is the first-run case (handled as empty state
+	// inside Load); a corrupt file leaves the in-memory state unchanged.
+	if h := svc.Handler(); h != nil {
+		if err := h.LoadDungeonRuns(dungeonPath); err != nil {
+			fmt.Printf("Warning: could not load dungeon history: %v\n", err)
+		}
+		if err := h.LoadSessionStats(statsPath); err != nil {
+			fmt.Printf("Warning: could not load session stats: %v\n", err)
+		}
+	}
+
+	// Periodic flush while the TUI runs: a crash or kill loses at most
+	// saveInterval of progress. Cancelled after p.Run returns.
+	saveCtx, saveCancel := context.WithCancel(context.Background())
+	defer saveCancel()
+	go periodicSave(saveCtx, saveInterval, func() error {
+		h := svc.Handler()
+		if h == nil {
+			return nil
+		}
+		if err := h.SaveDungeonRuns(dungeonPath); err != nil {
+			return err
+		}
+		return h.SaveSessionStats(statsPath)
+	})
+
 	// Send initial status event (as a batch)
 	bulkEventChan <- tui.BulkEventMsg{
 		{
@@ -96,6 +139,18 @@ func main() {
 	if _, err := p.Run(); err != nil {
 		fmt.Printf("Error running TUI: %v\n", err)
 		os.Exit(1)
+	}
+
+	// Stop the periodic flush, then do a final save-on-exit so the on-disk
+	// state reflects the very last in-memory values.
+	saveCancel()
+	if h := svc.Handler(); h != nil {
+		if err := h.SaveDungeonRuns(dungeonPath); err != nil {
+			fmt.Printf("Warning: could not save dungeon history: %v\n", err)
+		}
+		if err := h.SaveSessionStats(statsPath); err != nil {
+			fmt.Printf("Warning: could not save session stats: %v\n", err)
+		}
 	}
 
 	// In discovery mode, persist the captured event map so unmapped events
@@ -174,6 +229,25 @@ func bridgeEvents(
 
 		case <-ticker.C:
 			flush()
+		}
+	}
+}
+
+// periodicSave calls save at each interval until ctx is cancelled. Used to
+// bound the data-loss window on crash/kill while the TUI is running. A non-nil
+// error from save is surfaced as a warning so the user learns mid-session that
+// persistence has degraded (the final save-on-exit remains the safety net).
+func periodicSave(ctx context.Context, interval time.Duration, save func() error) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := save(); err != nil {
+				fmt.Printf("Warning: periodic save failed: %v\n", err)
+			}
 		}
 	}
 }

--- a/cmd/tui/main_test.go
+++ b/cmd/tui/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -155,4 +158,67 @@ func TestConstantsHaveExpectedValues(t *testing.T) {
 	if eventFlushInterval != 50*time.Millisecond {
 		t.Errorf("expected eventFlushInterval=50ms, got %v", eventFlushInterval)
 	}
+	if saveInterval != 5*time.Minute {
+		t.Errorf("expected saveInterval=5m, got %v", saveInterval)
+	}
 }
+
+// ============================================
+// periodicSave tests
+// ============================================
+
+func TestPeriodicSaveFiresAndStopsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls atomic.Int32
+
+	done := make(chan struct{})
+	go func() {
+		periodicSave(ctx, 10*time.Millisecond, func() error {
+			calls.Add(1)
+			return nil
+		})
+		close(done)
+	}()
+
+	// Allow at least one tick to fire.
+	time.Sleep(35 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// goroutine exited cleanly after cancel
+	case <-time.After(time.Second):
+		t.Fatal("periodicSave did not exit after cancel")
+	}
+
+	if calls.Load() < 1 {
+		t.Errorf("expected periodic save to fire at least once, got %d", calls.Load())
+	}
+}
+
+func TestPeriodicSaveContinuesAfterError(t *testing.T) {
+	// A failing save must not stop the loop; it should keep ticking until
+	// cancelled so the user can recover if the filesystem issue is transient.
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls atomic.Int32
+
+	done := make(chan struct{})
+	go func() {
+		periodicSave(ctx, 10*time.Millisecond, func() error {
+			calls.Add(1)
+			return errBoom
+		})
+		close(done)
+	}()
+
+	time.Sleep(35 * time.Millisecond)
+	cancel()
+	<-done
+
+	if calls.Load() < 2 {
+		t.Errorf("expected periodic save to keep firing after errors, got %d calls", calls.Load())
+	}
+}
+
+// errBoom is a sentinel error used only by TestPeriodicSaveContinuesAfterError.
+var errBoom = errors.New("boom")

--- a/internal/storage/paths.go
+++ b/internal/storage/paths.go
@@ -1,0 +1,42 @@
+// Package storage provides atomic JSON persistence for app state, porting the
+// reference repository's FileController (atomic tmp+rename writes with crash
+// recovery on load) to an XDG-compliant data directory.
+package storage
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// appName is the per-application subdirectory under the XDG data dir.
+const appName = "albion-lens"
+
+// DataDir resolves the application data directory following the XDG Base
+// Directory Specification: $XDG_DATA_HOME/albion-lens, falling back to
+// ~/.local/share/albion-lens when XDG_DATA_HOME is unset. The directory (and
+// any missing parents) are created with mode 0755.
+func DataDir() (string, error) {
+	base := os.Getenv("XDG_DATA_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		base = filepath.Join(home, ".local", "share")
+	}
+	dir := filepath.Join(base, appName)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// DataFile joins the data directory with the given file name. It is a
+// convenience over DataDir for callers that just need a single path.
+func DataFile(name string) (string, error) {
+	dir, err := DataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, name), nil
+}

--- a/internal/storage/paths_test.go
+++ b/internal/storage/paths_test.go
@@ -1,0 +1,59 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDataDirRespectsXDGDataHome(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dir)
+
+	got, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+
+	want := filepath.Join(dir, appName)
+	if got != want {
+		t.Errorf("DataDir = %q, want %q", got, want)
+	}
+	if fi, err := os.Stat(want); err != nil || !fi.IsDir() {
+		t.Errorf("DataDir did not create dir %q (err=%v)", want, err)
+	}
+}
+
+func TestDataDirFallsBackToHome(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", "")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+
+	want := filepath.Join(home, ".local", "share", appName)
+	if got != want {
+		t.Errorf("DataDir = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("fallback dir not created: %v", err)
+	}
+}
+
+func TestDataFileJoinsName(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dir)
+
+	got, err := DataFile("dungeon-runs.json")
+	if err != nil {
+		t.Fatalf("DataFile: %v", err)
+	}
+
+	want := filepath.Join(dir, appName, "dungeon-runs.json")
+	if got != want {
+		t.Errorf("DataFile = %q, want %q", got, want)
+	}
+}

--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -1,0 +1,124 @@
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// locks guards the per-path mutex map.
+var (
+	locksMu sync.Mutex
+	locks   = make(map[string]*sync.Mutex)
+)
+
+// lockFor returns a per-path mutex, creating it on first use. Serializing
+// writes (and tmp promotion) per path prevents concurrent save/load races on
+// the same file without a single global lock.
+func lockFor(path string) *sync.Mutex {
+	locksMu.Lock()
+	defer locksMu.Unlock()
+	if l, ok := locks[path]; ok {
+		return l
+	}
+	l := &sync.Mutex{}
+	locks[path] = l
+	return l
+}
+
+// tmpPath returns the temporary-write sibling path for a final path. It lives
+// in the same directory so os.Rename is atomic (same filesystem).
+func tmpPath(path string) string {
+	return path + ".tmp"
+}
+
+// Save serializes v as indented JSON and writes it atomically: the data is
+// first written to a .tmp sibling and then renamed onto the final path. Rename
+// is atomic on the same filesystem, so a crash leaves either the old or the
+// new file, never a partially-written one.
+func Save(path string, v any) error {
+	l := lockFor(path)
+	l.Lock()
+	defer l.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	tmp := tmpPath(path)
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		// Best-effort cleanup of the orphaned tmp file.
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// Load reads and decodes the JSON file at path into a new T.
+//
+// Crash recovery: if a .tmp sibling exists (left over from a Save interrupted
+// before the rename), it is tried first — a valid .tmp is promoted to the
+// final path, an invalid one is discarded — and then the final path is read.
+//
+// Return contract (callers must respect both cases):
+//   - missing file (and no recoverable .tmp): returns (zero, nil) — the
+//     expected first-run case; treat as empty state without warning.
+//   - existing file that fails to read or decode: returns (zero, err) — log a
+//     warning, since this indicates corruption rather than a first run.
+func Load[T any](path string) (T, error) {
+	var zero T
+
+	l := lockFor(path)
+	l.Lock()
+	defer l.Unlock()
+
+	tmp := tmpPath(path)
+
+	// Crash recovery: a leftover .tmp from an interrupted Save.
+	if _, statErr := os.Stat(tmp); statErr == nil {
+		if v, err := tryDecode[T](tmp); err == nil {
+			// Promote tmp to final. If the rename fails we still return the
+			// recovered value; the next Save will overwrite the final path.
+			_ = os.Rename(tmp, path)
+			return v, nil
+		}
+		// Corrupt tmp: discard and fall through to the final file.
+		_ = os.Remove(tmp)
+	}
+
+	// Final file missing -> first run, empty state (not an error).
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return zero, nil
+	}
+
+	v, err := tryDecode[T](path)
+	if err != nil {
+		return zero, fmt.Errorf("storage: decode %s: %w", path, err)
+	}
+	return v, nil
+}
+
+// tryDecode reads path and unmarshals it into a new T. A nil error indicates
+// success; any I/O or decode failure yields (zero, err).
+func tryDecode[T any](path string) (T, error) {
+	var zero T
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return zero, err
+	}
+	var v T
+	if err := json.Unmarshal(data, &v); err != nil {
+		return zero, err
+	}
+	return v, nil
+}

--- a/internal/storage/store_test.go
+++ b/internal/storage/store_test.go
@@ -1,0 +1,242 @@
+package storage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+type sample struct {
+	Name  string `json:"name"`
+	Value int    `json:"value"`
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "data.json")
+
+	in := sample{Name: "fame", Value: 12345}
+	if err := Save(path, in); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	out, err := Load[sample](path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if out != in {
+		t.Errorf("round-trip = %+v, want %+v", out, in)
+	}
+}
+
+func TestSaveLeavesNoTmpAndCreatesFinal(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "data.json")
+
+	if err := Save(path, sample{Name: "x"}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if _, err := os.Stat(tmpPath(path)); !os.IsNotExist(err) {
+		t.Errorf("tmp file should not exist after Save; stat err=%v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("final file should exist after Save; stat err=%v", err)
+	}
+}
+
+func TestLoadMissingFileReturnsZeroNoError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nope.json")
+
+	v, err := Load[sample](path)
+	if err != nil {
+		t.Errorf("Load missing file returned err: %v", err)
+	}
+	if v != (sample{}) {
+		t.Errorf("Load missing = %+v, want zero value", v)
+	}
+}
+
+func TestLoadCorruptFileReturnsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	v, err := Load[sample](path)
+	if err == nil {
+		t.Fatalf("Load corrupt file should return error, got nil with value %+v", v)
+	}
+	if v != (sample{}) {
+		t.Errorf("Load corrupt = %+v, want zero value", v)
+	}
+}
+
+func TestLoadPromotesValidTmp(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "data.json")
+	tmp := tmpPath(path)
+
+	// Only the tmp file exists — simulating a Save that wrote tmp but crashed
+	// before the rename.
+	good := sample{Name: "recovered", Value: 99}
+	data, err := json.Marshal(good)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	v, err := Load[sample](path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if v != good {
+		t.Errorf("Load = %+v, want promoted %+v", v, good)
+	}
+	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+		t.Errorf("tmp should be gone after promotion; stat err=%v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("final should exist after promotion; stat err=%v", err)
+	}
+}
+
+func TestLoadDiscardsCorruptTmpAndUsesFinal(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "data.json")
+
+	// Corrupt tmp + valid final: the corrupt tmp must be discarded and the
+	// final file used.
+	if err := os.WriteFile(tmpPath(path), []byte("garbage"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	good := sample{Name: "final", Value: 7}
+	data, err := json.Marshal(good)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	v, err := Load[sample](path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if v != good {
+		t.Errorf("Load = %+v, want final %+v", v, good)
+	}
+	if _, err := os.Stat(tmpPath(path)); !os.IsNotExist(err) {
+		t.Errorf("corrupt tmp should have been removed; stat err=%v", err)
+	}
+}
+
+func TestLoadIgnoresUnknownFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "data.json")
+	// Forward-compat: JSON with extra fields not present in the sample struct
+	// decodes successfully (encoding/json ignores unknown fields by default).
+	raw := []byte(`{"name":"x","value":1,"futureField":"ignore-me","extra":42}`)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	v, err := Load[sample](path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if v.Name != "x" || v.Value != 1 {
+		t.Errorf("Load = %+v, want parsed sample", v)
+	}
+}
+
+func TestSaveMarshalErrorPropagates(t *testing.T) {
+	// json.Marshal fails on unsupported types (chan/func). This deterministically
+	// exercises the marshal-error path of Save without any OS/filesystem tricks.
+	path := filepath.Join(t.TempDir(), "bad.json")
+	err := Save(path, map[string]any{"chan": make(chan int)})
+	if err == nil {
+		t.Fatal("expected marshal error for unsupported type, got nil")
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Errorf("final file must not be written when marshal fails; stat err=%v", statErr)
+	}
+}
+
+func TestSaveRenameFailureCleansUpTmp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data.json")
+	tmp := tmpPath(path)
+
+	// Make the final path a non-empty directory so os.Rename(tmp, path) fails
+	// (rename cannot overwrite a non-empty directory). This forces the cleanup
+	// branch in Save.
+	if err := os.MkdirAll(filepath.Join(path, "blocker"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	err := Save(path, sample{Name: "x", Value: 1})
+	if err == nil {
+		t.Fatal("expected Rename error, got nil")
+	}
+	if _, statErr := os.Stat(tmp); !os.IsNotExist(statErr) {
+		t.Errorf("tmp should be removed after rename failure; stat err=%v", statErr)
+	}
+}
+
+func TestLoadRenameFailureStillReturnsRecoveredValue(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data.json")
+	tmp := tmpPath(path)
+
+	// A valid leftover .tmp (interrupted Save) plus a final path that is a
+	// non-empty directory: promotion via os.Rename fails, but Load must still
+	// return the recovered value (best-effort, documented behavior).
+	good := sample{Name: "recovered", Value: 42}
+	data, err := json.Marshal(good)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(path, "blocker"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	v, err := Load[sample](path)
+	if err != nil {
+		t.Fatalf("Load should return recovered value even if rename fails: %v", err)
+	}
+	if v != good {
+		t.Errorf("Load = %+v, want recovered %+v", v, good)
+	}
+}
+
+func TestConcurrentSaveSamePathStaysConsistent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "data.json")
+
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			if err := Save(path, sample{Name: "x", Value: i}); err != nil {
+				t.Errorf("Save %d: %v", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// The final file must be readable and valid regardless of which writer
+	// won the race.
+	v, err := Load[sample](path)
+	if err != nil {
+		t.Fatalf("final Load: %v", err)
+	}
+	if v.Name != "x" {
+		t.Errorf("final = %+v, want name %q", v, "x")
+	}
+	// No leftover tmp after the dust settles.
+	if _, err := os.Stat(tmpPath(path)); !os.IsNotExist(err) {
+		t.Errorf("tmp should not exist after concurrent saves; stat err=%v", err)
+	}
+}

--- a/internal/tui/components/statspanel.go
+++ b/internal/tui/components/statspanel.go
@@ -95,6 +95,25 @@ func (s StatsPanel) IncrLoot() StatsPanel {
 	return s
 }
 
+// SetKills sets the kill counter to an absolute value (used to hydrate the
+// panel from persisted state on startup).
+func (s StatsPanel) SetKills(n int) StatsPanel {
+	s.kills = n
+	return s
+}
+
+// SetDeaths sets the death counter to an absolute value.
+func (s StatsPanel) SetDeaths(n int) StatsPanel {
+	s.deaths = n
+	return s
+}
+
+// SetLoot sets the loot counter to an absolute value.
+func (s StatsPanel) SetLoot(n int) StatsPanel {
+	s.lootCount = n
+	return s
+}
+
 // Reset clears all session stats
 func (s StatsPanel) Reset() StatsPanel {
 	s.fame = 0

--- a/internal/tui/components/statspanel_test.go
+++ b/internal/tui/components/statspanel_test.go
@@ -156,6 +156,48 @@ func TestStatsPanelIncrLoot(t *testing.T) {
 	}
 }
 
+func TestStatsPanelSetKills(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.IncrKills()
+	s = s.IncrKills()
+	s = s.SetKills(10)
+	if s.kills != 10 {
+		t.Errorf("SetKills: expected 10 (absolute), got %d", s.kills)
+	}
+	// Incr after Set adds on top of the absolute value.
+	s = s.IncrKills()
+	if s.kills != 11 {
+		t.Errorf("IncrKills after SetKills: expected 11, got %d", s.kills)
+	}
+}
+
+func TestStatsPanelSetDeaths(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.IncrDeaths()
+	s = s.SetDeaths(5)
+	if s.deaths != 5 {
+		t.Errorf("SetDeaths: expected 5 (absolute), got %d", s.deaths)
+	}
+	s = s.IncrDeaths()
+	if s.deaths != 6 {
+		t.Errorf("IncrDeaths after SetDeaths: expected 6, got %d", s.deaths)
+	}
+}
+
+func TestStatsPanelSetLoot(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.IncrLoot()
+	s = s.IncrLoot()
+	s = s.SetLoot(8)
+	if s.lootCount != 8 {
+		t.Errorf("SetLoot: expected 8 (absolute), got %d", s.lootCount)
+	}
+	s = s.IncrLoot()
+	if s.lootCount != 9 {
+		t.Errorf("IncrLoot after SetLoot: expected 9, got %d", s.lootCount)
+	}
+}
+
 // ============================================
 // Reset tests (full)
 // ============================================

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -87,8 +87,30 @@ func New(svc *backend.Service, bulkEventChan chan BulkEventMsg, statsChan chan *
 	if svc != nil {
 		m.debug = svc.IsDebug()
 		m.onlineChan = svc.OnlineStatus
+		// Hydrate the stats panel with persisted cumulative counters so the
+		// dashboard shows long-term totals immediately rather than zeros.
+		m.statsPanel = hydrateStatsPanel(m.statsPanel, svc.Handler())
 	}
 	return m
+}
+
+// hydrateStatsPanel seeds a stats panel from the handler's current session
+// snapshot. It is a no-op when the handler is nil (e.g. before the backend
+// service has started). Extracted from New so the hydration logic can be
+// tested without a running (pcap-backed) service.
+func hydrateStatsPanel(panel components.StatsPanel, h *handlers.AlbionHandler) components.StatsPanel {
+	if h == nil {
+		return panel
+	}
+	snap := h.SessionSnapshot()
+	return panel.
+		SetFame(snap.Fame).
+		SetSilver(snap.Silver).
+		SetRespec(snap.Respec).
+		SetRespecSilver(snap.RespecSilver).
+		SetKills(int(snap.Kills)).
+		SetDeaths(int(snap.Deaths)).
+		SetLoot(int(snap.Loot))
 }
 
 // defaultHiddenDebugEvents returns the set of high-frequency / low-signal debug

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,11 +1,14 @@
 package tui
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/cantalupo555/albion-lens/internal/tui/components"
 	"github.com/cantalupo555/albion-lens/pkg/backend"
 	"github.com/cantalupo555/albion-lens/pkg/events"
 	"github.com/cantalupo555/albion-lens/pkg/handlers"
@@ -86,6 +89,38 @@ func TestNewModelDefaults(t *testing.T) {
 	}
 	if m.ready {
 		t.Error("expected ready=false by default")
+	}
+}
+
+func TestHydrateStatsPanel(t *testing.T) {
+	h := handlers.NewAlbionHandler()
+
+	// Seed the handler via the public disk-load API: the session counters are
+	// not settable from outside the handlers package.
+	path := filepath.Join(t.TempDir(), "stats.json")
+	seed := []byte(`{"version":1,"fame":123456,"silver":987654,"respec":333,"respec_silver":2222,"kills":42,"deaths":17,"loot":99,"saved_at":"2026-06-29T00:00:00Z"}`)
+	if err := os.WriteFile(path, seed, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := h.LoadSessionStats(path); err != nil {
+		t.Fatalf("LoadSessionStats: %v", err)
+	}
+
+	panel := hydrateStatsPanel(components.NewStatsPanel(), h)
+	// NewStatsPanel defaults to fullNumbers, so fame renders as "+123456".
+	view := panel.View()
+	for _, want := range []string{"123456", "987654", "99 items"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("stats panel view missing %q after hydration\n%s", want, view)
+		}
+	}
+}
+
+func TestHydrateStatsPanelNilHandlerIsNoOp(t *testing.T) {
+	empty := components.NewStatsPanel()
+	got := hydrateStatsPanel(empty, nil)
+	if got.View() != empty.View() {
+		t.Error("hydrateStatsPanel with nil handler should leave the panel unchanged")
 	}
 }
 

--- a/pkg/handlers/albion.go
+++ b/pkg/handlers/albion.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cantalupo555/albion-lens/internal/storage"
 	"github.com/cantalupo555/albion-lens/pkg/events"
 	"github.com/cantalupo555/albion-lens/pkg/items"
 )
@@ -560,6 +561,64 @@ func (h *AlbionHandler) SaveDiscoveredEvents(filename string) error {
 	}
 
 	return os.WriteFile(filename, data, 0644)
+}
+
+// SaveDungeonRuns persists the completed dungeon run history to path as JSON.
+// The active run (if any) is excluded because it is still incomplete. The
+// snapshot is copied under the dungeon lock and the (potentially slow) atomic
+// write happens without holding it, so dungeon tracking is not blocked on I/O.
+func (h *AlbionHandler) SaveDungeonRuns(path string) error {
+	h.dungeonMu.Lock()
+	toSave := make([]*DungeonRun, 0, len(h.dungeonRuns))
+	for _, r := range h.dungeonRuns {
+		if r.Status == RunStatusActive {
+			continue
+		}
+		cp := *r
+		toSave = append(toSave, &cp)
+	}
+	h.dungeonMu.Unlock()
+
+	return storage.Save(path, toSave)
+}
+
+// LoadDungeonRuns replaces the in-memory run history with the runs decoded from
+// path. Runs are sorted oldest-first by EnteredAt and trimmed to
+// maxDungeonRuns. A missing file is treated as an empty history (first run); a
+// corrupt file is returned as err and leaves the current history unchanged. The
+// active run is always reset to nil after a load.
+func (h *AlbionHandler) LoadDungeonRuns(path string) error {
+	runs, err := storage.Load[[]*DungeonRun](path)
+	if err != nil {
+		return err
+	}
+	sort.Slice(runs, func(i, j int) bool {
+		return runs[i].EnteredAt.Before(runs[j].EnteredAt)
+	})
+	if len(runs) > maxDungeonRuns {
+		runs = runs[len(runs)-maxDungeonRuns:]
+	}
+
+	h.dungeonMu.Lock()
+	h.dungeonRuns = runs
+	h.activeRun = nil
+	h.dungeonMu.Unlock()
+	return nil
+}
+
+// DungeonRunsSnapshot returns a defensive copy of the recorded run history
+// (oldest first) for inspection by tests or the UI without holding the handler
+// lock. It is the read-only counterpart to GetDungeonRuns that does not
+// close-gap expired active runs.
+func (h *AlbionHandler) DungeonRunsSnapshot() []*DungeonRun {
+	h.dungeonMu.Lock()
+	defer h.dungeonMu.Unlock()
+	result := make([]*DungeonRun, len(h.dungeonRuns))
+	for i, r := range h.dungeonRuns {
+		cp := *r
+		result[i] = &cp
+	}
+	return result
 }
 
 // GetSessionFame returns the total fame gained in this session

--- a/pkg/handlers/albion.go
+++ b/pkg/handlers/albion.go
@@ -31,26 +31,145 @@ type EventCallback func(eventType, message string, data interface{})
 // testing via AlbionHandler.deathDedupWindow.
 const defaultDeathDedupWindow = 5 * time.Second
 
+// sessionCounters holds the seven cumulative session counters behind a single
+// RWMutex so a snapshot reads all of them consistently (independent atomics
+// would allow a snapshot to mix pre- and post-update values). The lock is
+// fine-grained: event handlers take a write lock per increment, persistence
+// and UI hydration take a read lock for the whole set.
+type sessionCounters struct {
+	mu            sync.RWMutex
+	fame          int64
+	silver        int64
+	respec        int64
+	respecSilver  int64
+	kills         int64
+	deaths        int64
+	loot          int64
+}
+
+// snapshot returns a consistent point-in-time copy of all seven counters.
+func (c *sessionCounters) snapshot() SessionStats {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return SessionStats{
+		Fame:         c.fame,
+		Silver:       c.silver,
+		Respec:       c.respec,
+		RespecSilver: c.respecSilver,
+		Kills:        c.kills,
+		Deaths:       c.deaths,
+		Loot:         c.loot,
+	}
+}
+
+// apply overwrites all seven counters. Used when restoring persisted state.
+func (c *sessionCounters) apply(s SessionStats) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.fame = s.Fame
+	c.silver = s.Silver
+	c.respec = s.Respec
+	c.respecSilver = s.RespecSilver
+	c.kills = s.Kills
+	c.deaths = s.Deaths
+	c.loot = s.Loot
+}
+
+func (c *sessionCounters) addFame(n int64) {
+	c.mu.Lock()
+	c.fame += n
+	c.mu.Unlock()
+}
+
+func (c *sessionCounters) addSilver(n int64) {
+	c.mu.Lock()
+	c.silver += n
+	c.mu.Unlock()
+}
+
+func (c *sessionCounters) addRespec(n int64) {
+	c.mu.Lock()
+	c.respec += n
+	c.mu.Unlock()
+}
+
+func (c *sessionCounters) addRespecSilver(n int64) {
+	c.mu.Lock()
+	c.respecSilver += n
+	c.mu.Unlock()
+}
+
+func (c *sessionCounters) addKill() {
+	c.mu.Lock()
+	c.kills++
+	c.mu.Unlock()
+}
+
+func (c *sessionCounters) addDeath() {
+	c.mu.Lock()
+	c.deaths++
+	c.mu.Unlock()
+}
+
+func (c *sessionCounters) addLoot() {
+	c.mu.Lock()
+	c.loot++
+	c.mu.Unlock()
+}
+
+func (c *sessionCounters) fameNow() int64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.fame
+}
+
+func (c *sessionCounters) silverNow() int64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.silver
+}
+
+func (c *sessionCounters) respecNow() int64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.respec
+}
+
+func (c *sessionCounters) respecSilverNow() int64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.respecSilver
+}
+
+func (c *sessionCounters) killsNow() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return int(c.kills)
+}
+
+func (c *sessionCounters) deathsNow() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return int(c.deaths)
+}
+
+func (c *sessionCounters) lootNow() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return int(c.loot)
+}
+
 // AlbionHandler handles Albion Online game events
 type AlbionHandler struct {
 	debug     bool
 	discovery bool
 
 	// Fame tracking
-	totalFame   atomic.Int64
-	sessionFame atomic.Int64
+	totalFame atomic.Int64
 
-	// Silver tracking
-	sessionSilver atomic.Int64
-
-	// Combat Fame Credits (respec) tracking
-	sessionRespec       atomic.Int64
-	sessionRespecSilver atomic.Int64
-
-	// Kill/Death tracking
-	sessionKills  atomic.Int64
-	sessionDeaths atomic.Int64
-	sessionLoot   atomic.Int64
+	// Cumulative session counters (fame, silver, respec, respecSilver, kills,
+	// deaths, loot). Grouped under one RWMutex so snapshots are consistent.
+	stats sessionCounters
 
 	// Items database
 	itemDB *items.ItemDatabase
@@ -304,17 +423,17 @@ type ZoneEventData struct {
 
 // GetSessionKills returns the number of kills in this session
 func (h *AlbionHandler) GetSessionKills() int {
-	return int(h.sessionKills.Load())
+	return h.stats.killsNow()
 }
 
 // GetSessionDeaths returns the number of deaths in this session
 func (h *AlbionHandler) GetSessionDeaths() int {
-	return int(h.sessionDeaths.Load())
+	return h.stats.deathsNow()
 }
 
 // GetSessionLoot returns the number of loot items in this session
 func (h *AlbionHandler) GetSessionLoot() int {
-	return int(h.sessionLoot.Load())
+	return h.stats.lootNow()
 }
 
 // LoadItemDatabase loads the item database from ao-bin-dumps
@@ -606,39 +725,24 @@ func (h *AlbionHandler) LoadDungeonRuns(path string) error {
 	return nil
 }
 
-// DungeonRunsSnapshot returns a defensive copy of the recorded run history
-// (oldest first) for inspection by tests or the UI without holding the handler
-// lock. It is the read-only counterpart to GetDungeonRuns that does not
-// close-gap expired active runs.
-func (h *AlbionHandler) DungeonRunsSnapshot() []*DungeonRun {
-	h.dungeonMu.Lock()
-	defer h.dungeonMu.Unlock()
-	result := make([]*DungeonRun, len(h.dungeonRuns))
-	for i, r := range h.dungeonRuns {
-		cp := *r
-		result[i] = &cp
-	}
-	return result
-}
-
 // GetSessionFame returns the total fame gained in this session
 func (h *AlbionHandler) GetSessionFame() int64 {
-	return h.sessionFame.Load()
+	return h.stats.fameNow()
 }
 
 // GetSessionSilver returns the total silver looted in this session
 func (h *AlbionHandler) GetSessionSilver() int64 {
-	return h.sessionSilver.Load()
+	return h.stats.silverNow()
 }
 
 // GetSessionRespec returns the total combat fame credits gained in this session
 func (h *AlbionHandler) GetSessionRespec() int64 {
-	return h.sessionRespec.Load()
+	return h.stats.respecNow()
 }
 
 // GetSessionRespecSilver returns the total silver spent on auto-respec this session
 func (h *AlbionHandler) GetSessionRespecSilver() int64 {
-	return h.sessionRespecSilver.Load()
+	return h.stats.respecSilverNow()
 }
 
 // SessionStats is a point-in-time snapshot of the cumulative session counters,
@@ -661,33 +765,15 @@ func (h *AlbionHandler) SessionSnapshot() SessionStats {
 }
 
 // readSessionStats is the single source of truth for reading the seven
-// cumulative counters into a SessionStats. All reads of these atomics for
-// persistence or UI hydration go through here so a new counter only needs to
-// be added in one place.
+// cumulative counters into a consistent SessionStats snapshot.
 func (h *AlbionHandler) readSessionStats() SessionStats {
-	return SessionStats{
-		Fame:         h.sessionFame.Load(),
-		Silver:       h.sessionSilver.Load(),
-		Respec:       h.sessionRespec.Load(),
-		RespecSilver: h.sessionRespecSilver.Load(),
-		Kills:        h.sessionKills.Load(),
-		Deaths:       h.sessionDeaths.Load(),
-		Loot:         h.sessionLoot.Load(),
-	}
+	return h.stats.snapshot()
 }
 
 // applySessionStats is the single source of truth for writing the seven
 // cumulative counters from a SessionStats (the inverse of readSessionStats).
-// All stores of these atomics on load go through here so a new counter only
-// needs to be added in one place.
 func (h *AlbionHandler) applySessionStats(s SessionStats) {
-	h.sessionFame.Store(s.Fame)
-	h.sessionSilver.Store(s.Silver)
-	h.sessionRespec.Store(s.Respec)
-	h.sessionRespecSilver.Store(s.RespecSilver)
-	h.sessionKills.Store(s.Kills)
-	h.sessionDeaths.Store(s.Deaths)
-	h.sessionLoot.Store(s.Loot)
+	h.stats.apply(s)
 }
 
 // sessionStatsFile is the on-disk JSON representation of SessionStats. The
@@ -806,14 +892,14 @@ func (h *AlbionHandler) handleUpdateFame(params map[byte]interface{}) {
 
 		// Only notify if fame was actually gained
 		if fameGainedVal > 0 {
-			h.sessionFame.Add(int64(fameGainedVal))
+			h.stats.addFame(int64(fameGainedVal))
 			h.totalFame.Store(totalFame) // Update tracked total
 
 			// Message formatting is now handled by the frontend (TUI)
 			h.notifyEvent("fame", "", &FameEventData{
 				Gained:  int64(fameGainedVal),
 				Total:   int64(totalFameVal),
-				Session: h.sessionFame.Load(),
+				Session: h.stats.fameNow(),
 			})
 		}
 	} else {
@@ -823,12 +909,12 @@ func (h *AlbionHandler) handleUpdateFame(params map[byte]interface{}) {
 			gained := totalFame - h.totalFame.Load()
 			if gained > 0 {
 				gainedVal := math.Floor(float64(gained) / 10000.0)
-				h.sessionFame.Add(int64(gainedVal))
+				h.stats.addFame(int64(gainedVal))
 				// Message formatting is now handled by the frontend (TUI)
 				h.notifyEvent("fame", "", &FameEventData{
 					Gained:  int64(gainedVal),
 					Total:   int64(totalFameVal),
-					Session: h.sessionFame.Load(),
+					Session: h.stats.fameNow(),
 				})
 			}
 		}
@@ -906,13 +992,13 @@ func (h *AlbionHandler) handleOtherGrabbedLoot(params map[byte]interface{}) {
 		local := h.GetLocalPlayer()
 		counted := local != "" && lootedBy == local
 		if counted {
-			h.sessionSilver.Add(silverAmount)
+			h.stats.addSilver(silverAmount)
 		}
 		// Message formatting is now handled by the frontend (TUI)
 		// We just pass the raw data
 		h.notifyEvent("silver", "", &SilverEventData{
 			Amount:     silverAmount,
-			Session:    h.sessionSilver.Load(),
+			Session:    h.stats.silverNow(),
 			LootedBy:   lootedBy,
 			LootedFrom: lootedFrom,
 			Counted:    counted,
@@ -928,7 +1014,7 @@ func (h *AlbionHandler) handleOtherGrabbedLoot(params map[byte]interface{}) {
 		// player's loot), because the total volume of nearby loot is useful
 		// context. Silver is different — only the local player's silver
 		// contributes to the session total (see the silver branch above).
-		h.sessionLoot.Add(1)
+		h.stats.addLoot()
 
 		// Message formatting is now handled by the frontend (TUI)
 		h.notifyEvent("loot", "", &LootEventData{
@@ -1025,15 +1111,15 @@ func (h *AlbionHandler) handleDied(params map[byte]interface{}) {
 
 	// Count a kill when the local player is the killer.
 	if isLocalKill {
-		h.sessionKills.Add(1)
+		h.stats.addKill()
 		h.notifyEvent("kill", "", &KillEventData{
-			SessionKills: int(h.sessionKills.Load()),
+			SessionKills: h.stats.killsNow(),
 		})
 	}
 
 	// Count a death only when the local player is the victim.
 	if local != "" && victim == local {
-		h.sessionDeaths.Add(1)
+		h.stats.addDeath()
 	}
 
 	// Emit a death event for the local player's death or for nearby deaths
@@ -1043,7 +1129,7 @@ func (h *AlbionHandler) handleDied(params map[byte]interface{}) {
 		h.notifyEvent("death", "", &DeathEventData{
 			Victim:        victim,
 			Killer:        killer,
-			SessionDeaths: int(h.sessionDeaths.Load()),
+			SessionDeaths: h.stats.deathsNow(),
 		})
 	}
 }
@@ -1061,14 +1147,14 @@ func (h *AlbionHandler) handleUpdateReSpecPoints(params map[byte]interface{}) {
 	gainedVal := int64(math.Floor(float64(gainedReSpec) / 10000.0))
 	silverVal := int64(math.Floor(float64(paidSilver) / 10000.0))
 
-	h.sessionRespec.Add(gainedVal)
-	h.sessionRespecSilver.Add(silverVal)
+	h.stats.addRespec(gainedVal)
+	h.stats.addRespecSilver(silverVal)
 
 	h.notifyEvent("respec", "", &RespecEventData{
 		Gained:             gainedVal,
 		PaidSilver:         silverVal,
-		SessionTotal:       h.sessionRespec.Load(),
-		SessionSilverTotal: h.sessionRespecSilver.Load(),
+		SessionTotal:       h.stats.respecNow(),
+		SessionSilverTotal: h.stats.respecSilverNow(),
 	})
 }
 

--- a/pkg/handlers/albion.go
+++ b/pkg/handlers/albion.go
@@ -641,6 +641,119 @@ func (h *AlbionHandler) GetSessionRespecSilver() int64 {
 	return h.sessionRespecSilver.Load()
 }
 
+// SessionStats is a point-in-time snapshot of the cumulative session counters,
+// used to hydrate the UI on startup. All fields are absolute totals read
+// atomically.
+type SessionStats struct {
+	Fame         int64
+	Silver       int64
+	Respec       int64
+	RespecSilver int64
+	Kills        int64
+	Deaths       int64
+	Loot         int64
+}
+
+// SessionSnapshot returns the current cumulative session counters. Safe to
+// call concurrently with event processing.
+func (h *AlbionHandler) SessionSnapshot() SessionStats {
+	return h.readSessionStats()
+}
+
+// readSessionStats is the single source of truth for reading the seven
+// cumulative counters into a SessionStats. All reads of these atomics for
+// persistence or UI hydration go through here so a new counter only needs to
+// be added in one place.
+func (h *AlbionHandler) readSessionStats() SessionStats {
+	return SessionStats{
+		Fame:         h.sessionFame.Load(),
+		Silver:       h.sessionSilver.Load(),
+		Respec:       h.sessionRespec.Load(),
+		RespecSilver: h.sessionRespecSilver.Load(),
+		Kills:        h.sessionKills.Load(),
+		Deaths:       h.sessionDeaths.Load(),
+		Loot:         h.sessionLoot.Load(),
+	}
+}
+
+// applySessionStats is the single source of truth for writing the seven
+// cumulative counters from a SessionStats (the inverse of readSessionStats).
+// All stores of these atomics on load go through here so a new counter only
+// needs to be added in one place.
+func (h *AlbionHandler) applySessionStats(s SessionStats) {
+	h.sessionFame.Store(s.Fame)
+	h.sessionSilver.Store(s.Silver)
+	h.sessionRespec.Store(s.Respec)
+	h.sessionRespecSilver.Store(s.RespecSilver)
+	h.sessionKills.Store(s.Kills)
+	h.sessionDeaths.Store(s.Deaths)
+	h.sessionLoot.Store(s.Loot)
+}
+
+// sessionStatsFile is the on-disk JSON representation of SessionStats. The
+// Version field is reserved for future additive schema migrations; missing
+// fields in an old file default to zero via encoding/json.
+//
+// Once persisted and restored, the session* counters represent cumulative
+// totals across all launches of the application (long-term) rather than a
+// single session — this matches issue #104's intent. The "session" naming is
+// retained for now and will be revisited when daily/hourly bucketing lands
+// (follow-up #105).
+type sessionStatsFile struct {
+	Version      int       `json:"version"`
+	Fame         int64     `json:"fame"`
+	Silver       int64     `json:"silver"`
+	Respec       int64     `json:"respec"`
+	RespecSilver int64     `json:"respec_silver"`
+	Kills        int64     `json:"kills"`
+	Deaths       int64     `json:"deaths"`
+	Loot         int64     `json:"loot"`
+	SavedAt      time.Time `json:"saved_at"`
+}
+
+// sessionStatsVersion is the current on-disk schema version for session stats.
+const sessionStatsVersion = 1
+
+// SaveSessionStats persists the cumulative session counters to path as JSON
+// using an atomic write (tmp + rename).
+func (h *AlbionHandler) SaveSessionStats(path string) error {
+	s := h.readSessionStats()
+	f := sessionStatsFile{
+		Version:      sessionStatsVersion,
+		Fame:         s.Fame,
+		Silver:       s.Silver,
+		Respec:       s.Respec,
+		RespecSilver: s.RespecSilver,
+		Kills:        s.Kills,
+		Deaths:       s.Deaths,
+		Loot:         s.Loot,
+		SavedAt:      h.nowFunc(),
+	}
+	return storage.Save(path, f)
+}
+
+// LoadSessionStats restores the cumulative session counters from path. A
+// missing file leaves counters at zero (first run). A corrupt file is returned
+// as err and leaves the counters unchanged. The schema is additive: a version
+// mismatch or missing fields apply best-effort (unknown/absent fields default
+// to zero).
+func (h *AlbionHandler) LoadSessionStats(path string) error {
+	f, err := storage.Load[sessionStatsFile](path)
+	if err != nil {
+		return err
+	}
+	h.applySessionStats(SessionStats{
+		Fame:         f.Fame,
+		Silver:       f.Silver,
+		Respec:       f.Respec,
+		RespecSilver: f.RespecSilver,
+		Kills:        f.Kills,
+		Deaths:       f.Deaths,
+		Loot:         f.Loot,
+	})
+	return nil
+}
+
 // handleUpdateFame handles fame/XP gain events
 // Supports multiple event formats as they vary between game versions
 func (h *AlbionHandler) handleUpdateFame(params map[byte]interface{}) {

--- a/pkg/handlers/albion_test.go
+++ b/pkg/handlers/albion_test.go
@@ -1641,3 +1641,118 @@ func TestOnEventNewShrineNoActiveRun(t *testing.T) {
 		t.Error("expected nil active run when no dungeon entered")
 	}
 }
+
+func TestSaveLoadSessionStatsRoundTrip(t *testing.T) {
+	h := NewAlbionHandler()
+	h.sessionFame.Store(1500)
+	h.sessionSilver.Store(25000)
+	h.sessionRespec.Store(300)
+	h.sessionRespecSilver.Store(4500)
+	h.sessionKills.Store(7)
+	h.sessionDeaths.Store(2)
+	h.sessionLoot.Store(11)
+
+	path := filepath.Join(t.TempDir(), "session-stats.json")
+	if err := h.SaveSessionStats(path); err != nil {
+		t.Fatalf("SaveSessionStats: %v", err)
+	}
+
+	fresh := NewAlbionHandler()
+	if err := fresh.LoadSessionStats(path); err != nil {
+		t.Fatalf("LoadSessionStats: %v", err)
+	}
+	got := fresh.SessionSnapshot()
+	want := SessionStats{Fame: 1500, Silver: 25000, Respec: 300, RespecSilver: 4500, Kills: 7, Deaths: 2, Loot: 11}
+	if got != want {
+		t.Errorf("snapshot = %+v, want %+v", got, want)
+	}
+}
+
+func TestLoadSessionStatsMissingFileLeavesZeroNoError(t *testing.T) {
+	h := NewAlbionHandler()
+	path := filepath.Join(t.TempDir(), "nope.json")
+	if err := h.LoadSessionStats(path); err != nil {
+		t.Errorf("LoadSessionStats missing file: %v", err)
+	}
+	if got := h.SessionSnapshot(); got != (SessionStats{}) {
+		t.Errorf("expected zero snapshot, got %+v", got)
+	}
+}
+
+func TestLoadSessionStatsBackwardCompatMissingField(t *testing.T) {
+	// Older file written before respec_silver existed: that field must default
+	// to zero while the rest loads normally (additive schema).
+	path := filepath.Join(t.TempDir(), "old-stats.json")
+	raw := []byte(`{"version":1,"fame":100,"silver":200,"respec":30,"kills":1,"deaths":0,"loot":2,"saved_at":"2026-01-01T00:00:00Z"}`)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	h := NewAlbionHandler()
+	if err := h.LoadSessionStats(path); err != nil {
+		t.Fatalf("LoadSessionStats: %v", err)
+	}
+	got := h.SessionSnapshot()
+	want := SessionStats{Fame: 100, Silver: 200, Respec: 30, RespecSilver: 0, Kills: 1, Deaths: 0, Loot: 2}
+	if got != want {
+		t.Errorf("snapshot = %+v, want %+v (respec_silver defaulting to 0)", got, want)
+	}
+}
+
+func TestLoadSessionStatsCorruptFileReturnsError(t *testing.T) {
+	h := NewAlbionHandler()
+	h.sessionFame.Store(999) // pre-existing value must survive a corrupt load
+
+	path := filepath.Join(t.TempDir(), "bad-stats.json")
+	if err := os.WriteFile(path, []byte("{broken"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := h.LoadSessionStats(path); err == nil {
+		t.Fatal("expected error loading corrupt stats file, got nil")
+	}
+	if got := h.sessionFame.Load(); got != 999 {
+		t.Errorf("corrupt load should leave counters unchanged; Fame = %d, want 999", got)
+	}
+}
+
+func TestLoadSessionStatsVersionAbsentStillLoads(t *testing.T) {
+	// An even older file written before the `version` field existed: version
+	// defaults to zero (!= 1) but the schema is additive, so values still load.
+	path := filepath.Join(t.TempDir(), "no-version.json")
+	raw := []byte(`{"fame":50,"silver":60,"respec":7,"respec_silver":8,"kills":1,"deaths":0,"loot":1,"saved_at":"2026-06-29T00:00:00Z"}`)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	h := NewAlbionHandler()
+	if err := h.LoadSessionStats(path); err != nil {
+		t.Fatalf("LoadSessionStats: %v", err)
+	}
+	got := h.SessionSnapshot()
+	want := SessionStats{Fame: 50, Silver: 60, Respec: 7, RespecSilver: 8, Kills: 1, Deaths: 0, Loot: 1}
+	if got != want {
+		t.Errorf("snapshot = %+v, want %+v (loaded despite missing version)", got, want)
+	}
+}
+
+func TestSaveSessionStatsErrorPropagates(t *testing.T) {
+	h := NewAlbionHandler()
+	h.sessionFame.Store(100)
+
+	// Make the final path a non-empty directory so storage.Save's rename step
+	// fails — a deterministic way (no root/FS assumptions) to exercise error
+	// propagation through SaveSessionStats.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stats.json")
+	if err := os.MkdirAll(filepath.Join(path, "blocker"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	if err := h.SaveSessionStats(path); err == nil {
+		t.Fatal("expected error from SaveSessionStats when storage save fails, got nil")
+	}
+	// Counters must be untouched by a failed save.
+	if got := h.sessionFame.Load(); got != 100 {
+		t.Errorf("failed save should not mutate counters; Fame = %d, want 100", got)
+	}
+}

--- a/pkg/handlers/albion_test.go
+++ b/pkg/handlers/albion_test.go
@@ -1644,13 +1644,7 @@ func TestOnEventNewShrineNoActiveRun(t *testing.T) {
 
 func TestSaveLoadSessionStatsRoundTrip(t *testing.T) {
 	h := NewAlbionHandler()
-	h.sessionFame.Store(1500)
-	h.sessionSilver.Store(25000)
-	h.sessionRespec.Store(300)
-	h.sessionRespecSilver.Store(4500)
-	h.sessionKills.Store(7)
-	h.sessionDeaths.Store(2)
-	h.sessionLoot.Store(11)
+	h.stats.apply(SessionStats{Fame: 1500, Silver: 25000, Respec: 300, RespecSilver: 4500, Kills: 7, Deaths: 2, Loot: 11})
 
 	path := filepath.Join(t.TempDir(), "session-stats.json")
 	if err := h.SaveSessionStats(path); err != nil {
@@ -1701,7 +1695,7 @@ func TestLoadSessionStatsBackwardCompatMissingField(t *testing.T) {
 
 func TestLoadSessionStatsCorruptFileReturnsError(t *testing.T) {
 	h := NewAlbionHandler()
-	h.sessionFame.Store(999) // pre-existing value must survive a corrupt load
+	h.stats.apply(SessionStats{Fame: 999}) // pre-existing value must survive a corrupt load
 
 	path := filepath.Join(t.TempDir(), "bad-stats.json")
 	if err := os.WriteFile(path, []byte("{broken"), 0o644); err != nil {
@@ -1710,7 +1704,7 @@ func TestLoadSessionStatsCorruptFileReturnsError(t *testing.T) {
 	if err := h.LoadSessionStats(path); err == nil {
 		t.Fatal("expected error loading corrupt stats file, got nil")
 	}
-	if got := h.sessionFame.Load(); got != 999 {
+	if got := h.stats.fameNow(); got != 999 {
 		t.Errorf("corrupt load should leave counters unchanged; Fame = %d, want 999", got)
 	}
 }
@@ -1737,7 +1731,7 @@ func TestLoadSessionStatsVersionAbsentStillLoads(t *testing.T) {
 
 func TestSaveSessionStatsErrorPropagates(t *testing.T) {
 	h := NewAlbionHandler()
-	h.sessionFame.Store(100)
+	h.stats.apply(SessionStats{Fame: 100})
 
 	// Make the final path a non-empty directory so storage.Save's rename step
 	// fails — a deterministic way (no root/FS assumptions) to exercise error
@@ -1752,7 +1746,7 @@ func TestSaveSessionStatsErrorPropagates(t *testing.T) {
 		t.Fatal("expected error from SaveSessionStats when storage save fails, got nil")
 	}
 	// Counters must be untouched by a failed save.
-	if got := h.sessionFame.Load(); got != 100 {
+	if got := h.stats.fameNow(); got != 100 {
 		t.Errorf("failed save should not mutate counters; Fame = %d, want 100", got)
 	}
 }

--- a/pkg/handlers/dungeon.go
+++ b/pkg/handlers/dungeon.go
@@ -286,6 +286,9 @@ func (h *AlbionHandler) EnterDungeon(now time.Time) {
 		h.closeActiveRunLocked(now, RunStatusDone)
 	}
 
+	// Snapshot the session counters once, consistently, so the per-run delta
+	// computed on exit is coherent (no mix of pre/post-update values).
+	snap := h.stats.snapshot()
 	run := &DungeonRun{
 		EnteredAt:        now,
 		Mode:             DungeonModeUnknown,
@@ -293,13 +296,13 @@ func (h *AlbionHandler) EnterDungeon(now time.Time) {
 		Level:            -1,
 		Status:           RunStatusActive,
 		CloseAt:          now.Add(DungeonCloseTimeout),
-		snapFame:         h.sessionFame.Load(),
-		snapSilver:       h.sessionSilver.Load(),
-		snapRespec:       h.sessionRespec.Load(),
-		snapRespecSilver: h.sessionRespecSilver.Load(),
-		snapKills:        int(h.sessionKills.Load()),
-		snapDeaths:       int(h.sessionDeaths.Load()),
-		snapLoot:         int(h.sessionLoot.Load()),
+		snapFame:         snap.Fame,
+		snapSilver:       snap.Silver,
+		snapRespec:       snap.Respec,
+		snapRespecSilver: snap.RespecSilver,
+		snapKills:        int(snap.Kills),
+		snapDeaths:       int(snap.Deaths),
+		snapLoot:         int(snap.Loot),
 	}
 	h.activeRun = run
 	h.dungeonRuns = append(h.dungeonRuns, run)
@@ -330,13 +333,16 @@ func (h *AlbionHandler) closeActiveRunLocked(now time.Time, status RunStatus) {
 	}
 	r.ExitedAt = now
 	r.Status = status
-	r.Fame = h.sessionFame.Load() - r.snapFame
-	r.Silver = h.sessionSilver.Load() - r.snapSilver
-	r.Respec = h.sessionRespec.Load() - r.snapRespec
-	r.RespecSilver = h.sessionRespecSilver.Load() - r.snapRespecSilver
-	r.Kills = int(h.sessionKills.Load()) - r.snapKills
-	r.Deaths = int(h.sessionDeaths.Load()) - r.snapDeaths
-	r.Loot = int(h.sessionLoot.Load()) - r.snapLoot
+	// Read the current counters as one consistent snapshot so every delta is
+	// computed against the same point in time.
+	cur := h.stats.snapshot()
+	r.Fame = cur.Fame - r.snapFame
+	r.Silver = cur.Silver - r.snapSilver
+	r.Respec = cur.Respec - r.snapRespec
+	r.RespecSilver = cur.RespecSilver - r.snapRespecSilver
+	r.Kills = int(cur.Kills) - r.snapKills
+	r.Deaths = int(cur.Deaths) - r.snapDeaths
+	r.Loot = int(cur.Loot) - r.snapLoot
 	h.activeRun = nil
 }
 
@@ -400,6 +406,17 @@ func (h *AlbionHandler) GetActiveDungeon() *DungeonRun {
 	return &run
 }
 
+// copyDungeonRunsLocked returns defensive copies of all recorded runs. Caller
+// must hold dungeonMu.
+func (h *AlbionHandler) copyDungeonRunsLocked() []*DungeonRun {
+	result := make([]*DungeonRun, len(h.dungeonRuns))
+	for i, r := range h.dungeonRuns {
+		cp := *r
+		result[i] = &cp
+	}
+	return result
+}
+
 // GetDungeonRuns returns snapshots of all recorded dungeon runs (oldest first).
 // Each pointer is to a copy — callers may freely read, reorder, or retain the
 // slice without holding the handler lock.
@@ -407,10 +424,16 @@ func (h *AlbionHandler) GetDungeonRuns() []*DungeonRun {
 	h.dungeonMu.Lock()
 	defer h.dungeonMu.Unlock()
 	h.closeExpiredLocked(h.nowFunc())
-	result := make([]*DungeonRun, len(h.dungeonRuns))
-	for i, r := range h.dungeonRuns {
-		cp := *r
-		result[i] = &cp
-	}
-	return result
+	return h.copyDungeonRunsLocked()
+}
+
+// DungeonRunsSnapshot returns a defensive copy of the recorded run history
+// (oldest first) for inspection by tests or the UI without holding the handler
+// lock. Like GetDungeonRuns it closes any run whose 90s timer has elapsed, so
+// the two APIs are consistent.
+func (h *AlbionHandler) DungeonRunsSnapshot() []*DungeonRun {
+	h.dungeonMu.Lock()
+	defer h.dungeonMu.Unlock()
+	h.closeExpiredLocked(h.nowFunc())
+	return h.copyDungeonRunsLocked()
 }

--- a/pkg/handlers/dungeon.go
+++ b/pkg/handlers/dungeon.go
@@ -79,26 +79,33 @@ func (s RunStatus) String() string {
 }
 
 // DungeonRun represents a single random dungeon run from entry to exit.
+//
+// JSON tags pin the on-disk field names so the persisted format is stable and
+// additive-only (new fields default to zero when reading old files). The
+// unexported snap* fields below are runtime-only (delta computation) and are
+// automatically excluded from serialization by encoding/json.
 type DungeonRun struct {
-	EnteredAt time.Time
-	ExitedAt  time.Time // zero while active
-	Mode      DungeonMode
-	Faction   string // "", Keeper, Heretic, Morgana, Undead, Avalon
-	Tier      int    // -1 unknown; 0-7 (mob tier - 1 per reference)
-	Level     int    // -1 unknown (deferred — needs exit-position catalog)
-	Status    RunStatus
-	CloseAt   time.Time // EnteredAt + 90s
+	EnteredAt time.Time   `json:"entered_at"`
+	ExitedAt  time.Time   `json:"exited_at"` // zero while active
+	Mode      DungeonMode `json:"mode"`
+	Faction   string      `json:"faction"` // "", Keeper, Heretic, Morgana, Undead, Avalon
+	Tier      int         `json:"tier"`    // -1 unknown; 0-7 (mob tier - 1 per reference)
+	Level     int         `json:"level"`   // -1 unknown (deferred — needs exit-position catalog)
+	Status    RunStatus   `json:"status"`
+	CloseAt   time.Time   `json:"close_at"` // EnteredAt + 90s
 
 	// Per-run stat deltas (computed on exit).
-	Fame         int64
-	Silver       int64
-	Respec       int64
-	RespecSilver int64
-	Kills        int
-	Deaths       int
-	Loot         int
+	Fame         int64 `json:"fame"`
+	Silver       int64 `json:"silver"`
+	Respec       int64 `json:"respec"`
+	RespecSilver int64 `json:"respec_silver"`
+	Kills        int   `json:"kills"`
+	Deaths       int   `json:"deaths"`
+	Loot         int   `json:"loot"`
 
 	// Snapshot of session counters at entry (internal, for delta computation).
+	// These unexported fields are NOT serialized; restored runs always have
+	// Status != Active, so no delta computation is needed after load.
 	snapFame         int64
 	snapSilver       int64
 	snapRespec       int64

--- a/pkg/handlers/dungeon_test.go
+++ b/pkg/handlers/dungeon_test.go
@@ -84,8 +84,8 @@ func TestEnterExitDungeonLifecycle(t *testing.T) {
 	}
 
 	// Exit — deltas should be zero (no stats gained)
-	h.sessionFame.Add(500)
-	h.sessionKills.Add(1)
+	h.stats.addFame(500)
+	h.stats.addKill()
 	exitTime := base.Add(2 * time.Minute)
 	h.nowFunc = func() time.Time { return exitTime }
 	h.ExitDungeon(exitTime)
@@ -119,7 +119,7 @@ func TestEnterDungeonClosesPrevious(t *testing.T) {
 	h.EnterDungeon(t0)
 
 	// Gain some fame during first run
-	h.sessionFame.Add(1000)
+	h.stats.addFame(1000)
 
 	// Enter a second dungeon without exiting the first
 	t1 := t0.Add(3 * time.Minute)
@@ -464,8 +464,9 @@ func TestSaveLoadDungeonRunsRoundTrip(t *testing.T) {
 	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
 	h.nowFunc = func() time.Time { return t0 }
 	h.EnterDungeon(t0)
-	h.sessionFame.Add(500)
-	h.sessionKills.Add(2)
+	h.stats.addFame(500)
+	h.stats.addKill()
+	h.stats.addKill()
 	exit := t0.Add(2 * time.Minute)
 	h.nowFunc = func() time.Time { return exit }
 	h.ExitDungeon(exit)
@@ -474,7 +475,7 @@ func TestSaveLoadDungeonRunsRoundTrip(t *testing.T) {
 	t1 := t0.Add(10 * time.Minute)
 	h.nowFunc = func() time.Time { return t1 }
 	h.EnterDungeon(t1)
-	h.sessionSilver.Add(300)
+	h.stats.addSilver(300)
 	t2 := t1.Add(5 * time.Minute)
 	h.nowFunc = func() time.Time { return t2 }
 	h.ExitDungeon(t2)

--- a/pkg/handlers/dungeon_test.go
+++ b/pkg/handlers/dungeon_test.go
@@ -1,8 +1,12 @@
 package handlers
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/cantalupo555/albion-lens/internal/storage"
 )
 
 func TestClassifyDungeonMode(t *testing.T) {
@@ -452,5 +456,171 @@ func TestGetActiveDungeonReturnsCopy(t *testing.T) {
 	// But same field values
 	if !a1.EnteredAt.Equal(a2.EnteredAt) {
 		t.Error("copies should have same EnteredAt")
+	}
+}
+
+func TestSaveLoadDungeonRunsRoundTrip(t *testing.T) {
+	h := NewAlbionHandler()
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return t0 }
+	h.EnterDungeon(t0)
+	h.sessionFame.Add(500)
+	h.sessionKills.Add(2)
+	exit := t0.Add(2 * time.Minute)
+	h.nowFunc = func() time.Time { return exit }
+	h.ExitDungeon(exit)
+
+	// Second completed run with a different stat.
+	t1 := t0.Add(10 * time.Minute)
+	h.nowFunc = func() time.Time { return t1 }
+	h.EnterDungeon(t1)
+	h.sessionSilver.Add(300)
+	t2 := t1.Add(5 * time.Minute)
+	h.nowFunc = func() time.Time { return t2 }
+	h.ExitDungeon(t2)
+
+	path := filepath.Join(t.TempDir(), "dungeon-runs.json")
+	if err := h.SaveDungeonRuns(path); err != nil {
+		t.Fatalf("SaveDungeonRuns: %v", err)
+	}
+
+	fresh := NewAlbionHandler()
+	if err := fresh.LoadDungeonRuns(path); err != nil {
+		t.Fatalf("LoadDungeonRuns: %v", err)
+	}
+	got := fresh.GetDungeonRuns()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 runs after load, got %d", len(got))
+	}
+	if got[0].Fame != 500 || got[0].Kills != 2 || got[0].Status != RunStatusDone {
+		t.Errorf("run0 = %+v, want Fame=500 Kills=2 Status=Done", got[0])
+	}
+	if !got[0].EnteredAt.Equal(t0) {
+		t.Errorf("run0 EnteredAt = %v, want %v", got[0].EnteredAt, t0)
+	}
+	if got[1].Silver != 300 || got[1].Status != RunStatusDone {
+		t.Errorf("run1 = %+v, want Silver=300 Status=Done", got[1])
+	}
+	// Unexported snapshot fields are not persisted.
+	if got[0].snapFame != 0 {
+		t.Errorf("run0 snapFame should be zero after load (not persisted), got %d", got[0].snapFame)
+	}
+}
+
+func TestSaveDungeonRunsExcludesActiveRun(t *testing.T) {
+	h := NewAlbionHandler()
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return t0 }
+	h.EnterDungeon(t0) // active, never exited
+
+	path := filepath.Join(t.TempDir(), "dungeon-runs.json")
+	if err := h.SaveDungeonRuns(path); err != nil {
+		t.Fatalf("SaveDungeonRuns: %v", err)
+	}
+
+	fresh := NewAlbionHandler()
+	if err := fresh.LoadDungeonRuns(path); err != nil {
+		t.Fatalf("LoadDungeonRuns: %v", err)
+	}
+	if got := fresh.GetDungeonRuns(); len(got) != 0 {
+		t.Errorf("active run should not be persisted; got %d runs", len(got))
+	}
+}
+
+func TestLoadDungeonRunsMissingFileIsEmptyNoError(t *testing.T) {
+	h := NewAlbionHandler()
+	path := filepath.Join(t.TempDir(), "nope.json")
+	if err := h.LoadDungeonRuns(path); err != nil {
+		t.Errorf("LoadDungeonRuns missing file: %v", err)
+	}
+	if got := h.GetDungeonRuns(); len(got) != 0 {
+		t.Errorf("expected empty history, got %d runs", len(got))
+	}
+}
+
+func TestLoadDungeonRunsCorruptFileReturnsError(t *testing.T) {
+	h := NewAlbionHandler()
+	// Seed an existing history that must survive a corrupt load.
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return t0 }
+	h.EnterDungeon(t0)
+	h.ExitDungeon(t0.Add(time.Minute))
+
+	path := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(path, []byte("{not valid"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := h.LoadDungeonRuns(path); err == nil {
+		t.Fatal("expected error loading corrupt file, got nil")
+	}
+	if got := h.GetDungeonRuns(); len(got) != 1 {
+		t.Errorf("corrupt load should leave existing history intact; got %d runs", len(got))
+	}
+}
+
+func TestLoadDungeonRunsRespectsCapAndSorts(t *testing.T) {
+	// Persist more than the cap, in reverse order, directly to disk so we can
+	// verify Load trims to the newest and re-sorts oldest-first.
+	total := maxDungeonRuns + 50
+	runs := make([]*DungeonRun, 0, total)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < total; i++ {
+		runs = append(runs, &DungeonRun{
+			EnteredAt: base.Add(time.Duration(i) * time.Minute),
+			Status:    RunStatusDone,
+			Fame:      int64(i),
+		})
+	}
+	for i, j := 0, len(runs)-1; i < j; i, j = i+1, j-1 {
+		runs[i], runs[j] = runs[j], runs[i]
+	}
+
+	path := filepath.Join(t.TempDir(), "many.json")
+	if err := storage.Save(path, runs); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	h := NewAlbionHandler()
+	if err := h.LoadDungeonRuns(path); err != nil {
+		t.Fatalf("LoadDungeonRuns: %v", err)
+	}
+	got := h.GetDungeonRuns()
+	if len(got) != maxDungeonRuns {
+		t.Fatalf("expected %d runs after cap, got %d", maxDungeonRuns, len(got))
+	}
+	// Oldest surviving run is index (total - cap) = 50.
+	wantFirst := int64(total - maxDungeonRuns)
+	if got[0].Fame != wantFirst {
+		t.Errorf("first run Fame = %d, want %d (oldest after trim)", got[0].Fame, wantFirst)
+	}
+	if !got[0].EnteredAt.Before(got[len(got)-1].EnteredAt) {
+		t.Errorf("runs should be ordered oldest-first after load")
+	}
+}
+
+func TestDungeonRunsSnapshotIsDefensiveCopy(t *testing.T) {
+	h := NewAlbionHandler()
+	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return t0 }
+	h.EnterDungeon(t0)
+	h.ExitDungeon(t0.Add(time.Minute))
+
+	snap := h.DungeonRunsSnapshot()
+	if len(snap) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(snap))
+	}
+
+	// Mutate the returned slice and its element; the handler's internal state
+	// must be insulated.
+	snap[0].Fame = 999999
+	snap[0].Mode = DungeonModeCorrupted
+	snap = append(snap, &DungeonRun{EnteredAt: t0.Add(time.Hour)})
+
+	again := h.DungeonRunsSnapshot()
+	if len(again) != 1 {
+		t.Errorf("internal history changed after mutating snapshot: got %d runs", len(again))
+	}
+	if again[0].Fame == 999999 || again[0].Mode == DungeonModeCorrupted {
+		t.Errorf("internal run mutated via snapshot: %+v", again[0])
 	}
 }


### PR DESCRIPTION
## Summary

Dungeon runs and session stats lived only in memory and were lost on every app restart. This PR persists both to disk (atomic writes, crash recovery, backward-compatible JSON) so they survive across launches.

A reusable persistence layer (`internal/storage`) ports the reference repository's `FileController` (atomic tmp+rename writes + crash recovery on load) and `AppDataPaths` (XDG-compliant data directory) to idiomatic Go. Dungeon-run and session-stat persistence are thin consumers of that layer.

## What changed (per commit)

- **`feat(storage): add atomic JSON persistence layer`** — `DataDir`/`DataFile` (XDG), `Save`/`Load` with per-path mutex, `.tmp` promotion on load, zero-value on missing file. Comprehensive tests: round-trip, atomic-rename, crash-recovery (valid/corrupt tmp), missing/corrupt final, forward-compat, concurrency, rename-failure cleanup.
- **`feat(handlers): persist dungeon runs to disk`** — JSON tags on `DungeonRun`; `SaveDungeonRuns` (excludes active run), `LoadDungeonRuns` (sorts oldest-first, trims to cap, resets active run), `DungeonRunsSnapshot`.
- **`feat(handlers): persist cumulative session stats`** — `SessionStats` type + `SessionSnapshot()`; `readSessionStats`/`applySessionStats` single edit points; `sessionStatsFile` schema with `version: 1`; `SaveSessionStats`/`LoadSessionStats`.
- **`feat(tui): hydrate stats panel from persisted state`** — `SetKills`/`SetDeaths`/`SetLoot` absolute setters; `tui.New` seeds the panel from `SessionSnapshot()` via `hydrateStatsPanel`.
- **`feat(tui): wire persistence lifecycle in main`** — load-on-startup, periodic save (5 min), save-on-exit; `periodicSave` helper.

## Acceptance criteria

### Dungeon runs (#103) — fully resolved ✅
- [x] Serialized to JSON on exit and periodically (5 min ticker + save-on-exit)
- [x] Loaded from disk on startup
- [x] Session fame/silver/respec/kills/deaths restored on load (each run persists its own deltas)
- [x] Backward-compatible format (additive JSON tags; unknown fields ignored)
- [x] Non-blocking save (periodic save is a goroutine; save-on-exit runs after TUI closes)
- [x] Tests cover round-trip and corrupted file handling

### Session stats (#104) — partially resolved (phased)
- [x] Saved on exit with atomic write (tmp-swap)
- [x] Restored on startup
- [x] Saved periodically during the session (every 5 min)
- [ ] **Daily cumulative values (fame today, silver today, etc.) — deferred to #112**
- [x] Backward-compatible format (`version` field + additive schema)
- [x] Crash corruption handled (stale `.tmp` recovered or discarded; invalid JSON loads defaults)
- [x] Tests cover round-trip, crash recovery, backward compat

## Notes

- After restore, the `session*` counters represent **cumulative totals across all launches** rather than a single session. The naming will be revisited when time-bucketed stats land (#112).
- Active (in-progress) dungeon runs are excluded from the saved file (incomplete data); they are runtime-only.

## Out of scope (follow-up issues)

The remaining #104 acceptance criterion and its "How it works" mechanisms are tracked separately. **#104 stays open** until they land:
- **#112** — Daily/hourly session stat buckets (`DailyValues`/`HourlyValues`) + 90-day pruning
- **#113** — Server-region segregation (`UserData-{SERVER}` directories)
- **#114** — Append-only kill/death event log (`PlayerKillsDeaths.json`)
- **#115** — Save-on-cluster-change, rate-limited to 15 min

## Validation

\`\`\`
go build ./...   ✅
go vet ./...     ✅
go test -race ./...   ✅ (10/10 packages)
\`\`\`

Closes #103
Partially addresses #104

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

This PR adds a reusable atomic-JSON persistence layer (`internal/storage`) and wires it into dungeon runs and session stats so they survive app restarts. Dungeon runs serialize on exit and periodically (excluding active runs), while cumulative session stats load on startup and save every five minutes. The TUI hydrates its stats panel from the persisted state, and a save-on-exit handler ensures data is written after the UI closes.

---
<sup>Written for commit d37f2cf47e4090009d7bad1690756c1642fd53a4. Summary will update on new commits.</sup>
<!-- end-auto-generated -->