### PR TITLE
feat: persist kill/death events as append-only log

### DIFF
--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -99,7 +99,11 @@ func main() {
 	if err != nil {
 		fmt.Printf("Warning: persistence disabled, could not resolve stats data path: %v\n", err)
 	}
-	persistenceEnabled := dungeonPath != "" && statsPath != ""
+	kdLogPath, err := storage.DataFile("kill-death-log.json")
+	if err != nil {
+		fmt.Printf("Warning: persistence disabled, could not resolve kill/death log path: %v\n", err)
+	}
+	persistenceEnabled := dungeonPath != "" && statsPath != "" && kdLogPath != ""
 
 	// Load-on-startup. The handler is created by Start(), so this must run
 	// after it. A missing file is the first-run case (handled as empty state
@@ -111,6 +115,9 @@ func main() {
 			}
 			if err := h.LoadTotalStats(statsPath); err != nil {
 				fmt.Printf("Warning: could not load total stats: %v\n", err)
+			}
+			if err := h.LoadKillDeathLog(kdLogPath); err != nil {
+				fmt.Printf("Warning: could not load kill/death log: %v\n", err)
 			}
 		}
 	}
@@ -130,7 +137,10 @@ func main() {
 		if err := h.SaveDungeonRuns(dungeonPath); err != nil {
 			return err
 		}
-		return h.SaveTotalStats(statsPath)
+		if err := h.SaveTotalStats(statsPath); err != nil {
+			return err
+		}
+		return h.SaveKillDeathLog(kdLogPath)
 	})
 
 	// Send initial status event (as a batch)
@@ -161,6 +171,9 @@ func main() {
 			}
 			if err := h.SaveTotalStats(statsPath); err != nil {
 				fmt.Printf("Warning: could not save total stats: %v\n", err)
+			}
+			if err := h.SaveKillDeathLog(kdLogPath); err != nil {
+				fmt.Printf("Warning: could not save kill/death log: %v\n", err)
 			}
 		}
 	}

--- a/cmd/tui/runtime_verify_test.go
+++ b/cmd/tui/runtime_verify_test.go
@@ -112,3 +112,58 @@ func TestTotalStatsPersistenceLifecycle(t *testing.T) {
 		t.Error("expected error loading corrupt file, got nil")
 	}
 }
+
+// TestKillDeathLogPersistenceLifecycle exercises the on-disk lifecycle the TUI
+// orchestrates (main.go) for the kill/death log: a kill event lands in the
+// in-memory log, survives a save->reload round-trip, and a corrupt file errors
+// instead of crashing. Guards the persistence path the handler unit tests touch
+// only in pieces.
+func TestKillDeathLogPersistenceLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kill-death-log.json")
+
+	before := time.Now()
+	h := handlers.NewAlbionHandler()
+	h.SetLocalPlayer("Hero")
+
+	// 1. A kill event must land in the in-memory log.
+	h.OnEvent(byte(events.EventDied), map[byte]interface{}{
+		2:  "Enemy",
+		10: "Hero",
+	})
+	want := h.KillDeathLog()
+	if len(want) != 1 {
+		t.Fatalf("expected 1 in-memory entry, got %d", len(want))
+	}
+	if want[0].Type != handlers.KillTypeKill || want[0].Victim != "Enemy" {
+		t.Errorf("entry = %+v, want kill Victim=Enemy", want[0])
+	}
+
+	// 2. Save and reload — the entry must round-trip intact.
+	if err := h.SaveKillDeathLog(path); err != nil {
+		t.Fatalf("SaveKillDeathLog: %v", err)
+	}
+	fresh := handlers.NewAlbionHandler()
+	if err := fresh.LoadKillDeathLog(path); err != nil {
+		t.Fatalf("LoadKillDeathLog: %v", err)
+	}
+	got := fresh.KillDeathLog()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry after reload, got %d", len(got))
+	}
+	if got[0].Type != handlers.KillTypeKill || got[0].Victim != "Enemy" || got[0].Killer != "Hero" {
+		t.Errorf("reloaded entry = %+v, want kill Victim=Enemy Killer=Hero", got[0])
+	}
+	if got[0].Timestamp.Before(before) || got[0].Timestamp.After(time.Now().Add(time.Second)) {
+		t.Errorf("reloaded Timestamp = %v, want ~%v", got[0].Timestamp, before)
+	}
+
+	// 3. A corrupt file must error and not crash the app.
+	bad := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(bad, []byte("{broken"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := handlers.NewAlbionHandler().LoadKillDeathLog(bad); err == nil {
+		t.Error("expected error loading corrupt kill/death log, got nil")
+	}
+}

--- a/pkg/handlers/albion.go
+++ b/pkg/handlers/albion.go
@@ -36,6 +36,11 @@ const defaultDeathDedupWindow = 5 * time.Second
 // the totalCounters.pruneAge field for testing.
 const defaultPruneAge = 90 * 24 * time.Hour
 
+// maxKillDeathLogEntries bounds the persisted kill/death event log. The
+// reference (LocalUserData.cs) grows its PlayerKillsDeaths list unboundedly;
+// we cap it defensively so the on-disk file stays small and predictable.
+const maxKillDeathLogEntries = 1000
+
 // totalCounters holds the seven cumulative long-term counters behind a single
 // RWMutex so a snapshot reads all of them consistently (independent atomics
 // would allow a snapshot to mix pre- and post-update values). The lock is
@@ -382,6 +387,13 @@ type AlbionHandler struct {
 	dungeonRuns []*DungeonRun
 	activeRun   *DungeonRun
 
+	// Kill/death log of the local player's events, persisted to disk. The
+	// in-memory slice is bounded to maxKillDeathLogEntries (a ring window
+	// that drops the oldest entries when full). Distinct from the cumulative
+	// counters above: this preserves the per-event history.
+	kdLogMu sync.Mutex
+	kdLog   []*KillDeathLogEntry
+
 	// Event callback for frontend integration (TUI, Wails, etc.)
 	eventCallback EventCallback
 }
@@ -583,6 +595,35 @@ type DeathEventData struct {
 	TotalDeaths int    // Cumulative deaths across all launches (long-term total)
 }
 
+// KillDeathType discriminates a kill/death log entry. It is a string type so
+// the on-disk JSON stays human-readable ("kill"/"death"), while the named
+// constants prevent typo-prone bare strings at the call sites.
+type KillDeathType string
+
+const (
+	KillTypeKill  KillDeathType = "kill"
+	KillTypeDeath KillDeathType = "death"
+)
+
+// KillDeathLogEntry is a single persisted kill/death event of the local player
+// in the kill/death log (the reference's PlayerKillsDeaths.json equivalent).
+//
+// Only events involving the local player are recorded — a kill when the local
+// player is the killer, a death when the local player is the victim — mirroring
+// the reference, which fetches the local user's /deaths, /topkills and
+// /solokills. Nearby deaths (neither party is the local player) are not logged.
+//
+// The log is additive to the cumulative counters in session-stats.json: it
+// preserves per-event history (who/when/where) without replacing the totals.
+type KillDeathLogEntry struct {
+	Type      KillDeathType `json:"type"`
+	Timestamp time.Time     `json:"timestamp"`
+	Victim    string        `json:"victim"`
+	Killer    string        `json:"killer"`
+	Local     string        `json:"local,omitempty"` // local player name at the time
+	Zone      string        `json:"zone,omitempty"`  // zone display string at the time
+}
+
 // RespecEventData contains respec-specific event data
 type RespecEventData struct {
 	Gained      int64 // Credits gained in this event
@@ -609,6 +650,30 @@ func (h *AlbionHandler) GetTotalKills() int {
 // GetTotalDeaths returns the cumulative number of deaths across all launches.
 func (h *AlbionHandler) GetTotalDeaths() int {
 	return h.stats.deathsNow()
+}
+
+// KillDeathLog returns a copy of the persisted kill/death event log of the
+// local player, oldest-first. The slice is a deep copy and safe to retain.
+// Returns nil/empty when nothing has been logged yet.
+func (h *AlbionHandler) KillDeathLog() []KillDeathLogEntry {
+	h.kdLogMu.Lock()
+	defer h.kdLogMu.Unlock()
+	out := make([]KillDeathLogEntry, len(h.kdLog))
+	for i, e := range h.kdLog {
+		out[i] = *e
+	}
+	return out
+}
+
+// appendKillDeath appends a kill/death event to the in-memory log, trimming
+// the oldest entries when it exceeds maxKillDeathLogEntries (keeps the newest).
+func (h *AlbionHandler) appendKillDeath(e KillDeathLogEntry) {
+	h.kdLogMu.Lock()
+	h.kdLog = append(h.kdLog, &e)
+	if len(h.kdLog) > maxKillDeathLogEntries {
+		h.kdLog = h.kdLog[len(h.kdLog)-maxKillDeathLogEntries:]
+	}
+	h.kdLogMu.Unlock()
 }
 
 // GetTotalLoot returns the cumulative number of loot items across all launches.
@@ -902,6 +967,48 @@ func (h *AlbionHandler) LoadDungeonRuns(path string) error {
 	h.dungeonRuns = runs
 	h.activeRun = nil
 	h.dungeonMu.Unlock()
+	return nil
+}
+
+// SaveKillDeathLog persists the kill/death event log to path as JSON. The log
+// is copied under the lock and the (potentially slow) atomic write happens
+// without holding it, so event handling is not blocked on I/O — same shape as
+// SaveDungeonRuns. Atomicity (tmp + rename) and crash-recovery are provided by
+// storage.Save / storage.Load.
+func (h *AlbionHandler) SaveKillDeathLog(path string) error {
+	h.kdLogMu.Lock()
+	toSave := make([]*KillDeathLogEntry, len(h.kdLog))
+	for i, e := range h.kdLog {
+		cp := *e
+		toSave[i] = &cp
+	}
+	h.kdLogMu.Unlock()
+
+	return storage.Save(path, toSave)
+}
+
+// LoadKillDeathLog replaces the in-memory kill/death log with the entries
+// decoded from path. Entries are sorted oldest-first by Timestamp and trimmed
+// to maxKillDeathLogEntries (newest kept). The sort is stable so entries that
+// share a timestamp (e.g. near-simultaneous kills) keep their on-disk order.
+// A missing file is treated as an empty log (first run); a corrupt file is
+// returned as err and leaves the current log unchanged — same contract as
+// LoadDungeonRuns / LoadTotalStats.
+func (h *AlbionHandler) LoadKillDeathLog(path string) error {
+	entries, err := storage.Load[[]*KillDeathLogEntry](path)
+	if err != nil {
+		return err
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].Timestamp.Before(entries[j].Timestamp)
+	})
+	if len(entries) > maxKillDeathLogEntries {
+		entries = entries[len(entries)-maxKillDeathLogEntries:]
+	}
+
+	h.kdLogMu.Lock()
+	h.kdLog = entries
+	h.kdLogMu.Unlock()
 	return nil
 }
 
@@ -1284,6 +1391,7 @@ func (h *AlbionHandler) handleDied(params map[byte]interface{}) {
 	killer := getString(params, 10)
 
 	local := h.GetLocalPlayer()
+	now := h.nowFunc()
 
 	// Dedup redundant copies of the same death. The server delivers EventDied
 	// multiple times when the local player is the killer. Only apply dedup in
@@ -1303,18 +1411,51 @@ func (h *AlbionHandler) handleDied(params map[byte]interface{}) {
 	}
 
 	isLocalKill := local != "" && killer == local
+	isLocalDeath := local != "" && victim == local
+
+	// Resolve the zone display string only when this event will be logged
+	// (local player is the killer or the victim). Nearby deaths take neither
+	// branch, so they never pay for DisplayString. A self-kill (which hits
+	// both branches) resolves it exactly once.
+	var zone string
+	if isLocalKill || isLocalDeath {
+		zone = h.GetCurrentZone().DisplayString()
+	}
 
 	// Count a kill when the local player is the killer.
 	if isLocalKill {
-		h.stats.addKill(h.nowFunc())
+		h.stats.addKill(now)
 		h.notifyEvent("kill", "", &KillEventData{
 			TotalKills: h.stats.killsNow(),
+		})
+		// Append the kill to the persisted log. Only events involving the
+		// local player are logged (mirrors the reference), so this is the
+		// sole capture point for kills.
+		h.appendKillDeath(KillDeathLogEntry{
+			Type:      KillTypeKill,
+			Timestamp: now,
+			Victim:    victim,
+			Killer:    local,
+			Local:     local,
+			Zone:      zone,
 		})
 	}
 
 	// Count a death only when the local player is the victim.
-	if local != "" && victim == local {
-		h.stats.addDeath(h.nowFunc())
+	if isLocalDeath {
+		h.stats.addDeath(now)
+		// Append the local player's death to the persisted log. Note: a
+		// self-kill (suicide, where killer == victim == local) lands in the
+		// log as both a kill and a death entry — matches the reference,
+		// which would receive the same event from both /topkills and /deaths.
+		h.appendKillDeath(KillDeathLogEntry{
+			Type:      KillTypeDeath,
+			Timestamp: now,
+			Victim:    victim,
+			Killer:    killer,
+			Local:     local,
+			Zone:      zone,
+		})
 	}
 
 	// Emit a death event for the local player's death or for nearby deaths

--- a/pkg/handlers/albion_test.go
+++ b/pkg/handlers/albion_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cantalupo555/albion-lens/internal/storage"
 	"github.com/cantalupo555/albion-lens/pkg/events"
 )
 
@@ -2017,5 +2018,313 @@ func TestLoadTotalStatsV1FileLoadsEmptyBuckets(t *testing.T) {
 	}
 	if len(snap.Hourly) != 0 {
 		t.Errorf("v1 file should load with empty hourly buckets, got %d entries", len(snap.Hourly))
+	}
+}
+
+// killDeathLogEqual compares two kill/death log slices for equality (used by
+// the persistence round-trip and reload tests).
+func killDeathLogEqual(a, b []KillDeathLogEntry) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Type != b[i].Type {
+			return false
+		}
+		if !a[i].Timestamp.Equal(b[i].Timestamp) {
+			return false
+		}
+		if a[i].Victim != b[i].Victim || a[i].Killer != b[i].Killer {
+			return false
+		}
+		if a[i].Local != b[i].Local || a[i].Zone != b[i].Zone {
+			return false
+		}
+	}
+	return true
+}
+
+// TestKillDeathLogClassification verifies that only events involving the local
+// player are logged: a kill when the local player is the killer, a death when
+// the local player is the victim. Nearby deaths (neither party is the local
+// player) must NOT be logged.
+func TestKillDeathLogClassification(t *testing.T) {
+	t0 := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	h := NewAlbionHandler()
+	h.SetLocalPlayer("Hero")
+	h.nowFunc = func() time.Time { return t0 }
+
+	// Local player kills someone -> one kill entry.
+	h.OnEvent(byte(events.EventDied), map[byte]interface{}{
+		2:  "Enemy",
+		10: "Hero",
+	})
+	// Local player dies -> one death entry.
+	t1 := t0.Add(time.Minute)
+	h.nowFunc = func() time.Time { return t1 }
+	h.OnEvent(byte(events.EventDied), map[byte]interface{}{
+		2:  "Hero",
+		10: "Enemy2",
+	})
+	// Nearby death (neither party is local) -> NOT logged.
+	t2 := t0.Add(2 * time.Minute)
+	h.nowFunc = func() time.Time { return t2 }
+	h.OnEvent(byte(events.EventDied), map[byte]interface{}{
+		2:  "Alice",
+		10: "Bob",
+	})
+
+	got := h.KillDeathLog()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 log entries (kill + death), got %d: %+v", len(got), got)
+	}
+	if got[0].Type != KillTypeKill || got[0].Victim != "Enemy" || got[0].Killer != "Hero" {
+		t.Errorf("entry0 = %+v, want kill Victim=Enemy Killer=Hero", got[0])
+	}
+	if !got[0].Timestamp.Equal(t0) {
+		t.Errorf("entry0 Timestamp = %v, want %v", got[0].Timestamp, t0)
+	}
+	if got[1].Type != KillTypeDeath || got[1].Victim != "Hero" || got[1].Killer != "Enemy2" {
+		t.Errorf("entry1 = %+v, want death Victim=Hero Killer=Enemy2", got[1])
+	}
+}
+
+// TestKillDeathLogSelfKill verifies the documented self-kill (suicide) edge
+// case: when the local player is both killer and victim, a single EventDied
+// produces one kill entry AND one death entry. This mirrors the reference,
+// which would receive the same event from both /topkills and /deaths. The test
+// locks in the intended behavior so a future guard against double-counting
+// doesn't silently change the log semantics.
+func TestKillDeathLogSelfKill(t *testing.T) {
+	t0 := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	h := NewAlbionHandler()
+	h.SetLocalPlayer("Hero")
+	h.nowFunc = func() time.Time { return t0 }
+
+	// Self-kill: killer == victim == local.
+	h.OnEvent(byte(events.EventDied), map[byte]interface{}{
+		2:  "Hero",
+		10: "Hero",
+	})
+
+	got := h.KillDeathLog()
+	if len(got) != 2 {
+		t.Fatalf("self-kill should produce 2 entries (kill + death), got %d: %+v", len(got), got)
+	}
+	// Kill branch runs first (isLocalKill), death branch second (victim == local).
+	if got[0].Type != KillTypeKill {
+		t.Errorf("entry0 Type = %q, want %q", got[0].Type, KillTypeKill)
+	}
+	if got[1].Type != KillTypeDeath {
+		t.Errorf("entry1 Type = %q, want %q", got[1].Type, KillTypeDeath)
+	}
+	// Both entries describe the same victim/killer (the local player).
+	for i, e := range got {
+		if e.Victim != "Hero" || e.Killer != "Hero" {
+			t.Errorf("entry%d = Victim=%q Killer=%q, want both Hero", i, e.Victim, e.Killer)
+		}
+	}
+	// Counters are also incremented for both (consistent with the log).
+	if h.GetTotalKills() != 1 {
+		t.Errorf("kills counter = %d, want 1", h.GetTotalKills())
+	}
+	if h.GetTotalDeaths() != 1 {
+		t.Errorf("deaths counter = %d, want 1", h.GetTotalDeaths())
+	}
+}
+
+// TestKillDeathLogEnrichedFields verifies the local and zone context fields
+// are captured from the handler state at event time.
+func TestKillDeathLogEnrichedFields(t *testing.T) {
+	t0 := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	h := NewAlbionHandler()
+	h.SetLocalPlayer("Hero")
+	h.nowFunc = func() time.Time { return t0 }
+
+	// Establish a zone before the kill so DisplayString is non-empty.
+	h.OnResponse(events.OperationChangeCluster, 0, "", map[byte]interface{}{
+		0: "@ISLAND@my-island",
+		2: "My Island",
+	})
+
+	h.OnEvent(byte(events.EventDied), map[byte]interface{}{
+		2:  "Enemy",
+		10: "Hero",
+	})
+
+	got := h.KillDeathLog()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(got))
+	}
+	if got[0].Local != "Hero" {
+		t.Errorf("Local = %q, want \"Hero\"", got[0].Local)
+	}
+	if got[0].Zone == "" {
+		t.Errorf("Zone is empty, want a non-empty display string after ChangeCluster")
+	}
+}
+
+// TestKillDeathLogDedup verifies that the redundant copies of EventDied
+// delivered when the local player is the killer produce exactly one log entry.
+func TestKillDeathLogDedup(t *testing.T) {
+	t0 := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	h := NewAlbionHandler()
+	h.SetLocalPlayer("Hero")
+	h.nowFunc = func() time.Time { return t0 }
+
+	params := map[byte]interface{}{2: "Enemy", 10: "Hero"}
+	for i := 0; i < 5; i++ {
+		h.OnEvent(byte(events.EventDied), params)
+	}
+
+	got := h.KillDeathLog()
+	if len(got) != 1 {
+		t.Errorf("expected 1 log entry after dedup, got %d: %+v", len(got), got)
+	}
+}
+
+// TestKillDeathLogCap verifies the log is bounded to maxKillDeathLogEntries,
+// keeping the newest entries when the cap is exceeded.
+func TestKillDeathLogCap(t *testing.T) {
+	h := NewAlbionHandler()
+	h.SetLocalPlayer("Hero")
+	// Advance time per event so each kill is distinct (avoid dedup) and the
+	// ordering of retained entries is deterministic. ts is freshly declared
+	// each iteration, so the closure captures a distinct value per event.
+	base := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	for i := 0; i < maxKillDeathLogEntries+50; i++ {
+		ts := base.Add(time.Duration(i) * time.Second)
+		h.nowFunc = func() time.Time { return ts }
+		h.OnEvent(byte(events.EventDied), map[byte]interface{}{
+			2:  fmt.Sprintf("Enemy%d", i),
+			10: "Hero",
+		})
+	}
+
+	got := h.KillDeathLog()
+	if len(got) != maxKillDeathLogEntries {
+		t.Fatalf("expected log capped to %d entries, got %d", maxKillDeathLogEntries, len(got))
+	}
+	// The newest maxKillDeathLogEntries should be retained (indices
+	// 50..maxKillDeathLogEntries+49). The first retained victim reflects index 50.
+	wantFirstVictim := "Enemy50"
+	if got[0].Victim != wantFirstVictim {
+		t.Errorf("oldest retained Victim = %q, want %q (cap should drop oldest)", got[0].Victim, wantFirstVictim)
+	}
+	wantLastVictim := fmt.Sprintf("Enemy%d", maxKillDeathLogEntries+49)
+	if got[len(got)-1].Victim != wantLastVictim {
+		t.Errorf("newest retained Victim = %q, want %q", got[len(got)-1].Victim, wantLastVictim)
+	}
+}
+
+// TestSaveLoadKillDeathLogRoundTrip verifies the log survives save+reload
+// intact.
+func TestSaveLoadKillDeathLogRoundTrip(t *testing.T) {
+	t0 := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	h := NewAlbionHandler()
+	h.SetLocalPlayer("Hero")
+	h.nowFunc = func() time.Time { return t0 }
+	h.OnEvent(byte(events.EventDied), map[byte]interface{}{2: "Enemy", 10: "Hero"})
+
+	t1 := t0.Add(time.Minute)
+	h.nowFunc = func() time.Time { return t1 }
+	h.OnEvent(byte(events.EventDied), map[byte]interface{}{2: "Hero", 10: "Enemy2"})
+
+	want := h.KillDeathLog()
+	if len(want) != 2 {
+		t.Fatalf("expected 2 entries seeded, got %d", len(want))
+	}
+
+	path := filepath.Join(t.TempDir(), "kill-death-log.json")
+	if err := h.SaveKillDeathLog(path); err != nil {
+		t.Fatalf("SaveKillDeathLog: %v", err)
+	}
+
+	fresh := NewAlbionHandler()
+	if err := fresh.LoadKillDeathLog(path); err != nil {
+		t.Fatalf("LoadKillDeathLog: %v", err)
+	}
+	got := fresh.KillDeathLog()
+	if !killDeathLogEqual(want, got) {
+		t.Errorf("round-trip mismatch\nwant: %+v\ngot:  %+v", want, got)
+	}
+}
+
+// TestLoadKillDeathLogMissingFile verifies a missing file is the first-run
+// case: no error, empty log.
+func TestLoadKillDeathLogMissingFile(t *testing.T) {
+	h := NewAlbionHandler()
+	path := filepath.Join(t.TempDir(), "does-not-exist.json")
+	if err := h.LoadKillDeathLog(path); err != nil {
+		t.Errorf("missing file should not error, got: %v", err)
+	}
+	if got := h.KillDeathLog(); len(got) != 0 {
+		t.Errorf("expected empty log on missing file, got %d entries", len(got))
+	}
+}
+
+// TestLoadKillDeathLogCorruptFile verifies a corrupt file returns an error and
+// leaves any pre-existing in-memory log unchanged.
+func TestLoadKillDeathLogCorruptFile(t *testing.T) {
+	h := NewAlbionHandler()
+	h.SetLocalPlayer("Hero")
+	h.nowFunc = func() time.Time { return time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC) }
+	h.OnEvent(byte(events.EventDied), map[byte]interface{}{2: "Enemy", 10: "Hero"})
+	pre := h.KillDeathLog()
+
+	path := filepath.Join(t.TempDir(), "kill-death-log.json")
+	if err := os.WriteFile(path, []byte("{broken json"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := h.LoadKillDeathLog(path); err == nil {
+		t.Error("expected error loading corrupt file, got nil")
+	}
+	if got := h.KillDeathLog(); !killDeathLogEqual(pre, got) {
+		t.Errorf("corrupt load should leave log unchanged\npre: %+v\npost: %+v", pre, got)
+	}
+}
+
+// TestLoadKillDeathLogTrimsToCap verifies that loading more entries than the
+// cap keeps only the newest. The oversized file is written directly (bypassing
+// appendKillDeath, which trims at append time) so the load-time trim branch in
+// LoadKillDeathLog is what's actually exercised.
+func TestLoadKillDeathLogTrimsToCap(t *testing.T) {
+	const n = maxKillDeathLogEntries + 20
+	oversized := make([]*KillDeathLogEntry, 0, n)
+	base := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	for i := 0; i < n; i++ {
+		oversized = append(oversized, &KillDeathLogEntry{
+			Type:      KillTypeKill,
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+			Victim:    fmt.Sprintf("Enemy%d", i),
+			Killer:    "Hero",
+		})
+	}
+
+	// Write the oversized slice directly to disk via the storage layer, so the
+	// append-time trim never runs and the file genuinely contains n entries.
+	path := filepath.Join(t.TempDir(), "kill-death-log.json")
+	if err := storage.Save(path, oversized); err != nil {
+		t.Fatalf("storage.Save oversized: %v", err)
+	}
+
+	fresh := NewAlbionHandler()
+	if err := fresh.LoadKillDeathLog(path); err != nil {
+		t.Fatalf("LoadKillDeathLog: %v", err)
+	}
+	got := fresh.KillDeathLog()
+	if len(got) != maxKillDeathLogEntries {
+		t.Fatalf("expected log trimmed to %d on load, got %d", maxKillDeathLogEntries, len(got))
+	}
+	// After trimming, the newest maxKillDeathLogEntries survive: indices
+	// 20..n-1. The oldest retained entry reflects index 20; the newest index n-1.
+	wantFirstVictim := "Enemy20"
+	if got[0].Victim != wantFirstVictim {
+		t.Errorf("oldest retained Victim = %q, want %q (load trim should drop oldest)", got[0].Victim, wantFirstVictim)
+	}
+	wantLastVictim := fmt.Sprintf("Enemy%d", n-1)
+	if got[len(got)-1].Victim != wantLastVictim {
+		t.Errorf("newest retained Victim = %q, want %q", got[len(got)-1].Victim, wantLastVictim)
 	}
 }


### PR DESCRIPTION
Persist kill/death events as an append-only log, mirroring the reference's `PlayerKillsDeaths.json`. The log is **additive** — the cumulative counters in `session-stats.json` are untouched.

## How it works

Each kill/death event involving the **local player** (as killer → kill entry; as victim → death entry) is appended to an in-memory bounded slice and persisted to `kill-death-log.json` via the existing atomic `storage.Save` / `storage.Load` (tmp + rename, crash-recovery on load). Nearby deaths are not logged, matching the reference's local-player scope.

Persists: `type`, `timestamp`, `victim`, `killer`, `local`, `zone`.

## Divergences from the reference (documented in code)

- **Data source**: the reference fetches kills/deaths from the Albion REST API (`/deaths`, `/topkills`, `/solokills`), which yields rich fields (`EventId`, `TotalVictimKillFame`, solo/group tag). This project captures via the `EventDied` packet (code 165), which carries only victim + killer, so the log holds a subset of the fields. Migrating to the REST API is out of scope.
- **Counters**: kept separate/additive (the reference derives them from the log). Deriving from the log would require refactoring the freshly-merged daily/hourly bucket system (#104/#116) and contradicts the issue's "additive, not a replacement" requirement.
- **Improvements over the reference**: (1) explicit 1000-entry cap (the reference grows unboundedly); (2) atomic tmp-swap write via `storage.Save` (the reference uses a non-atomic `File.WriteAllTextAsync`).

## Acceptance criteria (issue #114)

- [x] Each kill/death event involving the local player is appended to a persistent log
- [x] The log survives restarts (loaded on startup, appended on new events)
- [x] Append writes are atomic (tmp-swap) and crash-safe
- [x] The log is capped (last 1000 entries; newest kept)
- [x] Backward-compatible with the cumulative counters (additive)
- [x] Tests cover append, reload, cap/prune, and round-trip

Closes #114.
Parent: #104.

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

This PR adds an append-only `kill-death-log.json` that records kill/death events involving the local player, persisted via atomic tmp-swap writes and capped at 1000 entries. The log is loaded on startup and appended on new `EventDied` packets, with the existing cumulative counters in `session-stats.json` left untouched for backward compatibility. The implementation spans packet handling, TUI lifecycle wiring, and tests covering append, dedup, cap/prune, and round-trip persistence.

---
<sup>Written for commit 8da5b454e6df201f23d674f0d3ee10a68fdec2a9. Summary will update on new commits.</sup>
<!-- end-auto-generated -->