### PR TITLE
feat: daily/hourly stat buckets + rename session stats to total

### DIFF
--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -110,7 +110,7 @@ func main() {
 				fmt.Printf("Warning: could not load dungeon history: %v\n", err)
 			}
 			if err := h.LoadTotalStats(statsPath); err != nil {
-				fmt.Printf("Warning: could not load session stats: %v\n", err)
+				fmt.Printf("Warning: could not load total stats: %v\n", err)
 			}
 		}
 	}
@@ -160,7 +160,7 @@ func main() {
 				fmt.Printf("Warning: could not save dungeon history: %v\n", err)
 			}
 			if err := h.SaveTotalStats(statsPath); err != nil {
-				fmt.Printf("Warning: could not save session stats: %v\n", err)
+				fmt.Printf("Warning: could not save total stats: %v\n", err)
 			}
 		}
 	}

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -109,7 +109,7 @@ func main() {
 			if err := h.LoadDungeonRuns(dungeonPath); err != nil {
 				fmt.Printf("Warning: could not load dungeon history: %v\n", err)
 			}
-			if err := h.LoadSessionStats(statsPath); err != nil {
+			if err := h.LoadTotalStats(statsPath); err != nil {
 				fmt.Printf("Warning: could not load session stats: %v\n", err)
 			}
 		}
@@ -130,7 +130,7 @@ func main() {
 		if err := h.SaveDungeonRuns(dungeonPath); err != nil {
 			return err
 		}
-		return h.SaveSessionStats(statsPath)
+		return h.SaveTotalStats(statsPath)
 	})
 
 	// Send initial status event (as a batch)
@@ -159,7 +159,7 @@ func main() {
 			if err := h.SaveDungeonRuns(dungeonPath); err != nil {
 				fmt.Printf("Warning: could not save dungeon history: %v\n", err)
 			}
-			if err := h.SaveSessionStats(statsPath); err != nil {
+			if err := h.SaveTotalStats(statsPath); err != nil {
 				fmt.Printf("Warning: could not save session stats: %v\n", err)
 			}
 		}

--- a/cmd/tui/runtime_verify_test.go
+++ b/cmd/tui/runtime_verify_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cantalupo555/albion-lens/internal/tui/components"
+	"github.com/cantalupo555/albion-lens/pkg/events"
+	"github.com/cantalupo555/albion-lens/pkg/handlers"
+)
+
+// TestEventToBucketToPanel is an integration check that the full runtime
+// path works end to end: a game event populates today's daily bucket, and the
+// stats panel (hydrated as the TUI does on startup) renders the "today"
+// section with the accumulated value. The per-package unit tests cover each
+// layer in isolation; this guards the wiring between them.
+func TestEventToBucketToPanel(t *testing.T) {
+	h := handlers.NewAlbionHandler()
+	h.SetLocalPlayer("Hero")
+
+	// Feed a fame event (EventUpdateFame, FixPoint): gained 1000.
+	h.OnEvent(0, map[byte]interface{}{
+		1:                     int64(50000000000), // total fame (FixPoint)
+		2:                     int64(10000000),    // gained 1000 (FixPoint)
+		events.ParamEventCode: int16(events.EventUpdateFame),
+	})
+
+	// The fame must land in today's daily bucket.
+	now := time.Now()
+	snap := h.TotalSnapshot()
+	today := snap.Daily[now.Format("2006-01-02")]
+	if today.Fame != 1000 {
+		t.Fatalf("today bucket fame = %d, want 1000", today.Fame)
+	}
+
+	// Hydrate the panel as the TUI does, then render.
+	panel := components.NewStatsPanel().
+		SetFullNumbers(true).
+		SetFame(snap.Fame).
+		SetKills(int(snap.Kills)).
+		SetTodayFame(today.Fame).
+		SetSize(40, 30)
+	out := panel.View()
+	for _, want := range []string{"Total Stats", "today", "1000"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("panel view missing %q\n%s", want, out)
+		}
+	}
+
+	// Negative control: a panel with no today values must hide the section.
+	empty := components.NewStatsPanel().
+		SetFullNumbers(true).
+		SetFame(5000).
+		SetSize(40, 30)
+	if strings.Contains(empty.View(), "today") {
+		t.Errorf("panel with zero today values should not render 'today' section")
+	}
+}
+
+// TestTotalStatsPersistenceLifecycle exercises the on-disk lifecycle the TUI
+// orchestrates (main.go): a v1 file (pre-bucketing) loads with empty buckets,
+// cumulative values survive a save->reload round-trip, and a corrupt file
+// errors instead of crashing. Guards the real persistence path the unit tests
+// touch only in pieces.
+func TestTotalStatsPersistenceLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session-stats.json")
+
+	// 1. A v1 file (no daily/hourly) must load with empty buckets, cumulative
+	//    intact — the upgrade path for existing users.
+	v1 := `{"version":1,"fame":100,"silver":200,"respec":30,"respec_silver":8,"kills":1,"deaths":0,"loot":2,"saved_at":"2026-06-29T00:00:00Z"}`
+	if err := os.WriteFile(path, []byte(v1), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	h := handlers.NewAlbionHandler()
+	if err := h.LoadTotalStats(path); err != nil {
+		t.Fatalf("LoadTotalStats v1: %v", err)
+	}
+	if h.GetTotalFame() != 100 || h.GetTotalSilver() != 200 || h.GetTotalKills() != 1 {
+		t.Errorf("v1 load: Fame=%d Silver=%d Kills=%d, want 100/200/1",
+			h.GetTotalFame(), h.GetTotalSilver(), h.GetTotalKills())
+	}
+	snap := h.TotalSnapshot()
+	if len(snap.Daily) != 0 || len(snap.Hourly) != 0 {
+		t.Errorf("v1 load should yield empty buckets, got daily=%d hourly=%d",
+			len(snap.Daily), len(snap.Hourly))
+	}
+
+	// 2. Save (now v2) and reload — cumulative values must round-trip.
+	out := filepath.Join(dir, "out.json")
+	if err := h.SaveTotalStats(out); err != nil {
+		t.Fatalf("SaveTotalStats: %v", err)
+	}
+	fresh := handlers.NewAlbionHandler()
+	if err := fresh.LoadTotalStats(out); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if fresh.GetTotalFame() != 100 || fresh.GetTotalSilver() != 200 {
+		t.Errorf("round-trip: Fame=%d Silver=%d, want 100/200",
+			fresh.GetTotalFame(), fresh.GetTotalSilver())
+	}
+
+	// 3. A corrupt file must error and not crash the app.
+	bad := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(bad, []byte("{broken"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := handlers.NewAlbionHandler().LoadTotalStats(bad); err == nil {
+		t.Error("expected error loading corrupt file, got nil")
+	}
+}

--- a/internal/tui/components/eventlog.go
+++ b/internal/tui/components/eventlog.go
@@ -201,30 +201,30 @@ func (e EventLog) formatEventMessage(event Event) string {
 	switch event.Type {
 	case "fame":
 		if data, ok := event.Data.(*handlers.FameEventData); ok && data != nil {
-			return fmt.Sprintf("⭐ FAME: +%s | Total: %s | Session: %s",
+			return fmt.Sprintf("⭐ FAME: +%s | Pool: %s | Total: %s",
 				FormatNumber(data.Gained, e.fullNumbers),
 				FormatNumber(data.Total, e.fullNumbers),
-				FormatNumber(data.Session, e.fullNumbers))
+				FormatNumber(data.AllTime, e.fullNumbers))
 		}
 	case "silver":
 		if data, ok := event.Data.(*handlers.SilverEventData); ok && data != nil {
-			return fmt.Sprintf("💰 %s looted silver (%s) from %s | Session: %s",
+			return fmt.Sprintf("💰 %s looted silver (%s) from %s | Total: %s",
 				data.LootedBy,
 				FormatNumber(data.Amount, e.fullNumbers),
 				data.LootedFrom,
-				FormatNumber(data.Session, e.fullNumbers))
+				FormatNumber(data.Total, e.fullNumbers))
 		}
 	case "respec":
 		if data, ok := event.Data.(*handlers.RespecEventData); ok && data != nil {
 			if data.PaidSilver > 0 {
-				return fmt.Sprintf("🏆 RESPEC: +%s credits | Silver cost: -%s | Session: %s",
+				return fmt.Sprintf("🏆 RESPEC: +%s credits | Silver cost: -%s | Total: %s",
 					FormatNumber(data.Gained, e.fullNumbers),
 					FormatNumber(data.PaidSilver, e.fullNumbers),
-					FormatNumber(data.SessionTotal, e.fullNumbers))
+					FormatNumber(data.Total, e.fullNumbers))
 			}
-			return fmt.Sprintf("🏆 RESPEC: +%s credits | Session: %s",
+			return fmt.Sprintf("🏆 RESPEC: +%s credits | Total: %s",
 				FormatNumber(data.Gained, e.fullNumbers),
-				FormatNumber(data.SessionTotal, e.fullNumbers))
+				FormatNumber(data.Total, e.fullNumbers))
 		}
 	case "loot":
 		if data, ok := event.Data.(*handlers.LootEventData); ok && data != nil {
@@ -236,7 +236,7 @@ func (e EventLog) formatEventMessage(event Event) string {
 		}
 	case "kill":
 		if data, ok := event.Data.(*handlers.KillEventData); ok && data != nil {
-			return fmt.Sprintf("⚔️ Player Killed! (Session: %d kills)", data.SessionKills)
+			return fmt.Sprintf("⚔️ Player Killed! (Total: %d kills)", data.TotalKills)
 		}
 	case "death":
 		if data, ok := event.Data.(*handlers.DeathEventData); ok && data != nil {

--- a/internal/tui/components/eventlog_test.go
+++ b/internal/tui/components/eventlog_test.go
@@ -14,9 +14,9 @@ func TestFormatEventMessageRespecWithSilver(t *testing.T) {
 	event := Event{
 		Type: "respec",
 		Data: &handlers.RespecEventData{
-			Gained:       1000,
-			PaidSilver:   500,
-			SessionTotal: 3000,
+			Gained:     1000,
+			PaidSilver: 500,
+			Total:      3000,
 		},
 		Timestamp: time.Now(),
 	}
@@ -40,9 +40,9 @@ func TestFormatEventMessageRespecWithoutSilver(t *testing.T) {
 	event := Event{
 		Type: "respec",
 		Data: &handlers.RespecEventData{
-			Gained:       200,
-			PaidSilver:   0,
-			SessionTotal: 200,
+			Gained:     200,
+			PaidSilver: 0,
+			Total:      200,
 		},
 		Timestamp: time.Now(),
 	}
@@ -72,7 +72,7 @@ func TestFormatEventMessageFame(t *testing.T) {
 		Data: &handlers.FameEventData{
 			Gained:  500,
 			Total:   5000,
-			Session: 2000,
+			AllTime: 2000,
 		},
 		Timestamp: time.Now(),
 	}
@@ -97,7 +97,7 @@ func TestFormatEventMessageSilver(t *testing.T) {
 		Type: "silver",
 		Data: &handlers.SilverEventData{
 			Amount:     750,
-			Session:    3000,
+			Total:      3000,
 			LootedBy:   "PlayerA",
 			LootedFrom: "BossNPC",
 		},
@@ -150,7 +150,7 @@ func TestFormatEventMessageKill(t *testing.T) {
 	event := Event{
 		Type: "kill",
 		Data: &handlers.KillEventData{
-			SessionKills: 5,
+			TotalKills: 5,
 		},
 		Timestamp: time.Now(),
 	}
@@ -360,7 +360,7 @@ func TestSetFullNumbersReRender(t *testing.T) {
 	e = e.AddEvents([]Event{
 		{
 			Type:      "fame",
-			Data:      &handlers.FameEventData{Gained: 1500, Total: 5000, Session: 3000},
+			Data:      &handlers.FameEventData{Gained: 1500, Total: 5000, AllTime: 3000},
 			Timestamp: time.Now(),
 		},
 	})

--- a/internal/tui/components/statspanel.go
+++ b/internal/tui/components/statspanel.go
@@ -225,7 +225,7 @@ func (s StatsPanel) View() string {
 		Foreground(lipgloss.Color("62")).
 		MarginBottom(1)
 
-	title := titleStyle.Render("Session Stats")
+	title := titleStyle.Render("Total Stats")
 
 	return boxStyle.Render(
 		lipgloss.JoinVertical(lipgloss.Left, title, content),

--- a/internal/tui/components/statspanel.go
+++ b/internal/tui/components/statspanel.go
@@ -243,8 +243,13 @@ func (s StatsPanel) View() string {
 		todayLabelStyle := lipgloss.NewStyle().
 			Foreground(lipgloss.Color("241")).
 			Width(8)
+		// The divider is not a data label; render it plain so it spans its
+		// natural width instead of being squeezed by the 8-cell label style
+		// (the separator "─ today ─" is 9 cells wide).
+		dividerStyle := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("241"))
 		statRows = append(statRows,
-			todayLabelStyle.Render("─ today ─"),
+			dividerStyle.Render("─ today ─"),
 			fmt.Sprintf("%s %s",
 				todayLabelStyle.Render("Fame"),
 				fameValueStyle.Render(formatNum(s.todayFame)),

--- a/internal/tui/components/statspanel.go
+++ b/internal/tui/components/statspanel.go
@@ -16,9 +16,13 @@ type StatsPanel struct {
 	kills        int
 	deaths       int
 	lootCount    int
-	width        int
-	height       int
-	fullNumbers  bool
+	// Today's totals (current calendar day) for the headline numeric stats.
+	todayFame   int64
+	todaySilver int64
+	todayRespec int64
+	width       int
+	height      int
+	fullNumbers bool
 }
 
 // NewStatsPanel creates a new StatsPanel component
@@ -77,6 +81,24 @@ func (s StatsPanel) SetRespecSilver(amount int64) StatsPanel {
 	return s
 }
 
+// SetTodayFame sets today's fame total.
+func (s StatsPanel) SetTodayFame(amount int64) StatsPanel {
+	s.todayFame = amount
+	return s
+}
+
+// SetTodaySilver sets today's silver total.
+func (s StatsPanel) SetTodaySilver(amount int64) StatsPanel {
+	s.todaySilver = amount
+	return s
+}
+
+// SetTodayRespec sets today's respec credits total.
+func (s StatsPanel) SetTodayRespec(amount int64) StatsPanel {
+	s.todayRespec = amount
+	return s
+}
+
 // IncrKills increments the kill counter
 func (s StatsPanel) IncrKills() StatsPanel {
 	s.kills++
@@ -123,6 +145,9 @@ func (s StatsPanel) Reset() StatsPanel {
 	s.kills = 0
 	s.deaths = 0
 	s.lootCount = 0
+	s.todayFame = 0
+	s.todaySilver = 0
+	s.todayRespec = 0
 	return s
 }
 
@@ -209,6 +234,30 @@ func (s StatsPanel) View() string {
 			labelStyle.Render("Loot"),
 			lootValueStyle.Render(fmt.Sprintf("%d items", s.lootCount)),
 		),
+	}
+
+	// "Today" breakdown for the headline numeric stats. Only rendered when at
+	// least one of today's values is non-zero, to avoid cluttering the panel on
+	// a fresh day or before any events arrive.
+	if s.todayFame != 0 || s.todaySilver != 0 || s.todayRespec != 0 {
+		todayLabelStyle := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("241")).
+			Width(8)
+		statRows = append(statRows,
+			todayLabelStyle.Render("─ today ─"),
+			fmt.Sprintf("%s %s",
+				todayLabelStyle.Render("Fame"),
+				fameValueStyle.Render(formatNum(s.todayFame)),
+			),
+			fmt.Sprintf("%s %s",
+				todayLabelStyle.Render("Silver"),
+				silverValueStyle.Render(formatNum(s.todaySilver)),
+			),
+			fmt.Sprintf("%s %s",
+				todayLabelStyle.Render("Respec"),
+				respecValueStyle.Render(formatNum(s.todayRespec)),
+			),
+		)
 	}
 
 	content := lipgloss.JoinVertical(lipgloss.Left, statRows...)

--- a/internal/tui/components/statspanel_test.go
+++ b/internal/tui/components/statspanel_test.go
@@ -320,3 +320,71 @@ func TestFormatAbbreviatedPreservesSign(t *testing.T) {
 		}
 	}
 }
+
+// --- Today rows (issue #112 / Phase 3) ---
+
+func TestStatsPanelSetTodayFame(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.SetTodayFame(12000)
+	if s.todayFame != 12000 {
+		t.Errorf("expected todayFame 12000, got %d", s.todayFame)
+	}
+}
+
+func TestStatsPanelSetTodaySilver(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.SetTodaySilver(3400)
+	if s.todaySilver != 3400 {
+		t.Errorf("expected todaySilver 3400, got %d", s.todaySilver)
+	}
+}
+
+func TestStatsPanelSetTodayRespec(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.SetTodayRespec(800)
+	if s.todayRespec != 800 {
+		t.Errorf("expected todayRespec 800, got %d", s.todayRespec)
+	}
+}
+
+func TestStatsPanelResetClearsToday(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.SetTodayFame(12000).SetTodaySilver(3400).SetTodayRespec(800)
+	s = s.Reset()
+	if s.todayFame != 0 || s.todaySilver != 0 || s.todayRespec != 0 {
+		t.Errorf("reset should zero today values, got fame=%d silver=%d respec=%d",
+			s.todayFame, s.todaySilver, s.todayRespec)
+	}
+}
+
+func TestStatsPanelViewShowsTodaySectionWhenNonZero(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.SetFullNumbers(true)
+	s = s.SetFame(1000000)
+	s = s.SetTodayFame(12000)
+	s = s.SetTodaySilver(3400)
+	s = s.SetSize(30, 24)
+
+	output := s.View()
+	if !strings.Contains(output, "today") {
+		t.Error("View should show a 'today' section when today values are non-zero")
+	}
+	if !strings.Contains(output, "12000") {
+		t.Error("View should contain today fame value 12000")
+	}
+	if !strings.Contains(output, "3400") {
+		t.Error("View should contain today silver value 3400")
+	}
+}
+
+func TestStatsPanelViewHidesTodaySectionWhenAllZero(t *testing.T) {
+	s := NewStatsPanel()
+	s = s.SetFullNumbers(true)
+	s = s.SetFame(1000000) // only cumulative, no today values
+	s = s.SetSize(30, 24)
+
+	output := s.View()
+	if strings.Contains(output, "today") {
+		t.Error("View should NOT show a 'today' section when all today values are zero")
+	}
+}

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -31,8 +31,8 @@ type OnlineMsg struct {
 // TickMsg is sent periodically to update the UI
 type TickMsg time.Time
 
-// SessionStatsMsg updates session-specific stats (fame, silver, etc.)
-type SessionStatsMsg struct {
+// TotalStatsMsg updates long-term stats (fame, silver, etc.)
+type TotalStatsMsg struct {
 	Fame   int64
 	Silver int64
 	Kills  int

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -102,7 +102,7 @@ func hydrateStatsPanel(panel components.StatsPanel, h *handlers.AlbionHandler) c
 	if h == nil {
 		return panel
 	}
-	snap := h.SessionSnapshot()
+	snap := h.TotalSnapshot()
 	return panel.
 		SetFame(snap.Fame).
 		SetSilver(snap.Silver).
@@ -257,34 +257,34 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch eventMsg.Type {
 			case "fame":
 				if data, ok := eventMsg.Data.(*handlers.FameEventData); ok && data != nil {
-					m.statsPanel = m.statsPanel.SetFame(data.Session)
-					displayMsg = fmt.Sprintf("⭐ FAME: +%s | Total: %s | Session: %s",
+					m.statsPanel = m.statsPanel.SetFame(data.AllTime)
+					displayMsg = fmt.Sprintf("⭐ FAME: +%s | Pool: %s | Total: %s",
 						formatNumber(data.Gained, m.fullNumbers),
 						formatNumber(data.Total, m.fullNumbers),
-						formatNumber(data.Session, m.fullNumbers))
+						formatNumber(data.AllTime, m.fullNumbers))
 				}
 			case "silver":
 				if data, ok := eventMsg.Data.(*handlers.SilverEventData); ok && data != nil {
-					m.statsPanel = m.statsPanel.SetSilver(data.Session)
-					displayMsg = fmt.Sprintf("💰 %s looted silver (%s) from %s | Session: %s",
+					m.statsPanel = m.statsPanel.SetSilver(data.Total)
+					displayMsg = fmt.Sprintf("💰 %s looted silver (%s) from %s | Total: %s",
 						data.LootedBy,
 						formatNumber(data.Amount, m.fullNumbers),
 						data.LootedFrom,
-						formatNumber(data.Session, m.fullNumbers))
+						formatNumber(data.Total, m.fullNumbers))
 				}
 			case "respec":
 				if data, ok := eventMsg.Data.(*handlers.RespecEventData); ok && data != nil {
-					m.statsPanel = m.statsPanel.SetRespec(data.SessionTotal)
-					m.statsPanel = m.statsPanel.SetRespecSilver(data.SessionSilverTotal)
+					m.statsPanel = m.statsPanel.SetRespec(data.Total)
+					m.statsPanel = m.statsPanel.SetRespecSilver(data.TotalSilver)
 					if data.PaidSilver > 0 {
-						displayMsg = fmt.Sprintf("🏆 RESPEC: +%s credits | Silver cost: -%s | Session: %s",
+						displayMsg = fmt.Sprintf("🏆 RESPEC: +%s credits | Silver cost: -%s | Total: %s",
 							formatNumber(data.Gained, m.fullNumbers),
 							formatNumber(data.PaidSilver, m.fullNumbers),
-							formatNumber(data.SessionTotal, m.fullNumbers))
+							formatNumber(data.Total, m.fullNumbers))
 					} else {
-						displayMsg = fmt.Sprintf("🏆 RESPEC: +%s credits | Session: %s",
+						displayMsg = fmt.Sprintf("🏆 RESPEC: +%s credits | Total: %s",
 							formatNumber(data.Gained, m.fullNumbers),
-							formatNumber(data.SessionTotal, m.fullNumbers))
+							formatNumber(data.Total, m.fullNumbers))
 					}
 				}
 			case "loot":
@@ -381,8 +381,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, TickCmd())
 		return m, tea.Batch(cmds...)
 
-	// Session stats update (from handler)
-	case SessionStatsMsg:
+	// Total stats update (from handler)
+	case TotalStatsMsg:
 		if msg.Fame > 0 {
 			m.statsPanel = m.statsPanel.AddFame(msg.Fame)
 		}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -89,20 +89,21 @@ func New(svc *backend.Service, bulkEventChan chan BulkEventMsg, statsChan chan *
 		m.onlineChan = svc.OnlineStatus
 		// Hydrate the stats panel with persisted cumulative counters so the
 		// dashboard shows long-term totals immediately rather than zeros.
-		m.statsPanel = hydrateStatsPanel(m.statsPanel, svc.Handler())
+		m.statsPanel = hydrateStatsPanel(m.statsPanel, svc.Handler(), time.Now())
 	}
 	return m
 }
 
-// hydrateStatsPanel seeds a stats panel from the handler's current session
-// snapshot. It is a no-op when the handler is nil (e.g. before the backend
-// service has started). Extracted from New so the hydration logic can be
-// tested without a running (pcap-backed) service.
-func hydrateStatsPanel(panel components.StatsPanel, h *handlers.AlbionHandler) components.StatsPanel {
+// hydrateStatsPanel seeds a stats panel from the handler's current long-term
+// snapshot, including today's daily bucket. It is a no-op when the handler is
+// nil (e.g. before the backend service has started). Extracted from New so the
+// hydration logic can be tested without a running (pcap-backed) service.
+func hydrateStatsPanel(panel components.StatsPanel, h *handlers.AlbionHandler, now time.Time) components.StatsPanel {
 	if h == nil {
 		return panel
 	}
 	snap := h.TotalSnapshot()
+	today := snap.Daily[now.Format("2006-01-02")]
 	return panel.
 		SetFame(snap.Fame).
 		SetSilver(snap.Silver).
@@ -110,7 +111,10 @@ func hydrateStatsPanel(panel components.StatsPanel, h *handlers.AlbionHandler) c
 		SetRespecSilver(snap.RespecSilver).
 		SetKills(int(snap.Kills)).
 		SetDeaths(int(snap.Deaths)).
-		SetLoot(int(snap.Loot))
+		SetLoot(int(snap.Loot)).
+		SetTodayFame(today.Fame).
+		SetTodaySilver(today.Silver).
+		SetTodayRespec(today.Respec)
 }
 
 // defaultHiddenDebugEvents returns the set of high-frequency / low-signal debug
@@ -257,7 +261,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch eventMsg.Type {
 			case "fame":
 				if data, ok := eventMsg.Data.(*handlers.FameEventData); ok && data != nil {
-					m.statsPanel = m.statsPanel.SetFame(data.AllTime)
+					m.statsPanel = m.statsPanel.SetFame(data.AllTime).SetTodayFame(data.Daily)
 					displayMsg = fmt.Sprintf("⭐ FAME: +%s | Pool: %s | Total: %s",
 						formatNumber(data.Gained, m.fullNumbers),
 						formatNumber(data.Total, m.fullNumbers),
@@ -265,7 +269,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			case "silver":
 				if data, ok := eventMsg.Data.(*handlers.SilverEventData); ok && data != nil {
-					m.statsPanel = m.statsPanel.SetSilver(data.Total)
+					m.statsPanel = m.statsPanel.SetSilver(data.Total).SetTodaySilver(data.Daily)
 					displayMsg = fmt.Sprintf("💰 %s looted silver (%s) from %s | Total: %s",
 						data.LootedBy,
 						formatNumber(data.Amount, m.fullNumbers),
@@ -274,8 +278,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			case "respec":
 				if data, ok := eventMsg.Data.(*handlers.RespecEventData); ok && data != nil {
-					m.statsPanel = m.statsPanel.SetRespec(data.Total)
-					m.statsPanel = m.statsPanel.SetRespecSilver(data.TotalSilver)
+					m.statsPanel = m.statsPanel.SetRespec(data.Total).
+						SetRespecSilver(data.TotalSilver).
+						SetTodayRespec(data.Daily)
 					if data.PaidSilver > 0 {
 						displayMsg = fmt.Sprintf("🏆 RESPEC: +%s credits | Silver cost: -%s | Total: %s",
 							formatNumber(data.Gained, m.fullNumbers),

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -102,8 +102,8 @@ func TestHydrateStatsPanel(t *testing.T) {
 	if err := os.WriteFile(path, seed, 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	if err := h.LoadSessionStats(path); err != nil {
-		t.Fatalf("LoadSessionStats: %v", err)
+	if err := h.LoadTotalStats(path); err != nil {
+		t.Fatalf("LoadTotalStats: %v", err)
 	}
 
 	panel := hydrateStatsPanel(components.NewStatsPanel(), h)
@@ -501,7 +501,7 @@ func TestUpdateKeyReset(t *testing.T) {
 
 	// Add some stats via events
 	m = updateModel(m, BulkEventMsg{
-		{Type: "fame", Data: &handlers.FameEventData{Gained: 100, Total: 500, Session: 200},
+		{Type: "fame", Data: &handlers.FameEventData{Gained: 100, Total: 500, AllTime: 200},
 			Timestamp: time.Now()},
 	})
 
@@ -535,7 +535,7 @@ func TestUpdateBulkEventFame(t *testing.T) {
 	bulkMsg := BulkEventMsg{
 		{
 			Type:      "fame",
-			Data:      &handlers.FameEventData{Gained: 100, Total: 500, Session: 200},
+			Data:      &handlers.FameEventData{Gained: 100, Total: 500, AllTime: 200},
 			Timestamp: time.Now(),
 		},
 	}
@@ -556,7 +556,7 @@ func TestUpdateBulkEventSilver(t *testing.T) {
 			Type: "silver",
 			Data: &handlers.SilverEventData{
 				Amount:     500,
-				Session:    1000,
+				Total:      1000,
 				LootedBy:   "Player1",
 				LootedFrom: "Mob",
 			},
@@ -578,7 +578,7 @@ func TestUpdateBulkEventKillDeath(t *testing.T) {
 	bulkMsg := BulkEventMsg{
 		{
 			Type:      "kill",
-			Data:      &handlers.KillEventData{SessionKills: 1},
+			Data:      &handlers.KillEventData{TotalKills: 1},
 			Timestamp: time.Now(),
 		},
 		{
@@ -665,14 +665,14 @@ func TestUpdateOnlineMsg(t *testing.T) {
 	}
 }
 
-func TestUpdateSessionStatsMsg(t *testing.T) {
+func TestUpdateTotalStatsMsg(t *testing.T) {
 	m := readyModel()
 
-	m = updateModel(m, SessionStatsMsg{Fame: 500, Silver: 1000})
+	m = updateModel(m, TotalStatsMsg{Fame: 500, Silver: 1000})
 
 	statsView := m.statsPanel.View()
 	if !strings.Contains(statsView, "Fame") {
-		t.Error("expected Fame in stats after SessionStatsMsg")
+		t.Error("expected Fame in stats after TotalStatsMsg")
 	}
 }
 
@@ -755,8 +755,8 @@ func TestViewReady(t *testing.T) {
 	if !strings.Contains(view, "Events") {
 		t.Error("expected 'Events' section in ready view")
 	}
-	if !strings.Contains(view, "Session Stats") {
-		t.Error("expected 'Session Stats' section in ready view")
+	if !strings.Contains(view, "Total Stats") {
+		t.Error("expected 'Total Stats' section in ready view")
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -106,7 +106,7 @@ func TestHydrateStatsPanel(t *testing.T) {
 		t.Fatalf("LoadTotalStats: %v", err)
 	}
 
-	panel := hydrateStatsPanel(components.NewStatsPanel(), h)
+	panel := hydrateStatsPanel(components.NewStatsPanel(), h, time.Now())
 	// NewStatsPanel defaults to fullNumbers, so fame renders as "+123456".
 	view := panel.View()
 	for _, want := range []string{"123456", "987654", "99 items"} {
@@ -118,9 +118,36 @@ func TestHydrateStatsPanel(t *testing.T) {
 
 func TestHydrateStatsPanelNilHandlerIsNoOp(t *testing.T) {
 	empty := components.NewStatsPanel()
-	got := hydrateStatsPanel(empty, nil)
+	got := hydrateStatsPanel(empty, nil, time.Now())
 	if got.View() != empty.View() {
 		t.Error("hydrateStatsPanel with nil handler should leave the panel unchanged")
+	}
+}
+
+// TestHydrateStatsPanelSeedsTodayFromDailyBucket verifies that hydration picks
+// up today's daily bucket values (fame/silver/respec) from persisted state.
+func TestHydrateStatsPanelSeedsTodayFromDailyBucket(t *testing.T) {
+	h := handlers.NewAlbionHandler()
+
+	// Seed with a v2 file that has a daily bucket for 2026-07-01.
+	path := filepath.Join(t.TempDir(), "stats.json")
+	seed := []byte(`{"version":2,"fame":1000000,"silver":500000,"respec":20000,"respec_silver":1000,"kills":42,"deaths":17,"loot":99,"daily":{"2026-07-01":{"fame":12000,"silver":3400,"respec":800,"respec_silver":0,"kills":0,"deaths":0,"loot":0}},"saved_at":"2026-07-01T12:00:00Z"}`)
+	if err := os.WriteFile(path, seed, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := h.LoadTotalStats(path); err != nil {
+		t.Fatalf("LoadTotalStats: %v", err)
+	}
+
+	// Hydrate using the same date the bucket is keyed on.
+	now := time.Date(2026, 7, 1, 14, 0, 0, 0, time.UTC)
+	panel := hydrateStatsPanel(components.NewStatsPanel(), h, now)
+	view := panel.View()
+
+	for _, want := range []string{"12000", "3400", "800", "today"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("stats panel view missing %q after hydration with daily bucket\n%s", want, view)
+		}
 	}
 }
 
@@ -545,6 +572,30 @@ func TestUpdateBulkEventFame(t *testing.T) {
 	view := m.View().Content
 	if !strings.Contains(view, "Fame") {
 		t.Error("expected 'Fame' in stats panel after fame event")
+	}
+}
+
+// TestUpdateBulkEventFameSetsToday verifies the event's Daily value flows into
+// the stats panel's "today" row.
+func TestUpdateBulkEventFameSetsToday(t *testing.T) {
+	m := readyModel()
+
+	bulkMsg := BulkEventMsg{
+		{
+			Type:      "fame",
+			Data:      &handlers.FameEventData{Gained: 100, Total: 500, AllTime: 200, Daily: 12000},
+			Timestamp: time.Now(),
+		},
+	}
+
+	m = updateModel(m, bulkMsg)
+
+	view := m.View().Content
+	if !strings.Contains(view, "today") {
+		t.Error("expected 'today' section in stats panel after fame event with Daily value")
+	}
+	if !strings.Contains(view, "12000") {
+		t.Error("expected today fame value 12000 in stats panel")
 	}
 }
 

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -263,7 +263,7 @@ func TestFameDataStructure(t *testing.T) {
 	data := FameData{
 		Gained:  1000,
 		Total:   50000,
-		Session: 5000,
+		AllTime: 5000,
 	}
 
 	if data.Gained != 1000 {
@@ -274,24 +274,24 @@ func TestFameDataStructure(t *testing.T) {
 		t.Errorf("Total: expected 50000, got %d", data.Total)
 	}
 
-	if data.Session != 5000 {
-		t.Errorf("Session: expected 5000, got %d", data.Session)
+	if data.AllTime != 5000 {
+		t.Errorf("AllTime: expected 5000, got %d", data.AllTime)
 	}
 }
 
 // TestSilverDataStructure tests SilverData struct
 func TestSilverDataStructure(t *testing.T) {
 	data := SilverData{
-		Amount:  5000,
-		Session: 25000,
+		Amount: 5000,
+		Total:  25000,
 	}
 
 	if data.Amount != 5000 {
 		t.Errorf("Amount: expected 5000, got %d", data.Amount)
 	}
 
-	if data.Session != 25000 {
-		t.Errorf("Session: expected 25000, got %d", data.Session)
+	if data.Total != 25000 {
+		t.Errorf("Total: expected 25000, got %d", data.Total)
 	}
 }
 
@@ -331,7 +331,7 @@ func TestCombatDataStructure(t *testing.T) {
 	data := CombatData{
 		KillerName: "Attacker",
 		VictimName: "Victim",
-		Session:    5,
+		Total:      5,
 	}
 
 	if data.KillerName != "Attacker" {
@@ -342,8 +342,8 @@ func TestCombatDataStructure(t *testing.T) {
 		t.Errorf("VictimName: expected 'Victim', got '%s'", data.VictimName)
 	}
 
-	if data.Session != 5 {
-		t.Errorf("Session: expected 5, got %d", data.Session)
+	if data.Total != 5 {
+		t.Errorf("Total: expected 5, got %d", data.Total)
 	}
 }
 
@@ -400,32 +400,32 @@ func TestServiceIsOnlineWithoutCapture(t *testing.T) {
 func TestServiceSessionMetricsWithoutHandler(t *testing.T) {
 	s := New()
 
-	if s.SessionFame() != 0 {
-		t.Errorf("SessionFame: expected 0, got %d", s.SessionFame())
+	if s.TotalFame() != 0 {
+		t.Errorf("TotalFame: expected 0, got %d", s.TotalFame())
 	}
 
-	if s.SessionSilver() != 0 {
-		t.Errorf("SessionSilver: expected 0, got %d", s.SessionSilver())
+	if s.TotalSilver() != 0 {
+		t.Errorf("TotalSilver: expected 0, got %d", s.TotalSilver())
 	}
 
-	if s.SessionKills() != 0 {
-		t.Errorf("SessionKills: expected 0, got %d", s.SessionKills())
+	if s.TotalKills() != 0 {
+		t.Errorf("TotalKills: expected 0, got %d", s.TotalKills())
 	}
 
-	if s.SessionDeaths() != 0 {
-		t.Errorf("SessionDeaths: expected 0, got %d", s.SessionDeaths())
+	if s.TotalDeaths() != 0 {
+		t.Errorf("TotalDeaths: expected 0, got %d", s.TotalDeaths())
 	}
 
-	if s.SessionLoot() != 0 {
-		t.Errorf("SessionLoot: expected 0, got %d", s.SessionLoot())
+	if s.TotalLoot() != 0 {
+		t.Errorf("TotalLoot: expected 0, got %d", s.TotalLoot())
 	}
 
-	if s.SessionRespec() != 0 {
-		t.Errorf("SessionRespec: expected 0, got %d", s.SessionRespec())
+	if s.TotalRespec() != 0 {
+		t.Errorf("TotalRespec: expected 0, got %d", s.TotalRespec())
 	}
 
-	if s.SessionRespecSilver() != 0 {
-		t.Errorf("SessionRespecSilver: expected 0, got %d", s.SessionRespecSilver())
+	if s.TotalRespecSilver() != 0 {
+		t.Errorf("TotalRespecSilver: expected 0, got %d", s.TotalRespecSilver())
 	}
 }
 

--- a/pkg/backend/events.go
+++ b/pkg/backend/events.go
@@ -30,14 +30,14 @@ type GameEvent struct {
 // FameData contains fame-specific event data
 type FameData struct {
 	Gained  int64 // Fame gained in this event
-	Total   int64 // Total fame after this event
-	Session int64 // Total fame gained this session
+	Total   int64 // Total fame pool reported by the server after this event
+	AllTime int64 // Cumulative fame gained across all launches (long-term total)
 }
 
 // SilverData contains silver-specific event data
 type SilverData struct {
-	Amount  int64 // Silver amount in this event
-	Session int64 // Total silver gained this session
+	Amount int64 // Silver amount in this event
+	Total  int64 // Cumulative silver gained across all launches (long-term total)
 }
 
 // LootData contains loot-specific event data
@@ -53,5 +53,5 @@ type LootData struct {
 type CombatData struct {
 	KillerName string // Name of the killer
 	VictimName string // Name of the victim
-	Session    int    // Total kills or deaths this session
+	Total      int    // Cumulative kills or deaths across all launches (long-term total)
 }

--- a/pkg/backend/service.go
+++ b/pkg/backend/service.go
@@ -313,7 +313,7 @@ func (s *Service) IsOnline() bool {
 	return s.capture.IsOnline()
 }
 
-// TotalFame returns the cumulative fame gained across all launches..
+// TotalFame returns the cumulative fame gained across all launches.
 func (s *Service) TotalFame() int64 {
 	if s.handler == nil {
 		return 0
@@ -321,7 +321,7 @@ func (s *Service) TotalFame() int64 {
 	return s.handler.GetTotalFame()
 }
 
-// TotalSilver returns the cumulative silver gained across all launches..
+// TotalSilver returns the cumulative silver gained across all launches.
 func (s *Service) TotalSilver() int64 {
 	if s.handler == nil {
 		return 0
@@ -329,7 +329,7 @@ func (s *Service) TotalSilver() int64 {
 	return s.handler.GetTotalSilver()
 }
 
-// TotalRespec returns the cumulative combat fame credits gained across all launches..
+// TotalRespec returns the cumulative combat fame credits gained across all launches.
 func (s *Service) TotalRespec() int64 {
 	if s.handler == nil {
 		return 0
@@ -337,7 +337,7 @@ func (s *Service) TotalRespec() int64 {
 	return s.handler.GetTotalRespec()
 }
 
-// TotalRespecSilver returns the cumulative silver spent on auto-respec across all launches..
+// TotalRespecSilver returns the cumulative silver spent on auto-respec across all launches.
 func (s *Service) TotalRespecSilver() int64 {
 	if s.handler == nil {
 		return 0
@@ -345,7 +345,7 @@ func (s *Service) TotalRespecSilver() int64 {
 	return s.handler.GetTotalRespecSilver()
 }
 
-// TotalKills returns the cumulative number of kills across all launches..
+// TotalKills returns the cumulative number of kills across all launches.
 func (s *Service) TotalKills() int {
 	if s.handler == nil {
 		return 0
@@ -353,7 +353,7 @@ func (s *Service) TotalKills() int {
 	return s.handler.GetTotalKills()
 }
 
-// TotalDeaths returns the cumulative number of deaths across all launches..
+// TotalDeaths returns the cumulative number of deaths across all launches.
 func (s *Service) TotalDeaths() int {
 	if s.handler == nil {
 		return 0
@@ -361,7 +361,7 @@ func (s *Service) TotalDeaths() int {
 	return s.handler.GetTotalDeaths()
 }
 
-// TotalLoot returns the cumulative number of loot items across all launches..
+// TotalLoot returns the cumulative number of loot items across all launches.
 func (s *Service) TotalLoot() int {
 	if s.handler == nil {
 		return 0

--- a/pkg/backend/service.go
+++ b/pkg/backend/service.go
@@ -313,60 +313,60 @@ func (s *Service) IsOnline() bool {
 	return s.capture.IsOnline()
 }
 
-// SessionFame returns the total fame gained in this session.
-func (s *Service) SessionFame() int64 {
+// TotalFame returns the cumulative fame gained across all launches..
+func (s *Service) TotalFame() int64 {
 	if s.handler == nil {
 		return 0
 	}
-	return s.handler.GetSessionFame()
+	return s.handler.GetTotalFame()
 }
 
-// SessionSilver returns the total silver gained in this session.
-func (s *Service) SessionSilver() int64 {
+// TotalSilver returns the cumulative silver gained across all launches..
+func (s *Service) TotalSilver() int64 {
 	if s.handler == nil {
 		return 0
 	}
-	return s.handler.GetSessionSilver()
+	return s.handler.GetTotalSilver()
 }
 
-// SessionRespec returns the total combat fame credits gained in this session.
-func (s *Service) SessionRespec() int64 {
+// TotalRespec returns the cumulative combat fame credits gained across all launches..
+func (s *Service) TotalRespec() int64 {
 	if s.handler == nil {
 		return 0
 	}
-	return s.handler.GetSessionRespec()
+	return s.handler.GetTotalRespec()
 }
 
-// SessionRespecSilver returns the total silver spent on auto-respec this session.
-func (s *Service) SessionRespecSilver() int64 {
+// TotalRespecSilver returns the cumulative silver spent on auto-respec across all launches..
+func (s *Service) TotalRespecSilver() int64 {
 	if s.handler == nil {
 		return 0
 	}
-	return s.handler.GetSessionRespecSilver()
+	return s.handler.GetTotalRespecSilver()
 }
 
-// SessionKills returns the number of kills in this session.
-func (s *Service) SessionKills() int {
+// TotalKills returns the cumulative number of kills across all launches..
+func (s *Service) TotalKills() int {
 	if s.handler == nil {
 		return 0
 	}
-	return s.handler.GetSessionKills()
+	return s.handler.GetTotalKills()
 }
 
-// SessionDeaths returns the number of deaths in this session.
-func (s *Service) SessionDeaths() int {
+// TotalDeaths returns the cumulative number of deaths across all launches..
+func (s *Service) TotalDeaths() int {
 	if s.handler == nil {
 		return 0
 	}
-	return s.handler.GetSessionDeaths()
+	return s.handler.GetTotalDeaths()
 }
 
-// SessionLoot returns the number of loot items in this session.
-func (s *Service) SessionLoot() int {
+// TotalLoot returns the cumulative number of loot items across all launches..
+func (s *Service) TotalLoot() int {
 	if s.handler == nil {
 		return 0
 	}
-	return s.handler.GetSessionLoot()
+	return s.handler.GetTotalLoot()
 }
 
 // LocalPlayerName returns the auto-detected local player name, or "" if the

--- a/pkg/handlers/albion.go
+++ b/pkg/handlers/albion.go
@@ -1343,7 +1343,12 @@ func (h *AlbionHandler) handleUpdateReSpecPoints(params map[byte]interface{}) {
 	silverVal := int64(math.Floor(float64(paidSilver) / 10000.0))
 
 	h.stats.addRespec(gainedVal, h.nowFunc())
-	h.stats.addRespecSilver(silverVal, h.nowFunc())
+	// Respect can be free (premium, or when the credit pool incurs no silver
+	// cost), so paidSilver is frequently zero. Skip the lock + bucket write in
+	// that case — adding zero would be a no-op but still acquire the write lock.
+	if silverVal > 0 {
+		h.stats.addRespecSilver(silverVal, h.nowFunc())
+	}
 
 	h.notifyEvent("respec", "", &RespecEventData{
 		Gained:      gainedVal,

--- a/pkg/handlers/albion.go
+++ b/pkg/handlers/albion.go
@@ -31,27 +31,27 @@ type EventCallback func(eventType, message string, data interface{})
 // testing via AlbionHandler.deathDedupWindow.
 const defaultDeathDedupWindow = 5 * time.Second
 
-// sessionCounters holds the seven cumulative session counters behind a single
+// totalCounters holds the seven cumulative session counters behind a single
 // RWMutex so a snapshot reads all of them consistently (independent atomics
 // would allow a snapshot to mix pre- and post-update values). The lock is
 // fine-grained: event handlers take a write lock per increment, persistence
 // and UI hydration take a read lock for the whole set.
-type sessionCounters struct {
-	mu            sync.RWMutex
-	fame          int64
-	silver        int64
-	respec        int64
-	respecSilver  int64
-	kills         int64
-	deaths        int64
-	loot          int64
+type totalCounters struct {
+	mu           sync.RWMutex
+	fame         int64
+	silver       int64
+	respec       int64
+	respecSilver int64
+	kills        int64
+	deaths       int64
+	loot         int64
 }
 
 // snapshot returns a consistent point-in-time copy of all seven counters.
-func (c *sessionCounters) snapshot() SessionStats {
+func (c *totalCounters) snapshot() TotalStats {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return SessionStats{
+	return TotalStats{
 		Fame:         c.fame,
 		Silver:       c.silver,
 		Respec:       c.respec,
@@ -63,7 +63,7 @@ func (c *sessionCounters) snapshot() SessionStats {
 }
 
 // apply overwrites all seven counters. Used when restoring persisted state.
-func (c *sessionCounters) apply(s SessionStats) {
+func (c *totalCounters) apply(s TotalStats) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.fame = s.Fame
@@ -75,85 +75,85 @@ func (c *sessionCounters) apply(s SessionStats) {
 	c.loot = s.Loot
 }
 
-func (c *sessionCounters) addFame(n int64) {
+func (c *totalCounters) addFame(n int64) {
 	c.mu.Lock()
 	c.fame += n
 	c.mu.Unlock()
 }
 
-func (c *sessionCounters) addSilver(n int64) {
+func (c *totalCounters) addSilver(n int64) {
 	c.mu.Lock()
 	c.silver += n
 	c.mu.Unlock()
 }
 
-func (c *sessionCounters) addRespec(n int64) {
+func (c *totalCounters) addRespec(n int64) {
 	c.mu.Lock()
 	c.respec += n
 	c.mu.Unlock()
 }
 
-func (c *sessionCounters) addRespecSilver(n int64) {
+func (c *totalCounters) addRespecSilver(n int64) {
 	c.mu.Lock()
 	c.respecSilver += n
 	c.mu.Unlock()
 }
 
-func (c *sessionCounters) addKill() {
+func (c *totalCounters) addKill() {
 	c.mu.Lock()
 	c.kills++
 	c.mu.Unlock()
 }
 
-func (c *sessionCounters) addDeath() {
+func (c *totalCounters) addDeath() {
 	c.mu.Lock()
 	c.deaths++
 	c.mu.Unlock()
 }
 
-func (c *sessionCounters) addLoot() {
+func (c *totalCounters) addLoot() {
 	c.mu.Lock()
 	c.loot++
 	c.mu.Unlock()
 }
 
-func (c *sessionCounters) fameNow() int64 {
+func (c *totalCounters) fameNow() int64 {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.fame
 }
 
-func (c *sessionCounters) silverNow() int64 {
+func (c *totalCounters) silverNow() int64 {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.silver
 }
 
-func (c *sessionCounters) respecNow() int64 {
+func (c *totalCounters) respecNow() int64 {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.respec
 }
 
-func (c *sessionCounters) respecSilverNow() int64 {
+func (c *totalCounters) respecSilverNow() int64 {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.respecSilver
 }
 
-func (c *sessionCounters) killsNow() int {
+func (c *totalCounters) killsNow() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return int(c.kills)
 }
 
-func (c *sessionCounters) deathsNow() int {
+func (c *totalCounters) deathsNow() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return int(c.deaths)
 }
 
-func (c *sessionCounters) lootNow() int {
+func (c *totalCounters) lootNow() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return int(c.loot)
@@ -169,7 +169,7 @@ type AlbionHandler struct {
 
 	// Cumulative session counters (fame, silver, respec, respecSilver, kills,
 	// deaths, loot). Grouped under one RWMutex so snapshots are consistent.
-	stats sessionCounters
+	stats totalCounters
 
 	// Items database
 	itemDB *items.ItemDatabase
@@ -371,17 +371,17 @@ func (h *AlbionHandler) debugNotify(message string, data interface{}) {
 // FameEventData contains fame-specific event data
 type FameEventData struct {
 	Gained  int64 // Fame gained in this event
-	Total   int64 // Total fame after this event
-	Session int64 // Total fame gained this session
+	Total   int64 // Total fame pool reported by the server after this event
+	AllTime int64 // Cumulative fame gained across all launches (long-term total)
 }
 
 // SilverEventData contains silver-specific event data
 type SilverEventData struct {
 	Amount     int64  // Silver amount in this event
-	Session    int64  // Total silver gained this session
+	Total      int64  // Cumulative silver gained across all launches (long-term total)
 	LootedBy   string // Player who looted
 	LootedFrom string // Source of the loot
-	Counted    bool   // Whether this amount was added to the session total
+	Counted    bool   // Whether this amount was added to the long-term total
 }
 
 // LootEventData contains loot-specific event data
@@ -394,22 +394,22 @@ type LootEventData struct {
 
 // KillEventData contains kill-specific event data
 type KillEventData struct {
-	SessionKills int // Total kills in this session
+	TotalKills int // Cumulative kills across all launches (long-term total)
 }
 
 // DeathEventData contains death-specific event data
 type DeathEventData struct {
-	Victim        string // Player who died
-	Killer        string // Player who killed
-	SessionDeaths int    // Total deaths in this session
+	Victim      string // Player who died
+	Killer      string // Player who killed
+	TotalDeaths int    // Cumulative deaths across all launches (long-term total)
 }
 
 // RespecEventData contains respec-specific event data
 type RespecEventData struct {
-	Gained             int64 // Credits gained in this event
-	PaidSilver         int64 // Silver paid for auto-respec in this event
-	SessionTotal       int64 // Total credits gained this session
-	SessionSilverTotal int64 // Total silver spent on auto-respec this session
+	Gained      int64 // Credits gained in this event
+	PaidSilver  int64 // Silver paid for auto-respec in this event
+	Total       int64 // Cumulative credits gained across all launches (long-term total)
+	TotalSilver int64 // Cumulative silver spent on auto-respec across all launches
 }
 
 // ZoneEventData contains zone-transition event data emitted on ChangeCluster.
@@ -421,18 +421,18 @@ type ZoneEventData struct {
 	Previous     MapType // The zone the player left (MapTypeUnknown on first transition)
 }
 
-// GetSessionKills returns the number of kills in this session
-func (h *AlbionHandler) GetSessionKills() int {
+// GetTotalKills returns the number of kills in this session
+func (h *AlbionHandler) GetTotalKills() int {
 	return h.stats.killsNow()
 }
 
-// GetSessionDeaths returns the number of deaths in this session
-func (h *AlbionHandler) GetSessionDeaths() int {
+// GetTotalDeaths returns the number of deaths in this session
+func (h *AlbionHandler) GetTotalDeaths() int {
 	return h.stats.deathsNow()
 }
 
-// GetSessionLoot returns the number of loot items in this session
-func (h *AlbionHandler) GetSessionLoot() int {
+// GetTotalLoot returns the number of loot items in this session
+func (h *AlbionHandler) GetTotalLoot() int {
 	return h.stats.lootNow()
 }
 
@@ -725,30 +725,30 @@ func (h *AlbionHandler) LoadDungeonRuns(path string) error {
 	return nil
 }
 
-// GetSessionFame returns the total fame gained in this session
-func (h *AlbionHandler) GetSessionFame() int64 {
+// GetTotalFame returns the total fame gained in this session
+func (h *AlbionHandler) GetTotalFame() int64 {
 	return h.stats.fameNow()
 }
 
-// GetSessionSilver returns the total silver looted in this session
-func (h *AlbionHandler) GetSessionSilver() int64 {
+// GetTotalSilver returns the total silver looted in this session
+func (h *AlbionHandler) GetTotalSilver() int64 {
 	return h.stats.silverNow()
 }
 
-// GetSessionRespec returns the total combat fame credits gained in this session
-func (h *AlbionHandler) GetSessionRespec() int64 {
+// GetTotalRespec returns the total combat fame credits gained in this session
+func (h *AlbionHandler) GetTotalRespec() int64 {
 	return h.stats.respecNow()
 }
 
-// GetSessionRespecSilver returns the total silver spent on auto-respec this session
-func (h *AlbionHandler) GetSessionRespecSilver() int64 {
+// GetTotalRespecSilver returns the total silver spent on auto-respec this session
+func (h *AlbionHandler) GetTotalRespecSilver() int64 {
 	return h.stats.respecSilverNow()
 }
 
 // SessionStats is a point-in-time snapshot of the cumulative session counters,
 // used to hydrate the UI on startup. All fields are absolute totals read
 // atomically.
-type SessionStats struct {
+type TotalStats struct {
 	Fame         int64
 	Silver       int64
 	Respec       int64
@@ -758,25 +758,25 @@ type SessionStats struct {
 	Loot         int64
 }
 
-// SessionSnapshot returns the current cumulative session counters. Safe to
+// TotalSnapshot returns the current cumulative session counters. Safe to
 // call concurrently with event processing.
-func (h *AlbionHandler) SessionSnapshot() SessionStats {
-	return h.readSessionStats()
+func (h *AlbionHandler) TotalSnapshot() TotalStats {
+	return h.readTotalStats()
 }
 
-// readSessionStats is the single source of truth for reading the seven
+// readTotalStats is the single source of truth for reading the seven
 // cumulative counters into a consistent SessionStats snapshot.
-func (h *AlbionHandler) readSessionStats() SessionStats {
+func (h *AlbionHandler) readTotalStats() TotalStats {
 	return h.stats.snapshot()
 }
 
-// applySessionStats is the single source of truth for writing the seven
-// cumulative counters from a SessionStats (the inverse of readSessionStats).
-func (h *AlbionHandler) applySessionStats(s SessionStats) {
+// applyTotalStats is the single source of truth for writing the seven
+// cumulative counters from a SessionStats (the inverse of readTotalStats).
+func (h *AlbionHandler) applyTotalStats(s TotalStats) {
 	h.stats.apply(s)
 }
 
-// sessionStatsFile is the on-disk JSON representation of SessionStats. The
+// totalStatsFile is the on-disk JSON representation of SessionStats. The
 // Version field is reserved for future additive schema migrations; missing
 // fields in an old file default to zero via encoding/json.
 //
@@ -785,7 +785,7 @@ func (h *AlbionHandler) applySessionStats(s SessionStats) {
 // single session — this matches issue #104's intent. The "session" naming is
 // retained for now and will be revisited when daily/hourly bucketing lands
 // (follow-up #105).
-type sessionStatsFile struct {
+type totalStatsFile struct {
 	Version      int       `json:"version"`
 	Fame         int64     `json:"fame"`
 	Silver       int64     `json:"silver"`
@@ -797,15 +797,15 @@ type sessionStatsFile struct {
 	SavedAt      time.Time `json:"saved_at"`
 }
 
-// sessionStatsVersion is the current on-disk schema version for session stats.
-const sessionStatsVersion = 1
+// totalStatsVersion is the current on-disk schema version for session stats.
+const totalStatsVersion = 1
 
-// SaveSessionStats persists the cumulative session counters to path as JSON
+// SaveTotalStats persists the cumulative session counters to path as JSON
 // using an atomic write (tmp + rename).
-func (h *AlbionHandler) SaveSessionStats(path string) error {
-	s := h.readSessionStats()
-	f := sessionStatsFile{
-		Version:      sessionStatsVersion,
+func (h *AlbionHandler) SaveTotalStats(path string) error {
+	s := h.readTotalStats()
+	f := totalStatsFile{
+		Version:      totalStatsVersion,
 		Fame:         s.Fame,
 		Silver:       s.Silver,
 		Respec:       s.Respec,
@@ -818,17 +818,17 @@ func (h *AlbionHandler) SaveSessionStats(path string) error {
 	return storage.Save(path, f)
 }
 
-// LoadSessionStats restores the cumulative session counters from path. A
+// LoadTotalStats restores the cumulative session counters from path. A
 // missing file leaves counters at zero (first run). A corrupt file is returned
 // as err and leaves the counters unchanged. The schema is additive: a version
 // mismatch or missing fields apply best-effort (unknown/absent fields default
 // to zero).
-func (h *AlbionHandler) LoadSessionStats(path string) error {
-	f, err := storage.Load[sessionStatsFile](path)
+func (h *AlbionHandler) LoadTotalStats(path string) error {
+	f, err := storage.Load[totalStatsFile](path)
 	if err != nil {
 		return err
 	}
-	h.applySessionStats(SessionStats{
+	h.applyTotalStats(TotalStats{
 		Fame:         f.Fame,
 		Silver:       f.Silver,
 		Respec:       f.Respec,
@@ -899,7 +899,7 @@ func (h *AlbionHandler) handleUpdateFame(params map[byte]interface{}) {
 			h.notifyEvent("fame", "", &FameEventData{
 				Gained:  int64(fameGainedVal),
 				Total:   int64(totalFameVal),
-				Session: h.stats.fameNow(),
+				AllTime: h.stats.fameNow(),
 			})
 		}
 	} else {
@@ -914,7 +914,7 @@ func (h *AlbionHandler) handleUpdateFame(params map[byte]interface{}) {
 				h.notifyEvent("fame", "", &FameEventData{
 					Gained:  int64(gainedVal),
 					Total:   int64(totalFameVal),
-					Session: h.stats.fameNow(),
+					AllTime: h.stats.fameNow(),
 				})
 			}
 		}
@@ -998,7 +998,7 @@ func (h *AlbionHandler) handleOtherGrabbedLoot(params map[byte]interface{}) {
 		// We just pass the raw data
 		h.notifyEvent("silver", "", &SilverEventData{
 			Amount:     silverAmount,
-			Session:    h.stats.silverNow(),
+			Total:      h.stats.silverNow(),
 			LootedBy:   lootedBy,
 			LootedFrom: lootedFrom,
 			Counted:    counted,
@@ -1113,7 +1113,7 @@ func (h *AlbionHandler) handleDied(params map[byte]interface{}) {
 	if isLocalKill {
 		h.stats.addKill()
 		h.notifyEvent("kill", "", &KillEventData{
-			SessionKills: h.stats.killsNow(),
+			TotalKills: h.stats.killsNow(),
 		})
 	}
 
@@ -1127,9 +1127,9 @@ func (h *AlbionHandler) handleDied(params map[byte]interface{}) {
 	// killer — the kill event already covers it and avoids a duplicate entry.
 	if !isLocalKill {
 		h.notifyEvent("death", "", &DeathEventData{
-			Victim:        victim,
-			Killer:        killer,
-			SessionDeaths: h.stats.deathsNow(),
+			Victim:      victim,
+			Killer:      killer,
+			TotalDeaths: h.stats.deathsNow(),
 		})
 	}
 }
@@ -1151,10 +1151,10 @@ func (h *AlbionHandler) handleUpdateReSpecPoints(params map[byte]interface{}) {
 	h.stats.addRespecSilver(silverVal)
 
 	h.notifyEvent("respec", "", &RespecEventData{
-		Gained:             gainedVal,
-		PaidSilver:         silverVal,
-		SessionTotal:       h.stats.respecNow(),
-		SessionSilverTotal: h.stats.respecSilverNow(),
+		Gained:      gainedVal,
+		PaidSilver:  silverVal,
+		Total:       h.stats.respecNow(),
+		TotalSilver: h.stats.respecSilverNow(),
 	})
 }
 

--- a/pkg/handlers/albion.go
+++ b/pkg/handlers/albion.go
@@ -31,23 +31,52 @@ type EventCallback func(eventType, message string, data interface{})
 // testing via AlbionHandler.deathDedupWindow.
 const defaultDeathDedupWindow = 5 * time.Second
 
-// totalCounters holds the seven cumulative session counters behind a single
+// defaultPruneAge is how long daily/hourly buckets are retained before being
+// pruned. Matches the reference's 90-day retention. Overridable per-handler via
+// the totalCounters.pruneAge field for testing.
+const defaultPruneAge = 90 * 24 * time.Hour
+
+// totalCounters holds the seven cumulative long-term counters behind a single
 // RWMutex so a snapshot reads all of them consistently (independent atomics
 // would allow a snapshot to mix pre- and post-update values). The lock is
 // fine-grained: event handlers take a write lock per increment, persistence
 // and UI hydration take a read lock for the whole set.
+//
+// In addition to the running totals, each increment is also attributed to two
+// time buckets: daily (keyed "2006-01-02") and hourly (keyed "2006-01-02T15").
+// These mirror the reference's DailyValues/HourlyValues and let the UI show
+// "fame earned today" alongside the all-time total. Buckets are pruned lazily
+// to pruneAge (default 90 days) so the maps stay bounded.
 type totalCounters struct {
-	mu           sync.RWMutex
-	fame         int64
-	silver       int64
-	respec       int64
-	respecSilver int64
-	kills        int64
-	deaths       int64
-	loot         int64
+	mu            sync.RWMutex
+	fame          int64
+	silver        int64
+	respec        int64
+	respecSilver  int64
+	kills         int64
+	deaths        int64
+	loot          int64
+	daily         map[string]StatValues // key: "2006-01-02" (local calendar date)
+	hourly        map[string]StatValues // key: "2006-01-02T15" (local calendar hour)
+	pruneAge      time.Duration
+	lastPruneDate string // last day a prune ran (avoids re-pruning every increment)
 }
 
-// snapshot returns a consistent point-in-time copy of all seven counters.
+// StatValues holds the bucketable stat types for a single time bucket (a day
+// or an hour). The zero value is a valid empty bucket.
+type StatValues struct {
+	Fame         int64 `json:"fame"`
+	Silver       int64 `json:"silver"`
+	Respec       int64 `json:"respec"`
+	RespecSilver int64 `json:"respec_silver"`
+	Kills        int64 `json:"kills"`
+	Deaths       int64 `json:"deaths"`
+	Loot         int64 `json:"loot"`
+}
+
+// snapshot returns a consistent point-in-time copy of all seven counters plus
+// deep copies of the daily/hourly buckets so callers cannot mutate shared
+// state. Returned maps are non-nil even when empty.
 func (c *totalCounters) snapshot() TotalStats {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -59,10 +88,13 @@ func (c *totalCounters) snapshot() TotalStats {
 		Kills:        c.kills,
 		Deaths:       c.deaths,
 		Loot:         c.loot,
+		Daily:        copyStatValuesMap(c.daily),
+		Hourly:       copyStatValuesMap(c.hourly),
 	}
 }
 
-// apply overwrites all seven counters. Used when restoring persisted state.
+// apply overwrites all seven counters and replaces both bucket maps. Used when
+// restoring persisted state. nil maps are treated as empty.
 func (c *totalCounters) apply(s TotalStats) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -73,48 +105,168 @@ func (c *totalCounters) apply(s TotalStats) {
 	c.kills = s.Kills
 	c.deaths = s.Deaths
 	c.loot = s.Loot
+	c.daily = copyStatValuesMap(s.Daily)
+	c.hourly = copyStatValuesMap(s.Hourly)
+	if c.daily == nil {
+		c.daily = map[string]StatValues{}
+	}
+	if c.hourly == nil {
+		c.hourly = map[string]StatValues{}
+	}
 }
 
-func (c *totalCounters) addFame(n int64) {
+// addDelta applies an arbitrary delta to one numeric field of a StatValues.
+// It panics if field is unknown — a programming error, not a runtime path.
+// Failing loud is safer than silently dropping a delta, which would let the
+// time-bucketed value drift out of sync with the cumulative total.
+func (v *StatValues) addDelta(field string, n int64) {
+	switch field {
+	case "fame":
+		v.Fame += n
+	case "silver":
+		v.Silver += n
+	case "respec":
+		v.Respec += n
+	case "respec_silver":
+		v.RespecSilver += n
+	default:
+		panic("totalCounters: unknown stat field " + field)
+	}
+}
+
+// bucket records a delta into both the daily and hourly buckets for time t.
+// Caller must hold c.mu (write).
+func (c *totalCounters) bucket(t time.Time, field string, n int64) {
+	c.maybePruneLocked(t)
+	dk := t.Format("2006-01-02")
+	d := c.daily[dk]
+	d.addDelta(field, n)
+	c.daily[dk] = d
+
+	hk := t.Format("2006-01-02T15")
+	h := c.hourly[hk]
+	h.addDelta(field, n)
+	c.hourly[hk] = h
+}
+
+// addFame adds n to the cumulative fame total and attributes it to the buckets
+// for time t.
+func (c *totalCounters) addFame(n int64, t time.Time) {
 	c.mu.Lock()
 	c.fame += n
+	c.bucket(t, "fame", n)
 	c.mu.Unlock()
 }
 
-func (c *totalCounters) addSilver(n int64) {
+func (c *totalCounters) addSilver(n int64, t time.Time) {
 	c.mu.Lock()
 	c.silver += n
+	c.bucket(t, "silver", n)
 	c.mu.Unlock()
 }
 
-func (c *totalCounters) addRespec(n int64) {
+func (c *totalCounters) addRespec(n int64, t time.Time) {
 	c.mu.Lock()
 	c.respec += n
+	c.bucket(t, "respec", n)
 	c.mu.Unlock()
 }
 
-func (c *totalCounters) addRespecSilver(n int64) {
+func (c *totalCounters) addRespecSilver(n int64, t time.Time) {
 	c.mu.Lock()
 	c.respecSilver += n
+	c.bucket(t, "respec_silver", n)
 	c.mu.Unlock()
 }
 
-func (c *totalCounters) addKill() {
+// bucketCount attributes a +1 count to a discrete field (kills/deaths/loot) in
+// both buckets. Caller must hold c.mu (write).
+func (c *totalCounters) bucketCount(t time.Time, field string) {
+	c.maybePruneLocked(t)
+	dk := t.Format("2006-01-02")
+	d := c.daily[dk]
+	switch field {
+	case "kills":
+		d.Kills++
+	case "deaths":
+		d.Deaths++
+	case "loot":
+		d.Loot++
+	}
+	c.daily[dk] = d
+
+	hk := t.Format("2006-01-02T15")
+	h := c.hourly[hk]
+	switch field {
+	case "kills":
+		h.Kills++
+	case "deaths":
+		h.Deaths++
+	case "loot":
+		h.Loot++
+	}
+	c.hourly[hk] = h
+}
+
+func (c *totalCounters) addKill(t time.Time) {
 	c.mu.Lock()
 	c.kills++
+	c.bucketCount(t, "kills")
 	c.mu.Unlock()
 }
 
-func (c *totalCounters) addDeath() {
+func (c *totalCounters) addDeath(t time.Time) {
 	c.mu.Lock()
 	c.deaths++
+	c.bucketCount(t, "deaths")
 	c.mu.Unlock()
 }
 
-func (c *totalCounters) addLoot() {
+func (c *totalCounters) addLoot(t time.Time) {
 	c.mu.Lock()
 	c.loot++
+	c.bucketCount(t, "loot")
 	c.mu.Unlock()
+}
+
+// maybePruneLocked drops bucket keys older than pruneAge. Runs at most once per
+// calendar day to avoid scanning the maps on every event. Caller must hold
+// c.mu (write).
+func (c *totalCounters) maybePruneLocked(now time.Time) {
+	today := now.Format("2006-01-02")
+	if c.lastPruneDate == today {
+		return
+	}
+	c.lastPruneDate = today
+	if c.pruneAge <= 0 {
+		return
+	}
+	cutoff := now.Add(-c.pruneAge).Format("2006-01-02")
+	cutoffHour := now.Add(-c.pruneAge).Format("2006-01-02T15")
+	for k := range c.daily {
+		if k < cutoff {
+			delete(c.daily, k)
+		}
+	}
+	for k := range c.hourly {
+		if k < cutoffHour {
+			delete(c.hourly, k)
+		}
+	}
+}
+
+// copyStatValuesMap returns a shallow copy of m (the StatValues values are not
+// further nested, so shallow is a full copy). Returns nil for a nil map so the
+// caller can distinguish "unset" from "empty".
+func copyStatValuesMap(m map[string]StatValues) map[string]StatValues {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]StatValues, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
 }
 
 func (c *totalCounters) fameNow() int64 {
@@ -157,6 +309,26 @@ func (c *totalCounters) lootNow() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return int(c.loot)
+}
+
+// dailyValueNow returns one numeric field from today's daily bucket, read
+// under the read lock. field is one of: fame, silver, respec, respec_silver.
+func (c *totalCounters) dailyValueNow(now time.Time, field string) int64 {
+	dk := now.Format("2006-01-02")
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	v := c.daily[dk]
+	switch field {
+	case "fame":
+		return v.Fame
+	case "silver":
+		return v.Silver
+	case "respec":
+		return v.Respec
+	case "respec_silver":
+		return v.RespecSilver
+	}
+	return 0
 }
 
 // AlbionHandler handles Albion Online game events
@@ -231,6 +403,11 @@ func NewAlbionHandler() *AlbionHandler {
 		recentDeaths:     make(map[string]time.Time),
 		deathDedupWindow: defaultDeathDedupWindow,
 		nowFunc:          time.Now,
+		stats: totalCounters{
+			daily:    map[string]StatValues{},
+			hourly:   map[string]StatValues{},
+			pruneAge: defaultPruneAge,
+		},
 	}
 }
 
@@ -373,6 +550,7 @@ type FameEventData struct {
 	Gained  int64 // Fame gained in this event
 	Total   int64 // Total fame pool reported by the server after this event
 	AllTime int64 // Cumulative fame gained across all launches (long-term total)
+	Daily   int64 // Fame gained today (current calendar day)
 }
 
 // SilverEventData contains silver-specific event data
@@ -382,6 +560,7 @@ type SilverEventData struct {
 	LootedBy   string // Player who looted
 	LootedFrom string // Source of the loot
 	Counted    bool   // Whether this amount was added to the long-term total
+	Daily      int64  // Silver gained today (current calendar day)
 }
 
 // LootEventData contains loot-specific event data
@@ -410,6 +589,7 @@ type RespecEventData struct {
 	PaidSilver  int64 // Silver paid for auto-respec in this event
 	Total       int64 // Cumulative credits gained across all launches (long-term total)
 	TotalSilver int64 // Cumulative silver spent on auto-respec across all launches
+	Daily       int64 // Credits gained today (current calendar day)
 }
 
 // ZoneEventData contains zone-transition event data emitted on ChangeCluster.
@@ -421,17 +601,17 @@ type ZoneEventData struct {
 	Previous     MapType // The zone the player left (MapTypeUnknown on first transition)
 }
 
-// GetTotalKills returns the number of kills in this session
+// GetTotalKills returns the cumulative number of kills across all launches.
 func (h *AlbionHandler) GetTotalKills() int {
 	return h.stats.killsNow()
 }
 
-// GetTotalDeaths returns the number of deaths in this session
+// GetTotalDeaths returns the cumulative number of deaths across all launches.
 func (h *AlbionHandler) GetTotalDeaths() int {
 	return h.stats.deathsNow()
 }
 
-// GetTotalLoot returns the number of loot items in this session
+// GetTotalLoot returns the cumulative number of loot items across all launches.
 func (h *AlbionHandler) GetTotalLoot() int {
 	return h.stats.lootNow()
 }
@@ -725,29 +905,30 @@ func (h *AlbionHandler) LoadDungeonRuns(path string) error {
 	return nil
 }
 
-// GetTotalFame returns the total fame gained in this session
+// GetTotalFame returns the cumulative fame gained across all launches.
 func (h *AlbionHandler) GetTotalFame() int64 {
 	return h.stats.fameNow()
 }
 
-// GetTotalSilver returns the total silver looted in this session
+// GetTotalSilver returns the cumulative silver looted across all launches.
 func (h *AlbionHandler) GetTotalSilver() int64 {
 	return h.stats.silverNow()
 }
 
-// GetTotalRespec returns the total combat fame credits gained in this session
+// GetTotalRespec returns the cumulative combat fame credits gained across all launches.
 func (h *AlbionHandler) GetTotalRespec() int64 {
 	return h.stats.respecNow()
 }
 
-// GetTotalRespecSilver returns the total silver spent on auto-respec this session
+// GetTotalRespecSilver returns the cumulative silver spent on auto-respec across all launches.
 func (h *AlbionHandler) GetTotalRespecSilver() int64 {
 	return h.stats.respecSilverNow()
 }
 
-// SessionStats is a point-in-time snapshot of the cumulative session counters,
-// used to hydrate the UI on startup. All fields are absolute totals read
-// atomically.
+// TotalStats is a point-in-time snapshot of the cumulative long-term counters
+// and their time-bucketed breakdowns, used to hydrate the UI on startup. The
+// scalar fields are absolute totals read atomically; Daily and Hourly are
+// deep-copied so callers cannot mutate shared state.
 type TotalStats struct {
 	Fame         int64
 	Silver       int64
@@ -756,52 +937,59 @@ type TotalStats struct {
 	Kills        int64
 	Deaths       int64
 	Loot         int64
+	Daily        map[string]StatValues // key: "2006-01-02"
+	Hourly       map[string]StatValues // key: "2006-01-02T15"
 }
 
-// TotalSnapshot returns the current cumulative session counters. Safe to
+// TotalSnapshot returns the current cumulative long-term counters. Safe to
 // call concurrently with event processing.
 func (h *AlbionHandler) TotalSnapshot() TotalStats {
 	return h.readTotalStats()
 }
 
 // readTotalStats is the single source of truth for reading the seven
-// cumulative counters into a consistent SessionStats snapshot.
+// cumulative counters into a consistent TotalStats snapshot.
 func (h *AlbionHandler) readTotalStats() TotalStats {
 	return h.stats.snapshot()
 }
 
 // applyTotalStats is the single source of truth for writing the seven
-// cumulative counters from a SessionStats (the inverse of readTotalStats).
+// cumulative counters from a TotalStats (the inverse of readTotalStats).
 func (h *AlbionHandler) applyTotalStats(s TotalStats) {
 	h.stats.apply(s)
 }
 
-// totalStatsFile is the on-disk JSON representation of SessionStats. The
-// Version field is reserved for future additive schema migrations; missing
-// fields in an old file default to zero via encoding/json.
+// totalStatsFile is the on-disk JSON representation of TotalStats. The
+// Version field tracks additive schema migrations; missing fields in an old
+// file default to zero (scalars) or empty (maps) via encoding/json.
 //
-// Once persisted and restored, the session* counters represent cumulative
-// totals across all launches of the application (long-term) rather than a
-// single session — this matches issue #104's intent. The "session" naming is
-// retained for now and will be revisited when daily/hourly bucketing lands
-// (follow-up #105).
+// Version history:
+//   - 1: cumulative scalar counters only.
+//   - 2: added Daily and Hourly time-bucketed maps (#112).
+//
+// NOTE: the on-disk filename stays "session-stats.json" (see cmd/tui/main.go)
+// so existing files written by earlier versions keep loading. Only the Go
+// type/identifier was renamed (session* → total*) when daily/hourly bucketing
+// landed (#112).
 type totalStatsFile struct {
-	Version      int       `json:"version"`
-	Fame         int64     `json:"fame"`
-	Silver       int64     `json:"silver"`
-	Respec       int64     `json:"respec"`
-	RespecSilver int64     `json:"respec_silver"`
-	Kills        int64     `json:"kills"`
-	Deaths       int64     `json:"deaths"`
-	Loot         int64     `json:"loot"`
-	SavedAt      time.Time `json:"saved_at"`
+	Version      int                   `json:"version"`
+	Fame         int64                 `json:"fame"`
+	Silver       int64                 `json:"silver"`
+	Respec       int64                 `json:"respec"`
+	RespecSilver int64                 `json:"respec_silver"`
+	Kills        int64                 `json:"kills"`
+	Deaths       int64                 `json:"deaths"`
+	Loot         int64                 `json:"loot"`
+	Daily        map[string]StatValues `json:"daily,omitempty"`
+	Hourly       map[string]StatValues `json:"hourly,omitempty"`
+	SavedAt      time.Time             `json:"saved_at"`
 }
 
-// totalStatsVersion is the current on-disk schema version for session stats.
-const totalStatsVersion = 1
+// totalStatsVersion is the current on-disk schema version for total stats.
+const totalStatsVersion = 2
 
-// SaveTotalStats persists the cumulative session counters to path as JSON
-// using an atomic write (tmp + rename).
+// SaveTotalStats persists the cumulative long-term counters and their
+// daily/hourly buckets to path as JSON using an atomic write (tmp + rename).
 func (h *AlbionHandler) SaveTotalStats(path string) error {
 	s := h.readTotalStats()
 	f := totalStatsFile{
@@ -813,16 +1001,18 @@ func (h *AlbionHandler) SaveTotalStats(path string) error {
 		Kills:        s.Kills,
 		Deaths:       s.Deaths,
 		Loot:         s.Loot,
+		Daily:        s.Daily,
+		Hourly:       s.Hourly,
 		SavedAt:      h.nowFunc(),
 	}
 	return storage.Save(path, f)
 }
 
-// LoadTotalStats restores the cumulative session counters from path. A
-// missing file leaves counters at zero (first run). A corrupt file is returned
-// as err and leaves the counters unchanged. The schema is additive: a version
-// mismatch or missing fields apply best-effort (unknown/absent fields default
-// to zero).
+// LoadTotalStats restores the cumulative long-term counters and buckets from
+// path. A missing file leaves counters at zero (first run). A corrupt file is
+// returned as err and leaves the counters unchanged. The schema is additive:
+// a v1 file (no daily/hourly) loads with empty buckets, and unknown fields in
+// a newer file default to zero/empty.
 func (h *AlbionHandler) LoadTotalStats(path string) error {
 	f, err := storage.Load[totalStatsFile](path)
 	if err != nil {
@@ -836,6 +1026,8 @@ func (h *AlbionHandler) LoadTotalStats(path string) error {
 		Kills:        f.Kills,
 		Deaths:       f.Deaths,
 		Loot:         f.Loot,
+		Daily:        f.Daily,
+		Hourly:       f.Hourly,
 	})
 	return nil
 }
@@ -892,7 +1084,7 @@ func (h *AlbionHandler) handleUpdateFame(params map[byte]interface{}) {
 
 		// Only notify if fame was actually gained
 		if fameGainedVal > 0 {
-			h.stats.addFame(int64(fameGainedVal))
+			h.stats.addFame(int64(fameGainedVal), h.nowFunc())
 			h.totalFame.Store(totalFame) // Update tracked total
 
 			// Message formatting is now handled by the frontend (TUI)
@@ -900,6 +1092,7 @@ func (h *AlbionHandler) handleUpdateFame(params map[byte]interface{}) {
 				Gained:  int64(fameGainedVal),
 				Total:   int64(totalFameVal),
 				AllTime: h.stats.fameNow(),
+				Daily:   h.stats.dailyValueNow(h.nowFunc(), "fame"),
 			})
 		}
 	} else {
@@ -909,12 +1102,13 @@ func (h *AlbionHandler) handleUpdateFame(params map[byte]interface{}) {
 			gained := totalFame - h.totalFame.Load()
 			if gained > 0 {
 				gainedVal := math.Floor(float64(gained) / 10000.0)
-				h.stats.addFame(int64(gainedVal))
+				h.stats.addFame(int64(gainedVal), h.nowFunc())
 				// Message formatting is now handled by the frontend (TUI)
 				h.notifyEvent("fame", "", &FameEventData{
 					Gained:  int64(gainedVal),
 					Total:   int64(totalFameVal),
 					AllTime: h.stats.fameNow(),
+					Daily:   h.stats.dailyValueNow(h.nowFunc(), "fame"),
 				})
 			}
 		}
@@ -992,7 +1186,7 @@ func (h *AlbionHandler) handleOtherGrabbedLoot(params map[byte]interface{}) {
 		local := h.GetLocalPlayer()
 		counted := local != "" && lootedBy == local
 		if counted {
-			h.stats.addSilver(silverAmount)
+			h.stats.addSilver(silverAmount, h.nowFunc())
 		}
 		// Message formatting is now handled by the frontend (TUI)
 		// We just pass the raw data
@@ -1002,6 +1196,7 @@ func (h *AlbionHandler) handleOtherGrabbedLoot(params map[byte]interface{}) {
 			LootedBy:   lootedBy,
 			LootedFrom: lootedFrom,
 			Counted:    counted,
+			Daily:      h.stats.dailyValueNow(h.nowFunc(), "silver"),
 		})
 	} else {
 		// Try to get item name from database
@@ -1014,7 +1209,7 @@ func (h *AlbionHandler) handleOtherGrabbedLoot(params map[byte]interface{}) {
 		// player's loot), because the total volume of nearby loot is useful
 		// context. Silver is different — only the local player's silver
 		// contributes to the session total (see the silver branch above).
-		h.stats.addLoot()
+		h.stats.addLoot(h.nowFunc())
 
 		// Message formatting is now handled by the frontend (TUI)
 		h.notifyEvent("loot", "", &LootEventData{
@@ -1111,7 +1306,7 @@ func (h *AlbionHandler) handleDied(params map[byte]interface{}) {
 
 	// Count a kill when the local player is the killer.
 	if isLocalKill {
-		h.stats.addKill()
+		h.stats.addKill(h.nowFunc())
 		h.notifyEvent("kill", "", &KillEventData{
 			TotalKills: h.stats.killsNow(),
 		})
@@ -1119,7 +1314,7 @@ func (h *AlbionHandler) handleDied(params map[byte]interface{}) {
 
 	// Count a death only when the local player is the victim.
 	if local != "" && victim == local {
-		h.stats.addDeath()
+		h.stats.addDeath(h.nowFunc())
 	}
 
 	// Emit a death event for the local player's death or for nearby deaths
@@ -1147,14 +1342,15 @@ func (h *AlbionHandler) handleUpdateReSpecPoints(params map[byte]interface{}) {
 	gainedVal := int64(math.Floor(float64(gainedReSpec) / 10000.0))
 	silverVal := int64(math.Floor(float64(paidSilver) / 10000.0))
 
-	h.stats.addRespec(gainedVal)
-	h.stats.addRespecSilver(silverVal)
+	h.stats.addRespec(gainedVal, h.nowFunc())
+	h.stats.addRespecSilver(silverVal, h.nowFunc())
 
 	h.notifyEvent("respec", "", &RespecEventData{
 		Gained:      gainedVal,
 		PaidSilver:  silverVal,
 		Total:       h.stats.respecNow(),
 		TotalSilver: h.stats.respecSilverNow(),
+		Daily:       h.stats.dailyValueNow(h.nowFunc(), "respec"),
 	})
 }
 

--- a/pkg/handlers/albion_test.go
+++ b/pkg/handlers/albion_test.go
@@ -882,6 +882,43 @@ func TestHandleUpdateReSpecPointsZeroGained(t *testing.T) {
 	}
 }
 
+// TestHandleUpdateReSpecPointsFreeRespec tests the common case where respec is
+// free (premium): gained credits > 0 but paidSilver == 0. The credits must be
+// counted, the silver cost must stay zero, and the silver bucket must not be
+// written.
+func TestHandleUpdateReSpecPointsFreeRespec(t *testing.T) {
+	handler := NewAlbionHandler()
+
+	var receivedData *RespecEventData
+	handler.SetEventCallback(func(eventType, message string, data interface{}) {
+		if eventType == "respec" {
+			receivedData = data.(*RespecEventData)
+		}
+	})
+
+	// gained 1000 credits (FixPoint), zero silver paid.
+	params := map[byte]interface{}{
+		2:                     int64(10000000), // gained 1000 (FixPoint)
+		3:                     int64(0),        // free respec
+		events.ParamEventCode: int16(events.EventUpdateReSpecPoints),
+	}
+
+	handler.OnEvent(byte(events.EventUpdateReSpecPoints), params)
+
+	if receivedData == nil {
+		t.Fatal("respec callback was not called")
+	}
+	if handler.GetTotalRespec() != 1000 {
+		t.Errorf("expected total respec 1000, got %d", handler.GetTotalRespec())
+	}
+	if handler.GetTotalRespecSilver() != 0 {
+		t.Errorf("expected total respec silver 0 (free respec), got %d", handler.GetTotalRespecSilver())
+	}
+	if receivedData.PaidSilver != 0 {
+		t.Errorf("expected PaidSilver 0, got %d", receivedData.PaidSilver)
+	}
+}
+
 // TestHandleUpdateReSpecPointsAccumulation tests multiple events accumulate correctly
 func TestHandleUpdateReSpecPointsAccumulation(t *testing.T) {
 	handler := NewAlbionHandler()

--- a/pkg/handlers/albion_test.go
+++ b/pkg/handlers/albion_test.go
@@ -93,20 +93,20 @@ func TestSessionCounters(t *testing.T) {
 	handler.SetLocalPlayer("Hero")
 
 	// Initial values should be 0
-	if handler.GetSessionKills() != 0 {
+	if handler.GetTotalKills() != 0 {
 		t.Error("initial kills should be 0")
 	}
-	if handler.GetSessionDeaths() != 0 {
+	if handler.GetTotalDeaths() != 0 {
 		t.Error("initial deaths should be 0")
 	}
-	if handler.GetSessionLoot() != 0 {
+	if handler.GetTotalLoot() != 0 {
 		t.Error("initial loot should be 0")
 	}
 
 	// EventKilledPlayer is a no-op; kills are counted via EventDied.
 	handler.OnEvent(byte(events.EventKilledPlayer), map[byte]interface{}{})
-	if handler.GetSessionKills() != 0 {
-		t.Errorf("EventKilledPlayer should not count kills, got %d", handler.GetSessionKills())
+	if handler.GetTotalKills() != 0 {
+		t.Errorf("EventKilledPlayer should not count kills, got %d", handler.GetTotalKills())
 	}
 
 	// Local player kills someone -> kill counted.
@@ -114,8 +114,8 @@ func TestSessionCounters(t *testing.T) {
 		2:  "Enemy",
 		10: "Hero",
 	})
-	if handler.GetSessionKills() != 1 {
-		t.Errorf("expected 1 kill, got %d", handler.GetSessionKills())
+	if handler.GetTotalKills() != 1 {
+		t.Errorf("expected 1 kill, got %d", handler.GetTotalKills())
 	}
 
 	// Local player dies -> death counted.
@@ -123,25 +123,25 @@ func TestSessionCounters(t *testing.T) {
 		2:  "Hero",
 		10: "Enemy",
 	})
-	if handler.GetSessionDeaths() != 1 {
-		t.Errorf("expected 1 death, got %d", handler.GetSessionDeaths())
+	if handler.GetTotalDeaths() != 1 {
+		t.Errorf("expected 1 death, got %d", handler.GetTotalDeaths())
 	}
 }
 
-// TestGetSessionFame tests fame getter
-func TestGetSessionFame(t *testing.T) {
+// TestGetTotalFame tests fame getter
+func TestGetTotalFame(t *testing.T) {
 	handler := NewAlbionHandler()
 
-	if handler.GetSessionFame() != 0 {
+	if handler.GetTotalFame() != 0 {
 		t.Error("initial session fame should be 0")
 	}
 }
 
-// TestGetSessionSilver tests silver getter
-func TestGetSessionSilver(t *testing.T) {
+// TestGetTotalSilver tests silver getter
+func TestGetTotalSilver(t *testing.T) {
 	handler := NewAlbionHandler()
 
-	if handler.GetSessionSilver() != 0 {
+	if handler.GetTotalSilver() != 0 {
 		t.Error("initial session silver should be 0")
 	}
 }
@@ -177,8 +177,8 @@ func TestHandleUpdateFameDetailedFormat(t *testing.T) {
 		t.Errorf("expected gained 1000, got %d", receivedData.Gained)
 	}
 
-	if handler.GetSessionFame() != 1000 {
-		t.Errorf("expected session fame 1000, got %d", handler.GetSessionFame())
+	if handler.GetTotalFame() != 1000 {
+		t.Errorf("expected session fame 1000, got %d", handler.GetTotalFame())
 	}
 }
 
@@ -305,8 +305,8 @@ func TestHandleOtherGrabbedLootSilver(t *testing.T) {
 		t.Errorf("expected LootedFrom 'Monster', got '%s'", receivedData.LootedFrom)
 	}
 
-	if handler.GetSessionSilver() != 5000 {
-		t.Errorf("expected session silver 5000, got %d", handler.GetSessionSilver())
+	if handler.GetTotalSilver() != 5000 {
+		t.Errorf("expected session silver 5000, got %d", handler.GetTotalSilver())
 	}
 }
 
@@ -352,8 +352,8 @@ func TestHandleOtherGrabbedLootItem(t *testing.T) {
 		t.Errorf("expected Quantity 3, got %d", receivedData.Quantity)
 	}
 
-	if handler.GetSessionLoot() != 1 {
-		t.Errorf("expected session loot 1, got %d", handler.GetSessionLoot())
+	if handler.GetTotalLoot() != 1 {
+		t.Errorf("expected session loot 1, got %d", handler.GetTotalLoot())
 	}
 }
 
@@ -377,8 +377,8 @@ func TestHandleKilledPlayer(t *testing.T) {
 		t.Error("EventKilledPlayer should not produce a kill callback")
 	}
 
-	if handler.GetSessionKills() != 0 {
-		t.Errorf("expected 0 kills (no-op), got %d", handler.GetSessionKills())
+	if handler.GetTotalKills() != 0 {
+		t.Errorf("expected 0 kills (no-op), got %d", handler.GetTotalKills())
 	}
 }
 
@@ -407,12 +407,12 @@ func TestHandleDied(t *testing.T) {
 	}
 
 	// Without a known local player, deaths are not counted.
-	if receivedData.SessionDeaths != 0 {
-		t.Errorf("expected SessionDeaths 0 (no local player), got %d", receivedData.SessionDeaths)
+	if receivedData.TotalDeaths != 0 {
+		t.Errorf("expected SessionDeaths 0 (no local player), got %d", receivedData.TotalDeaths)
 	}
 
-	if handler.GetSessionDeaths() != 0 {
-		t.Errorf("expected 0 deaths (no local player), got %d", handler.GetSessionDeaths())
+	if handler.GetTotalDeaths() != 0 {
+		t.Errorf("expected 0 deaths (no local player), got %d", handler.GetTotalDeaths())
 	}
 }
 
@@ -753,7 +753,7 @@ func TestFameEventDataStructure(t *testing.T) {
 	data := &FameEventData{
 		Gained:  100,
 		Total:   5000,
-		Session: 500,
+		AllTime: 500,
 	}
 
 	if data.Gained != 100 {
@@ -762,8 +762,8 @@ func TestFameEventDataStructure(t *testing.T) {
 	if data.Total != 5000 {
 		t.Errorf("Total field incorrect")
 	}
-	if data.Session != 500 {
-		t.Errorf("Session field incorrect")
+	if data.AllTime != 500 {
+		t.Errorf("AllTime field incorrect")
 	}
 }
 
@@ -771,7 +771,7 @@ func TestFameEventDataStructure(t *testing.T) {
 func TestSilverEventDataStructure(t *testing.T) {
 	data := &SilverEventData{
 		Amount:     1000,
-		Session:    5000,
+		Total:      5000,
 		LootedBy:   "Player1",
 		LootedFrom: "Monster",
 	}
@@ -779,8 +779,8 @@ func TestSilverEventDataStructure(t *testing.T) {
 	if data.Amount != 1000 {
 		t.Errorf("Amount field incorrect")
 	}
-	if data.Session != 5000 {
-		t.Errorf("Session field incorrect")
+	if data.Total != 5000 {
+		t.Errorf("Total field incorrect")
 	}
 	if data.LootedBy != "Player1" {
 		t.Errorf("LootedBy field incorrect")
@@ -822,20 +822,20 @@ func TestHandleUpdateReSpecPoints(t *testing.T) {
 		t.Errorf("expected paid silver 500, got %d", receivedData.PaidSilver)
 	}
 
-	if receivedData.SessionTotal != 1000 {
-		t.Errorf("expected session total 1000, got %d", receivedData.SessionTotal)
+	if receivedData.Total != 1000 {
+		t.Errorf("expected session total 1000, got %d", receivedData.Total)
 	}
 
-	if receivedData.SessionSilverTotal != 500 {
-		t.Errorf("expected session silver total 500, got %d", receivedData.SessionSilverTotal)
+	if receivedData.TotalSilver != 500 {
+		t.Errorf("expected session silver total 500, got %d", receivedData.TotalSilver)
 	}
 
-	if handler.GetSessionRespec() != 1000 {
-		t.Errorf("expected session respec 1000, got %d", handler.GetSessionRespec())
+	if handler.GetTotalRespec() != 1000 {
+		t.Errorf("expected session respec 1000, got %d", handler.GetTotalRespec())
 	}
 
-	if handler.GetSessionRespecSilver() != 500 {
-		t.Errorf("expected session respec silver 500, got %d", handler.GetSessionRespecSilver())
+	if handler.GetTotalRespecSilver() != 500 {
+		t.Errorf("expected session respec silver 500, got %d", handler.GetTotalRespecSilver())
 	}
 }
 
@@ -862,8 +862,8 @@ func TestHandleUpdateReSpecPointsZeroGained(t *testing.T) {
 		t.Errorf("expected 0 callbacks for zero gained, got %d", callCount)
 	}
 
-	if handler.GetSessionRespec() != 0 {
-		t.Errorf("expected session respec 0, got %d", handler.GetSessionRespec())
+	if handler.GetTotalRespec() != 0 {
+		t.Errorf("expected session respec 0, got %d", handler.GetTotalRespec())
 	}
 }
 
@@ -871,13 +871,13 @@ func TestHandleUpdateReSpecPointsZeroGained(t *testing.T) {
 func TestHandleUpdateReSpecPointsAccumulation(t *testing.T) {
 	handler := NewAlbionHandler()
 
-	var lastSessionTotal int64
-	var lastSessionSilverTotal int64
+	var lastTotal int64
+	var lastTotalSilver int64
 	handler.SetEventCallback(func(eventType, message string, data interface{}) {
 		if eventType == "respec" {
 			if respecData, ok := data.(*RespecEventData); ok {
-				lastSessionTotal = respecData.SessionTotal
-				lastSessionSilverTotal = respecData.SessionSilverTotal
+				lastTotal = respecData.Total
+				lastTotalSilver = respecData.TotalSilver
 			}
 		}
 	})
@@ -896,20 +896,20 @@ func TestHandleUpdateReSpecPointsAccumulation(t *testing.T) {
 		events.ParamEventCode: int16(events.EventUpdateReSpecPoints),
 	})
 
-	if lastSessionTotal != 800 {
-		t.Errorf("expected session total 800, got %d", lastSessionTotal)
+	if lastTotal != 800 {
+		t.Errorf("expected session total 800, got %d", lastTotal)
 	}
 
-	if lastSessionSilverTotal != 150 {
-		t.Errorf("expected session silver total 150, got %d", lastSessionSilverTotal)
+	if lastTotalSilver != 150 {
+		t.Errorf("expected session silver total 150, got %d", lastTotalSilver)
 	}
 
-	if handler.GetSessionRespec() != 800 {
-		t.Errorf("expected session respec 800, got %d", handler.GetSessionRespec())
+	if handler.GetTotalRespec() != 800 {
+		t.Errorf("expected session respec 800, got %d", handler.GetTotalRespec())
 	}
 
-	if handler.GetSessionRespecSilver() != 150 {
-		t.Errorf("expected session respec silver 150, got %d", handler.GetSessionRespecSilver())
+	if handler.GetTotalRespecSilver() != 150 {
+		t.Errorf("expected session respec silver 150, got %d", handler.GetTotalRespecSilver())
 	}
 }
 
@@ -1035,8 +1035,8 @@ func TestDiedNoKillCountedWhenLocalUnknown(t *testing.T) {
 		10: "Someone",
 	})
 
-	if handler.GetSessionKills() != 0 {
-		t.Errorf("expected 0 kills when local player unknown, got %d", handler.GetSessionKills())
+	if handler.GetTotalKills() != 0 {
+		t.Errorf("expected 0 kills when local player unknown, got %d", handler.GetTotalKills())
 	}
 	if killCount != 0 {
 		t.Errorf("expected 0 kill callbacks when local player unknown, got %d", killCount)
@@ -1069,8 +1069,8 @@ func TestDiedCountsKillWhenLocalPlayerIsKiller(t *testing.T) {
 		handler.OnEvent(byte(events.EventDied), deathParams)
 	}
 
-	if handler.GetSessionKills() != 1 {
-		t.Errorf("expected 1 kill (deduped), got %d", handler.GetSessionKills())
+	if handler.GetTotalKills() != 1 {
+		t.Errorf("expected 1 kill (deduped), got %d", handler.GetTotalKills())
 	}
 	if killCount != 1 {
 		t.Errorf("expected 1 kill callback, got %d", killCount)
@@ -1080,8 +1080,8 @@ func TestDiedCountsKillWhenLocalPlayerIsKiller(t *testing.T) {
 	}
 
 	// Local player was the killer, not the victim: deaths must not be counted.
-	if handler.GetSessionDeaths() != 0 {
-		t.Errorf("expected 0 deaths, got %d", handler.GetSessionDeaths())
+	if handler.GetTotalDeaths() != 0 {
+		t.Errorf("expected 0 deaths, got %d", handler.GetTotalDeaths())
 	}
 }
 
@@ -1102,8 +1102,8 @@ func TestDiedDedupByVictimKiller(t *testing.T) {
 		10: "Hero",
 	})
 
-	if handler.GetSessionKills() != 2 {
-		t.Errorf("expected 2 kills for distinct victims, got %d", handler.GetSessionKills())
+	if handler.GetTotalKills() != 2 {
+		t.Errorf("expected 2 kills for distinct victims, got %d", handler.GetTotalKills())
 	}
 
 	// A duplicate of the first kill is collapsed.
@@ -1112,8 +1112,8 @@ func TestDiedDedupByVictimKiller(t *testing.T) {
 		10: "Hero",
 	})
 
-	if handler.GetSessionKills() != 2 {
-		t.Errorf("expected deduped 2 kills, got %d", handler.GetSessionKills())
+	if handler.GetTotalKills() != 2 {
+		t.Errorf("expected deduped 2 kills, got %d", handler.GetTotalKills())
 	}
 }
 
@@ -1128,8 +1128,8 @@ func TestDiedOnlyCountsLocalDeaths(t *testing.T) {
 		2:  "Stranger",
 		10: "SomeoneElse",
 	})
-	if handler.GetSessionDeaths() != 0 {
-		t.Errorf("foreign death must not count, got %d", handler.GetSessionDeaths())
+	if handler.GetTotalDeaths() != 0 {
+		t.Errorf("foreign death must not count, got %d", handler.GetTotalDeaths())
 	}
 
 	// Local player dies: counted.
@@ -1137,8 +1137,8 @@ func TestDiedOnlyCountsLocalDeaths(t *testing.T) {
 		2:  "Hero",
 		10: "Killer",
 	})
-	if handler.GetSessionDeaths() != 1 {
-		t.Errorf("expected 1 local death, got %d", handler.GetSessionDeaths())
+	if handler.GetTotalDeaths() != 1 {
+		t.Errorf("expected 1 local death, got %d", handler.GetTotalDeaths())
 	}
 }
 
@@ -1188,8 +1188,8 @@ func TestSilverExcludesForeignLoot(t *testing.T) {
 	}
 
 	// Only the local player's 5000 silver counts toward the session total.
-	if handler.GetSessionSilver() != 5000 {
-		t.Errorf("expected session silver 5000, got %d", handler.GetSessionSilver())
+	if handler.GetTotalSilver() != 5000 {
+		t.Errorf("expected session silver 5000, got %d", handler.GetTotalSilver())
 	}
 }
 
@@ -1213,8 +1213,8 @@ func TestSilverNotCountedWhenLocalUnknown(t *testing.T) {
 	if countedCount != 0 {
 		t.Errorf("expected 0 counted events when local unknown, got %d", countedCount)
 	}
-	if handler.GetSessionSilver() != 0 {
-		t.Errorf("expected session silver 0 (nothing counted), got %d", handler.GetSessionSilver())
+	if handler.GetTotalSilver() != 0 {
+		t.Errorf("expected session silver 0 (nothing counted), got %d", handler.GetTotalSilver())
 	}
 }
 
@@ -1242,8 +1242,8 @@ func TestSilverEmptyLootedWithKnownLocal(t *testing.T) {
 	if received.Counted {
 		t.Error("empty LootedBy must not be counted toward the session total")
 	}
-	if handler.GetSessionSilver() != 0 {
-		t.Errorf("expected session silver 0, got %d", handler.GetSessionSilver())
+	if handler.GetTotalSilver() != 0 {
+		t.Errorf("expected session silver 0, got %d", handler.GetTotalSilver())
 	}
 }
 
@@ -1266,21 +1266,21 @@ func TestDiedDedupWindowExpiry(t *testing.T) {
 
 	// First kill: counted.
 	handler.OnEvent(byte(events.EventDied), deathParams)
-	if handler.GetSessionKills() != 1 {
-		t.Fatalf("expected 1 kill after first death, got %d", handler.GetSessionKills())
+	if handler.GetTotalKills() != 1 {
+		t.Fatalf("expected 1 kill after first death, got %d", handler.GetTotalKills())
 	}
 
 	// Immediate duplicate: suppressed.
 	handler.OnEvent(byte(events.EventDied), deathParams)
-	if handler.GetSessionKills() != 1 {
-		t.Fatalf("expected duplicate to be suppressed, got %d", handler.GetSessionKills())
+	if handler.GetTotalKills() != 1 {
+		t.Fatalf("expected duplicate to be suppressed, got %d", handler.GetTotalKills())
 	}
 
 	// Advance time past the dedup window: the same victim+killer is counted again.
 	base = base.Add(handler.deathDedupWindow + time.Second)
 	handler.OnEvent(byte(events.EventDied), deathParams)
-	if handler.GetSessionKills() != 2 {
-		t.Errorf("expected 2 kills after window expiry, got %d", handler.GetSessionKills())
+	if handler.GetTotalKills() != 2 {
+		t.Errorf("expected 2 kills after window expiry, got %d", handler.GetTotalKills())
 	}
 }
 
@@ -1299,8 +1299,8 @@ func TestDiedDedupNotConsumedBeforeIdentity(t *testing.T) {
 
 	// Death arrives while identity is unknown: not counted, not deduped.
 	handler.OnEvent(byte(events.EventDied), deathParams)
-	if handler.GetSessionKills() != 0 {
-		t.Fatalf("expected 0 kills before identity, got %d", handler.GetSessionKills())
+	if handler.GetTotalKills() != 0 {
+		t.Fatalf("expected 0 kills before identity, got %d", handler.GetTotalKills())
 	}
 
 	// Identity captured (e.g. from OpJoin). The same victim+killer death arrives
@@ -1308,8 +1308,8 @@ func TestDiedDedupNotConsumedBeforeIdentity(t *testing.T) {
 	// never recorded during the unknown phase.
 	handler.SetLocalPlayer("Hero")
 	handler.OnEvent(byte(events.EventDied), deathParams)
-	if handler.GetSessionKills() != 1 {
-		t.Errorf("expected 1 kill after identity (dedup not pre-consumed), got %d", handler.GetSessionKills())
+	if handler.GetTotalKills() != 1 {
+		t.Errorf("expected 1 kill after identity (dedup not pre-consumed), got %d", handler.GetTotalKills())
 	}
 }
 
@@ -1386,13 +1386,13 @@ func TestSessionCountersConcurrent(t *testing.T) {
 			case <-stop:
 				return
 			default:
-				_ = handler.GetSessionKills()
-				_ = handler.GetSessionDeaths()
-				_ = handler.GetSessionLoot()
-				_ = handler.GetSessionFame()
-				_ = handler.GetSessionSilver()
-				_ = handler.GetSessionRespec()
-				_ = handler.GetSessionRespecSilver()
+				_ = handler.GetTotalKills()
+				_ = handler.GetTotalDeaths()
+				_ = handler.GetTotalLoot()
+				_ = handler.GetTotalFame()
+				_ = handler.GetTotalSilver()
+				_ = handler.GetTotalRespec()
+				_ = handler.GetTotalRespecSilver()
 			}
 		}
 	}()
@@ -1425,7 +1425,7 @@ func TestSessionCountersConcurrent(t *testing.T) {
 	wg.Wait()
 
 	// Final sanity: getters return sensible non-negative values.
-	if k := handler.GetSessionKills(); k < 0 {
+	if k := handler.GetTotalKills(); k < 0 {
 		t.Errorf("sessionKills should be >= 0, got %d", k)
 	}
 }
@@ -1642,38 +1642,38 @@ func TestOnEventNewShrineNoActiveRun(t *testing.T) {
 	}
 }
 
-func TestSaveLoadSessionStatsRoundTrip(t *testing.T) {
+func TestSaveLoadTotalStatsRoundTrip(t *testing.T) {
 	h := NewAlbionHandler()
-	h.stats.apply(SessionStats{Fame: 1500, Silver: 25000, Respec: 300, RespecSilver: 4500, Kills: 7, Deaths: 2, Loot: 11})
+	h.stats.apply(TotalStats{Fame: 1500, Silver: 25000, Respec: 300, RespecSilver: 4500, Kills: 7, Deaths: 2, Loot: 11})
 
 	path := filepath.Join(t.TempDir(), "session-stats.json")
-	if err := h.SaveSessionStats(path); err != nil {
-		t.Fatalf("SaveSessionStats: %v", err)
+	if err := h.SaveTotalStats(path); err != nil {
+		t.Fatalf("SaveTotalStats: %v", err)
 	}
 
 	fresh := NewAlbionHandler()
-	if err := fresh.LoadSessionStats(path); err != nil {
-		t.Fatalf("LoadSessionStats: %v", err)
+	if err := fresh.LoadTotalStats(path); err != nil {
+		t.Fatalf("LoadTotalStats: %v", err)
 	}
-	got := fresh.SessionSnapshot()
-	want := SessionStats{Fame: 1500, Silver: 25000, Respec: 300, RespecSilver: 4500, Kills: 7, Deaths: 2, Loot: 11}
+	got := fresh.TotalSnapshot()
+	want := TotalStats{Fame: 1500, Silver: 25000, Respec: 300, RespecSilver: 4500, Kills: 7, Deaths: 2, Loot: 11}
 	if got != want {
 		t.Errorf("snapshot = %+v, want %+v", got, want)
 	}
 }
 
-func TestLoadSessionStatsMissingFileLeavesZeroNoError(t *testing.T) {
+func TestLoadTotalStatsMissingFileLeavesZeroNoError(t *testing.T) {
 	h := NewAlbionHandler()
 	path := filepath.Join(t.TempDir(), "nope.json")
-	if err := h.LoadSessionStats(path); err != nil {
-		t.Errorf("LoadSessionStats missing file: %v", err)
+	if err := h.LoadTotalStats(path); err != nil {
+		t.Errorf("LoadTotalStats missing file: %v", err)
 	}
-	if got := h.SessionSnapshot(); got != (SessionStats{}) {
+	if got := h.TotalSnapshot(); got != (TotalStats{}) {
 		t.Errorf("expected zero snapshot, got %+v", got)
 	}
 }
 
-func TestLoadSessionStatsBackwardCompatMissingField(t *testing.T) {
+func TestLoadTotalStatsBackwardCompatMissingField(t *testing.T) {
 	// Older file written before respec_silver existed: that field must default
 	// to zero while the rest loads normally (additive schema).
 	path := filepath.Join(t.TempDir(), "old-stats.json")
@@ -1683,25 +1683,25 @@ func TestLoadSessionStatsBackwardCompatMissingField(t *testing.T) {
 	}
 
 	h := NewAlbionHandler()
-	if err := h.LoadSessionStats(path); err != nil {
-		t.Fatalf("LoadSessionStats: %v", err)
+	if err := h.LoadTotalStats(path); err != nil {
+		t.Fatalf("LoadTotalStats: %v", err)
 	}
-	got := h.SessionSnapshot()
-	want := SessionStats{Fame: 100, Silver: 200, Respec: 30, RespecSilver: 0, Kills: 1, Deaths: 0, Loot: 2}
+	got := h.TotalSnapshot()
+	want := TotalStats{Fame: 100, Silver: 200, Respec: 30, RespecSilver: 0, Kills: 1, Deaths: 0, Loot: 2}
 	if got != want {
 		t.Errorf("snapshot = %+v, want %+v (respec_silver defaulting to 0)", got, want)
 	}
 }
 
-func TestLoadSessionStatsCorruptFileReturnsError(t *testing.T) {
+func TestLoadTotalStatsCorruptFileReturnsError(t *testing.T) {
 	h := NewAlbionHandler()
-	h.stats.apply(SessionStats{Fame: 999}) // pre-existing value must survive a corrupt load
+	h.stats.apply(TotalStats{Fame: 999}) // pre-existing value must survive a corrupt load
 
 	path := filepath.Join(t.TempDir(), "bad-stats.json")
 	if err := os.WriteFile(path, []byte("{broken"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	if err := h.LoadSessionStats(path); err == nil {
+	if err := h.LoadTotalStats(path); err == nil {
 		t.Fatal("expected error loading corrupt stats file, got nil")
 	}
 	if got := h.stats.fameNow(); got != 999 {
@@ -1709,7 +1709,7 @@ func TestLoadSessionStatsCorruptFileReturnsError(t *testing.T) {
 	}
 }
 
-func TestLoadSessionStatsVersionAbsentStillLoads(t *testing.T) {
+func TestLoadTotalStatsVersionAbsentStillLoads(t *testing.T) {
 	// An even older file written before the `version` field existed: version
 	// defaults to zero (!= 1) but the schema is additive, so values still load.
 	path := filepath.Join(t.TempDir(), "no-version.json")
@@ -1719,31 +1719,31 @@ func TestLoadSessionStatsVersionAbsentStillLoads(t *testing.T) {
 	}
 
 	h := NewAlbionHandler()
-	if err := h.LoadSessionStats(path); err != nil {
-		t.Fatalf("LoadSessionStats: %v", err)
+	if err := h.LoadTotalStats(path); err != nil {
+		t.Fatalf("LoadTotalStats: %v", err)
 	}
-	got := h.SessionSnapshot()
-	want := SessionStats{Fame: 50, Silver: 60, Respec: 7, RespecSilver: 8, Kills: 1, Deaths: 0, Loot: 1}
+	got := h.TotalSnapshot()
+	want := TotalStats{Fame: 50, Silver: 60, Respec: 7, RespecSilver: 8, Kills: 1, Deaths: 0, Loot: 1}
 	if got != want {
 		t.Errorf("snapshot = %+v, want %+v (loaded despite missing version)", got, want)
 	}
 }
 
-func TestSaveSessionStatsErrorPropagates(t *testing.T) {
+func TestSaveTotalStatsErrorPropagates(t *testing.T) {
 	h := NewAlbionHandler()
-	h.stats.apply(SessionStats{Fame: 100})
+	h.stats.apply(TotalStats{Fame: 100})
 
 	// Make the final path a non-empty directory so storage.Save's rename step
 	// fails — a deterministic way (no root/FS assumptions) to exercise error
-	// propagation through SaveSessionStats.
+	// propagation through SaveTotalStats.
 	dir := t.TempDir()
 	path := filepath.Join(dir, "stats.json")
 	if err := os.MkdirAll(filepath.Join(path, "blocker"), 0o755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 
-	if err := h.SaveSessionStats(path); err == nil {
-		t.Fatal("expected error from SaveSessionStats when storage save fails, got nil")
+	if err := h.SaveTotalStats(path); err == nil {
+		t.Fatal("expected error from SaveTotalStats when storage save fails, got nil")
 	}
 	// Counters must be untouched by a failed save.
 	if got := h.stats.fameNow(); got != 100 {

--- a/pkg/handlers/albion_test.go
+++ b/pkg/handlers/albion_test.go
@@ -180,6 +180,11 @@ func TestHandleUpdateFameDetailedFormat(t *testing.T) {
 	if handler.GetTotalFame() != 1000 {
 		t.Errorf("expected session fame 1000, got %d", handler.GetTotalFame())
 	}
+
+	// Daily bucket must track today's gains end-to-end through the callback.
+	if receivedData.Daily != 1000 {
+		t.Errorf("expected daily fame 1000 (same day as cumulative), got %d", receivedData.Daily)
+	}
 }
 
 // TestHandleUpdateFameSimpleFormat tests fame handling with simple format (Event #81)
@@ -307,6 +312,11 @@ func TestHandleOtherGrabbedLootSilver(t *testing.T) {
 
 	if handler.GetTotalSilver() != 5000 {
 		t.Errorf("expected session silver 5000, got %d", handler.GetTotalSilver())
+	}
+
+	// Daily bucket must track today's silver end-to-end through the callback.
+	if receivedData.Daily != 5000 {
+		t.Errorf("expected daily silver 5000 (same day as cumulative), got %d", receivedData.Daily)
 	}
 }
 
@@ -836,6 +846,11 @@ func TestHandleUpdateReSpecPoints(t *testing.T) {
 
 	if handler.GetTotalRespecSilver() != 500 {
 		t.Errorf("expected session respec silver 500, got %d", handler.GetTotalRespecSilver())
+	}
+
+	// Daily bucket must track today's respec end-to-end through the callback.
+	if receivedData.Daily != 1000 {
+		t.Errorf("expected daily respec 1000 (same day as cumulative), got %d", receivedData.Daily)
 	}
 }
 

--- a/pkg/handlers/albion_test.go
+++ b/pkg/handlers/albion_test.go
@@ -1642,6 +1642,31 @@ func TestOnEventNewShrineNoActiveRun(t *testing.T) {
 	}
 }
 
+// totalStatsEqual reports whether two TotalStats snapshots are equal, treating
+// nil and empty bucket maps as equivalent (apply/snapshot normalize to empty).
+// Required because TotalStats now contains maps and is no longer comparable
+// with ==.
+func totalStatsEqual(a, b TotalStats) bool {
+	if a.Fame != b.Fame || a.Silver != b.Silver || a.Respec != b.Respec ||
+		a.RespecSilver != b.RespecSilver || a.Kills != b.Kills ||
+		a.Deaths != b.Deaths || a.Loot != b.Loot {
+		return false
+	}
+	return statValuesMapEqual(a.Daily, b.Daily) && statValuesMapEqual(a.Hourly, b.Hourly)
+}
+
+func statValuesMapEqual(a, b map[string]StatValues) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if v != b[k] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestSaveLoadTotalStatsRoundTrip(t *testing.T) {
 	h := NewAlbionHandler()
 	h.stats.apply(TotalStats{Fame: 1500, Silver: 25000, Respec: 300, RespecSilver: 4500, Kills: 7, Deaths: 2, Loot: 11})
@@ -1657,7 +1682,7 @@ func TestSaveLoadTotalStatsRoundTrip(t *testing.T) {
 	}
 	got := fresh.TotalSnapshot()
 	want := TotalStats{Fame: 1500, Silver: 25000, Respec: 300, RespecSilver: 4500, Kills: 7, Deaths: 2, Loot: 11}
-	if got != want {
+	if !totalStatsEqual(got, want) {
 		t.Errorf("snapshot = %+v, want %+v", got, want)
 	}
 }
@@ -1668,7 +1693,7 @@ func TestLoadTotalStatsMissingFileLeavesZeroNoError(t *testing.T) {
 	if err := h.LoadTotalStats(path); err != nil {
 		t.Errorf("LoadTotalStats missing file: %v", err)
 	}
-	if got := h.TotalSnapshot(); got != (TotalStats{}) {
+	if got := h.TotalSnapshot(); !totalStatsEqual(got, TotalStats{}) {
 		t.Errorf("expected zero snapshot, got %+v", got)
 	}
 }
@@ -1688,7 +1713,7 @@ func TestLoadTotalStatsBackwardCompatMissingField(t *testing.T) {
 	}
 	got := h.TotalSnapshot()
 	want := TotalStats{Fame: 100, Silver: 200, Respec: 30, RespecSilver: 0, Kills: 1, Deaths: 0, Loot: 2}
-	if got != want {
+	if !totalStatsEqual(got, want) {
 		t.Errorf("snapshot = %+v, want %+v (respec_silver defaulting to 0)", got, want)
 	}
 }
@@ -1724,7 +1749,7 @@ func TestLoadTotalStatsVersionAbsentStillLoads(t *testing.T) {
 	}
 	got := h.TotalSnapshot()
 	want := TotalStats{Fame: 50, Silver: 60, Respec: 7, RespecSilver: 8, Kills: 1, Deaths: 0, Loot: 1}
-	if got != want {
+	if !totalStatsEqual(got, want) {
 		t.Errorf("snapshot = %+v, want %+v (loaded despite missing version)", got, want)
 	}
 }
@@ -1748,5 +1773,197 @@ func TestSaveTotalStatsErrorPropagates(t *testing.T) {
 	// Counters must be untouched by a failed save.
 	if got := h.stats.fameNow(); got != 100 {
 		t.Errorf("failed save should not mutate counters; Fame = %d, want 100", got)
+	}
+}
+
+// --- Daily / hourly bucketing (issue #112) ---
+
+func TestStatsBucketDailyFame(t *testing.T) {
+	h := NewAlbionHandler()
+	day := time.Date(2026, 7, 1, 14, 30, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return day }
+
+	h.stats.addFame(1000, h.nowFunc())
+	h.stats.addSilver(2500, h.nowFunc())
+
+	snap := h.TotalSnapshot()
+	dk := day.Format("2006-01-02")
+	d, ok := snap.Daily[dk]
+	if !ok {
+		t.Fatalf("expected daily bucket for %s, got %v", dk, snap.Daily)
+	}
+	if d.Fame != 1000 {
+		t.Errorf("daily fame = %d, want 1000", d.Fame)
+	}
+	if d.Silver != 2500 {
+		t.Errorf("daily silver = %d, want 2500", d.Silver)
+	}
+	// Cumulative total must also be updated.
+	if got := h.GetTotalFame(); got != 1000 {
+		t.Errorf("cumulative fame = %d, want 1000", got)
+	}
+}
+
+func TestStatsBucketHourlyFame(t *testing.T) {
+	h := NewAlbionHandler()
+	hour := time.Date(2026, 7, 1, 14, 30, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return hour }
+
+	h.stats.addFame(500, h.nowFunc())
+
+	snap := h.TotalSnapshot()
+	hk := hour.Format("2006-01-02T15")
+	hv, ok := snap.Hourly[hk]
+	if !ok {
+		t.Fatalf("expected hourly bucket for %s, got %v", hk, snap.Hourly)
+	}
+	if hv.Fame != 500 {
+		t.Errorf("hourly fame = %d, want 500", hv.Fame)
+	}
+}
+
+func TestStatsBucketSeparatesByDay(t *testing.T) {
+	h := NewAlbionHandler()
+	day1 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	day2 := time.Date(2026, 7, 2, 10, 0, 0, 0, time.UTC)
+
+	h.nowFunc = func() time.Time { return day1 }
+	h.stats.addFame(100, h.nowFunc())
+	h.nowFunc = func() time.Time { return day2 }
+	h.stats.addFame(200, h.nowFunc())
+
+	snap := h.TotalSnapshot()
+	if got := snap.Daily[day1.Format("2006-01-02")].Fame; got != 100 {
+		t.Errorf("day1 fame = %d, want 100", got)
+	}
+	if got := snap.Daily[day2.Format("2006-01-02")].Fame; got != 200 {
+		t.Errorf("day2 fame = %d, want 200", got)
+	}
+	if got := h.GetTotalFame(); got != 300 {
+		t.Errorf("cumulative fame = %d, want 300", got)
+	}
+}
+
+func TestStatsBucketCountsKillDeathLoot(t *testing.T) {
+	h := NewAlbionHandler()
+	day := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return day }
+
+	h.stats.addKill(h.nowFunc())
+	h.stats.addKill(h.nowFunc())
+	h.stats.addDeath(h.nowFunc())
+	h.stats.addLoot(h.nowFunc())
+
+	snap := h.TotalSnapshot()
+	d := snap.Daily[day.Format("2006-01-02")]
+	if d.Kills != 2 {
+		t.Errorf("daily kills = %d, want 2", d.Kills)
+	}
+	if d.Deaths != 1 {
+		t.Errorf("daily deaths = %d, want 1", d.Deaths)
+	}
+	if d.Loot != 1 {
+		t.Errorf("daily loot = %d, want 1", d.Loot)
+	}
+}
+
+func TestStatsBucketPruneOldEntries(t *testing.T) {
+	h := NewAlbionHandler()
+	// Use a short prune age so old buckets are dropped.
+	h.stats.pruneAge = 1 * time.Hour
+
+	old := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return old }
+	h.stats.addFame(1000, h.nowFunc())
+
+	// Sanity: the old bucket exists before pruning.
+	snap := h.TotalSnapshot()
+	if _, ok := snap.Daily[old.Format("2006-01-02")]; !ok {
+		t.Fatalf("pre-prune: expected daily bucket for %s", old.Format("2006-01-02"))
+	}
+
+	// Advance well past the prune age; the next increment triggers a prune.
+	future := old.Add(48 * time.Hour)
+	h.nowFunc = func() time.Time { return future }
+	h.stats.addFame(50, h.nowFunc())
+
+	snap = h.TotalSnapshot()
+	if _, ok := snap.Daily[old.Format("2006-01-02")]; ok {
+		t.Errorf("post-prune: old daily bucket should have been removed")
+	}
+	// The new bucket remains.
+	if _, ok := snap.Daily[future.Format("2006-01-02")]; !ok {
+		t.Errorf("post-prune: expected daily bucket for %s", future.Format("2006-01-02"))
+	}
+}
+
+func TestStatsSnapshotReturnsIndependentMaps(t *testing.T) {
+	h := NewAlbionHandler()
+	day := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return day }
+	h.stats.addFame(100, h.nowFunc())
+
+	snap := h.TotalSnapshot()
+	// Mutate the returned map; the next snapshot must be unaffected.
+	snap.Daily[day.Format("2006-01-02")] = StatValues{Fame: 999999}
+
+	snap2 := h.TotalSnapshot()
+	if got := snap2.Daily[day.Format("2006-01-02")].Fame; got != 100 {
+		t.Errorf("snapshot isolation broken: fame = %d, want 100 (returned map was mutated)", got)
+	}
+}
+
+func TestSaveLoadTotalStatsRoundTripWithBuckets(t *testing.T) {
+	h := NewAlbionHandler()
+	day := time.Date(2026, 7, 1, 14, 0, 0, 0, time.UTC)
+	h.nowFunc = func() time.Time { return day }
+	h.stats.addFame(1000, h.nowFunc())
+	h.stats.addSilver(2500, h.nowFunc())
+
+	path := filepath.Join(t.TempDir(), "session-stats.json")
+	if err := h.SaveTotalStats(path); err != nil {
+		t.Fatalf("SaveTotalStats: %v", err)
+	}
+
+	fresh := NewAlbionHandler()
+	if err := fresh.LoadTotalStats(path); err != nil {
+		t.Fatalf("LoadTotalStats: %v", err)
+	}
+	snap := fresh.TotalSnapshot()
+	d := snap.Daily[day.Format("2006-01-02")]
+	if d.Fame != 1000 {
+		t.Errorf("restored daily fame = %d, want 1000", d.Fame)
+	}
+	if d.Silver != 2500 {
+		t.Errorf("restored daily silver = %d, want 2500", d.Silver)
+	}
+	hr := snap.Hourly[day.Format("2006-01-02T15")]
+	if hr.Fame != 1000 {
+		t.Errorf("restored hourly fame = %d, want 1000", hr.Fame)
+	}
+}
+
+func TestLoadTotalStatsV1FileLoadsEmptyBuckets(t *testing.T) {
+	// A v1 file (no daily/hourly fields) must load with empty buckets while
+	// cumulative counters are intact — the additive-schema guarantee for #112.
+	path := filepath.Join(t.TempDir(), "v1-stats.json")
+	raw := []byte(`{"version":1,"fame":100,"silver":200,"respec":30,"respec_silver":8,"kills":1,"deaths":0,"loot":2,"saved_at":"2026-06-29T00:00:00Z"}`)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	h := NewAlbionHandler()
+	if err := h.LoadTotalStats(path); err != nil {
+		t.Fatalf("LoadTotalStats: %v", err)
+	}
+	snap := h.TotalSnapshot()
+	if got := snap.Fame; got != 100 {
+		t.Errorf("cumulative fame = %d, want 100", got)
+	}
+	if len(snap.Daily) != 0 {
+		t.Errorf("v1 file should load with empty daily buckets, got %d entries", len(snap.Daily))
+	}
+	if len(snap.Hourly) != 0 {
+		t.Errorf("v1 file should load with empty hourly buckets, got %d entries", len(snap.Hourly))
 	}
 }

--- a/pkg/handlers/dungeon_test.go
+++ b/pkg/handlers/dungeon_test.go
@@ -84,8 +84,8 @@ func TestEnterExitDungeonLifecycle(t *testing.T) {
 	}
 
 	// Exit — deltas should be zero (no stats gained)
-	h.stats.addFame(500)
-	h.stats.addKill()
+	h.stats.addFame(500, h.nowFunc())
+	h.stats.addKill(h.nowFunc())
 	exitTime := base.Add(2 * time.Minute)
 	h.nowFunc = func() time.Time { return exitTime }
 	h.ExitDungeon(exitTime)
@@ -119,7 +119,7 @@ func TestEnterDungeonClosesPrevious(t *testing.T) {
 	h.EnterDungeon(t0)
 
 	// Gain some fame during first run
-	h.stats.addFame(1000)
+	h.stats.addFame(1000, h.nowFunc())
 
 	// Enter a second dungeon without exiting the first
 	t1 := t0.Add(3 * time.Minute)
@@ -464,9 +464,9 @@ func TestSaveLoadDungeonRunsRoundTrip(t *testing.T) {
 	t0 := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
 	h.nowFunc = func() time.Time { return t0 }
 	h.EnterDungeon(t0)
-	h.stats.addFame(500)
-	h.stats.addKill()
-	h.stats.addKill()
+	h.stats.addFame(500, h.nowFunc())
+	h.stats.addKill(h.nowFunc())
+	h.stats.addKill(h.nowFunc())
 	exit := t0.Add(2 * time.Minute)
 	h.nowFunc = func() time.Time { return exit }
 	h.ExitDungeon(exit)
@@ -475,7 +475,7 @@ func TestSaveLoadDungeonRunsRoundTrip(t *testing.T) {
 	t1 := t0.Add(10 * time.Minute)
 	h.nowFunc = func() time.Time { return t1 }
 	h.EnterDungeon(t1)
-	h.stats.addSilver(300)
+	h.stats.addSilver(300, h.nowFunc())
 	t2 := t1.Add(5 * time.Minute)
 	h.nowFunc = func() time.Time { return t2 }
 	h.ExitDungeon(t2)


### PR DESCRIPTION
## Summary

Implements the last remaining acceptance criterion of **#104** ("Daily cumulative values are tracked"), which was explicitly deferred to **#112** and is the reason #104 stayed open. Closes #112.

Three commits, each independently green (build + 10/10 tests + gofmt clean):

1. **`refactor(handlers): rename session stats to total stats`** — mechanical rename of the cumulative-stats API/types from `session*` to `total*`, since the persisted counters are long-term totals, not a single session. Precedes the bucketing so the all-time counter has an unambiguous name vs. the time-bucketed companion. `FameEventData.Session` → `.AllTime` (its `.Total` is the server fame pool and couldn't be reused); other event-data fields → `.Total*`. On-disk filename `session-stats.json` unchanged for backward compat. No behavior change.

2. **`feat(handlers): add daily and hourly stat buckets`** — each cumulative-stat increment is now also attributed to two time buckets (daily keyed `YYYY-MM-DD`, hourly keyed `YYYY-MM-DDTHH`), mirroring the reference's `DailyValues`/`HourlyValues`. Lazy pruning drops buckets older than 90 days. Schema bumped to v2 with `daily`/`hourly` maps (`omitempty`); a v1 file loads with empty buckets. `addDelta` panics on an unknown field rather than silently dropping a delta (prevents cumulative/bucket drift).

3. **`feat(tui): show today's stats in panel`** — surfaces today's fame/silver/respec as a `─ today ─` section in the stats panel (rendered only when non-zero). `hydrateStatsPanel` seeds it from the daily bucket on startup; live events pipe the new `Daily` field into the panel.

## Acceptance criteria (#112)
- [x] Daily buckets (fame today, silver today, etc.) alongside cumulative totals
- [x] Hourly buckets (persisted; charting is a follow-up)
- [x] Entries older than configurable threshold (default 90 days) auto-pruned
- [x] Daily/hourly persisted with the same atomic write + crash recovery
- [x] Backward-compatible with existing `session-stats.json` (additive schema)
- [x] Tests cover bucket assignment, pruning, round-trip, v1 backward compat

## Out of scope (tracked separately, per #104 notes)
- #113 — server-region segregation (`UserData-{SERVER}`)
- #114 — append-only kill/death event log
- #115 — save-on-cluster-change rate-limited to 15 min

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` — 10/10 packages pass
- [x] `go vet ./...` clean
- [x] `go test -race` on handler package (mutex-protected maps race-clean)
- [x] Each of the 3 commits verified standalone (build + tests + gofmt)
- [x] Functional diff vs. pre-review final state: 0 lines (semantically identical)

Closes #112

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

Renames cumulative `session*` stats to `total*` for clarity, then adds daily and hourly time-bucketed stat tracking with automatic 90-day pruning — persisted alongside the existing all-time counters in a backward-compatible schema v2. Today's fame/silver/respec are surfaced in the TUI stats panel. Closes #112 by implementing the last acceptance criteria deferred from #104.

---
<sup>Written for commit 7039c94fa9faec87d85baf4e5259335bff22142e. Summary will update on new commits.</sup>
<!-- end-auto-generated -->