### PR TITLE
feat(persistence): segregate data by server region and save on cluster change

### DIFF
--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -69,7 +68,9 @@ func main() {
 
 	// sendWarning delivers a diagnostic to the TUI event log so the user can
 	// see it during operation (fmt.Printf is hidden by the TUI alt-screen).
-	// Falls back to fmt.Printf when the channel is full so no warning is lost.
+	// When the channel is full the fallback writes to stdout, which is not
+	// visible during TUI operation — this is an accepted trade-off: warnings
+	// are rare and the channel buffer (250) is sized to absorb bursts.
 	sendWarning := func(msgType, format string, args ...any) {
 		select {
 		case bulkEventChan <- tui.BulkEventMsg{{
@@ -170,17 +171,22 @@ func main() {
 	// I/O. The periodic ticker and save-on-exit remain as safety nets.
 	// saveWg tracks these goroutines so the final save-on-exit can drain them
 	// first, avoiding an in-flight .tmp write racing with the exit save.
-	// shuttingDown gates saveWg.Add(1) so the WaitGroup cannot be re-entered
-	// after the exit drain has completed (which would panic).
-	var shuttingDown atomic.Bool
+	// clusterMu pairs the shutdown gate with saveWg.Add(1) so the WaitGroup
+	// cannot be re-entered after the exit drain (which would panic). The
+	// mutex is held only for the gate check + Add, never during I/O.
+	var clusterShutdown bool
+	var clusterMu sync.Mutex
 	clusterSaver := newRateLimiter(clusterSaveWindow)
 	var saveWg sync.WaitGroup
 	if h := svc.Handler(); h != nil {
 		h.SetClusterChangeCallback(func() {
-			if shuttingDown.Load() || !paths.Enabled() || !clusterSaver.Allow(time.Now()) {
+			clusterMu.Lock()
+			if clusterShutdown || !paths.Enabled() || !clusterSaver.Allow(time.Now()) {
+				clusterMu.Unlock()
 				return
 			}
 			saveWg.Add(1)
+			clusterMu.Unlock()
 			go func() {
 				defer saveWg.Done()
 				hh := svc.Handler()
@@ -220,7 +226,9 @@ func main() {
 	// 4. Final save-on-exit.
 	// 5. Stop capture (closes serverChangedCh so watchServerChanges exits).
 	// 6. Drain the region-change watcher.
-	shuttingDown.Store(true)
+	clusterMu.Lock()
+	clusterShutdown = true
+	clusterMu.Unlock()
 	saveCancel()
 	saveWg.Wait()
 	if h := svc.Handler(); h != nil && paths.Enabled() {

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -5,13 +5,17 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/cantalupo555/albion-lens/internal/storage"
+	"github.com/cantalupo555/albion-lens/internal/serverdetect"
 	"github.com/cantalupo555/albion-lens/internal/tui"
 	"github.com/cantalupo555/albion-lens/pkg/backend"
 	"github.com/cantalupo555/albion-lens/pkg/capture"
+	"github.com/cantalupo555/albion-lens/pkg/handlers"
 	"github.com/cantalupo555/albion-lens/pkg/photon"
 )
 
@@ -63,6 +67,21 @@ func main() {
 	bulkEventChan := make(chan tui.BulkEventMsg, bulkEventChannelSize)
 	statsChan := make(chan *photon.Stats, statsChannelSize)
 
+	// sendWarning delivers a diagnostic to the TUI event log so the user can
+	// see it during operation (fmt.Printf is hidden by the TUI alt-screen).
+	// Falls back to fmt.Printf when the channel is full so no warning is lost.
+	sendWarning := func(msgType, format string, args ...any) {
+		select {
+		case bulkEventChan <- tui.BulkEventMsg{{
+			Type:      msgType,
+			Message:   strings.TrimSpace(fmt.Sprintf(format, args...)),
+			Timestamp: time.Now(),
+		}}:
+		default:
+			fmt.Printf(format, args...)
+		}
+	}
+
 	// Bridge backend events to TUI with batching
 	go bridgeEvents(svc.Events, bulkEventChan, svc.ParserStats)
 
@@ -85,40 +104,47 @@ func main() {
 	}
 	defer svc.Stop()
 
-	// --- Persistence (issues #103, #104): restore state, then keep it warm. ---
-	// Resolve XDG data paths first (the directory is created if missing). If
-	// resolution fails (e.g. HOME unset or data dir read-only), persistence is
-	// disabled entirely: we never pass an empty path to Load/Save, which would
-	// otherwise silently no-op on Load and emit confusing "periodic save
-	// failed" warnings on Save.
-	dungeonPath, err := storage.DataFile("dungeon-runs.json")
-	if err != nil {
-		fmt.Printf("Warning: persistence disabled, could not resolve dungeon data path: %v\n", err)
+	// --- Persistence: restore state, keep it warm, and segregate it per
+	// Albion server region. ---
+	// A user-provided server-hint.txt overrides IP-based detection: when set,
+	// persistence pins to that region for the whole session and detection
+	// events are ignored. This is the escape hatch for when the server IP
+	// prefixes drift (see internal/serverdetect).
+	hintRegion := serverHintOverride()
+	if hintRegion.IsKnown() {
+		fmt.Printf("Server hint active: persistence pinned to %s; IP detection disabled.\n", hintRegion)
 	}
-	statsPath, err := storage.DataFile("session-stats.json")
-	if err != nil {
-		fmt.Printf("Warning: persistence disabled, could not resolve stats data path: %v\n", err)
+	warn := warnFn(func(format string, args ...any) {
+		sendWarning("warning", format, args...)
+	})
+	paths := newPersistPaths(hintRegion.DirName(), warn)
+	if !paths.Enabled() {
+		fmt.Printf("Warning: persistence disabled, could not resolve data directory: %v\n", paths.InitError())
 	}
-	kdLogPath, err := storage.DataFile("kill-death-log.json")
-	if err != nil {
-		fmt.Printf("Warning: persistence disabled, could not resolve kill/death log path: %v\n", err)
-	}
-	persistenceEnabled := dungeonPath != "" && statsPath != "" && kdLogPath != ""
 
 	// Load-on-startup. The handler is created by Start(), so this must run
 	// after it. A missing file is the first-run case (handled as empty state
 	// inside Load); a corrupt file leaves the in-memory state unchanged.
-	if persistenceEnabled {
+	if h := svc.Handler(); h != nil {
+		if err := paths.Load(h); err != nil {
+			sendWarning("warning", "Warning: could not load persisted state: %v\n", err)
+		}
+	}
+
+	// React to server-region changes: flush the old region, switch paths, and
+	// reload state for the new region. Skipped when a hint override is active
+	// (the user explicitly pinned the region) or persistence is disabled.
+	var watchWg sync.WaitGroup
+	notify := func(msgType, format string, args ...any) {
+		sendWarning(msgType, format, args...)
+	}
+	if hintRegion == serverdetect.ServerLocationUnknown && paths.Enabled() {
 		if h := svc.Handler(); h != nil {
-			if err := h.LoadDungeonRuns(dungeonPath); err != nil {
-				fmt.Printf("Warning: could not load dungeon history: %v\n", err)
-			}
-			if err := h.LoadTotalStats(statsPath); err != nil {
-				fmt.Printf("Warning: could not load total stats: %v\n", err)
-			}
-			if err := h.LoadKillDeathLog(kdLogPath); err != nil {
-				fmt.Printf("Warning: could not load kill/death log: %v\n", err)
-			}
+			watchWg.Add(1)
+			go func() {
+				defer watchWg.Done()
+				watchServerChanges(svc.ServerChanged(), h, paths, notify)
+			}()
 		}
 	}
 
@@ -127,21 +153,46 @@ func main() {
 	saveCtx, saveCancel := context.WithCancel(context.Background())
 	defer saveCancel()
 	go periodicSave(saveCtx, saveInterval, func() error {
-		if !persistenceEnabled {
-			return nil
+		if dropped := svc.ServerChangesDropped(); dropped > 0 {
+			notify("warning", "Warning: %d server-region change(s) dropped; persistence may not have switched to the correct region.\n", dropped)
 		}
 		h := svc.Handler()
-		if h == nil {
+		if h == nil || !paths.Enabled() {
 			return nil
 		}
-		if err := h.SaveDungeonRuns(dungeonPath); err != nil {
-			return err
-		}
-		if err := h.SaveTotalStats(statsPath); err != nil {
-			return err
-		}
-		return h.SaveKillDeathLog(kdLogPath)
-	})
+		return paths.Save(h)
+	}, notify)
+
+	// Cluster-change save: each confirmed zone transition asks for a
+	// persistence flush, rate-limited so rapid map hops coalesce into at most
+	// one write per clusterSaveWindow. The save runs in its own goroutine so
+	// the capture hot path that produced the transition is never blocked on
+	// I/O. The periodic ticker and save-on-exit remain as safety nets.
+	// saveWg tracks these goroutines so the final save-on-exit can drain them
+	// first, avoiding an in-flight .tmp write racing with the exit save.
+	// shuttingDown gates saveWg.Add(1) so the WaitGroup cannot be re-entered
+	// after the exit drain has completed (which would panic).
+	var shuttingDown atomic.Bool
+	clusterSaver := newRateLimiter(clusterSaveWindow)
+	var saveWg sync.WaitGroup
+	if h := svc.Handler(); h != nil {
+		h.SetClusterChangeCallback(func() {
+			if shuttingDown.Load() || !paths.Enabled() || !clusterSaver.Allow(time.Now()) {
+				return
+			}
+			saveWg.Add(1)
+			go func() {
+				defer saveWg.Done()
+				hh := svc.Handler()
+				if hh == nil {
+					return
+				}
+				if err := paths.Save(hh); err != nil {
+					notify("warning", "Warning: cluster-change save failed: %v\n", err)
+				}
+			}()
+		})
+	}
 
 	// Send initial status event (as a batch)
 	bulkEventChan <- tui.BulkEventMsg{
@@ -161,22 +212,25 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Stop the periodic flush, then do a final save-on-exit so the on-disk
-	// state reflects the very last in-memory values.
+	// --- Shutdown sequence ---
+	// 1. Gate the cluster-change callback so no new saveWg.Add(1) can fire
+	//    after we start draining (Add on a waited WaitGroup panics).
+	// 2. Stop the periodic flush.
+	// 3. Drain in-flight cluster-change saves.
+	// 4. Final save-on-exit.
+	// 5. Stop capture (closes serverChangedCh so watchServerChanges exits).
+	// 6. Drain the region-change watcher.
+	shuttingDown.Store(true)
 	saveCancel()
-	if persistenceEnabled {
-		if h := svc.Handler(); h != nil {
-			if err := h.SaveDungeonRuns(dungeonPath); err != nil {
-				fmt.Printf("Warning: could not save dungeon history: %v\n", err)
-			}
-			if err := h.SaveTotalStats(statsPath); err != nil {
-				fmt.Printf("Warning: could not save total stats: %v\n", err)
-			}
-			if err := h.SaveKillDeathLog(kdLogPath); err != nil {
-				fmt.Printf("Warning: could not save kill/death log: %v\n", err)
-			}
+	saveWg.Wait()
+	if h := svc.Handler(); h != nil && paths.Enabled() {
+		if err := paths.Save(h); err != nil {
+			fmt.Printf("Warning: final save failed: %v\n", err)
 		}
 	}
+
+	svc.Stop()
+	watchWg.Wait()
 
 	// In discovery mode, persist the captured event map so unmapped events
 	// (e.g. the dungeon-closure notification) can be identified offline.
@@ -260,9 +314,9 @@ func bridgeEvents(
 
 // periodicSave calls save at each interval until ctx is cancelled. Used to
 // bound the data-loss window on crash/kill while the TUI is running. A non-nil
-// error from save is surfaced as a warning so the user learns mid-session that
-// persistence has degraded (the final save-on-exit remains the safety net).
-func periodicSave(ctx context.Context, interval time.Duration, save func() error) {
+// error from save is surfaced via notify (or fmt.Printf when nil) so the user
+// learns mid-session that persistence has degraded.
+func periodicSave(ctx context.Context, interval time.Duration, save func() error, notify func(msgType, format string, args ...any)) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
@@ -271,8 +325,48 @@ func periodicSave(ctx context.Context, interval time.Duration, save func() error
 			return
 		case <-ticker.C:
 			if err := save(); err != nil {
-				fmt.Printf("Warning: periodic save failed: %v\n", err)
+				if notify != nil {
+					notify("warning", "Warning: periodic save failed: %v\n", err)
+				} else {
+					fmt.Printf("Warning: periodic save failed: %v\n", err)
+				}
 			}
+		}
+	}
+}
+
+// watchServerChanges consumes region transitions from changes and re-points
+// persistence at the newly active region. A transition to a known region
+// triggers SwitchRegion (flush old → reset → migrate → load new); a transition
+// back to Unknown (the detector lost confidence after seeing a different
+// region) is ignored so paths stay on the last known region rather than
+// churning to the shared root. Returns when the service stops and closes the
+// changes channel.
+//
+// notify routes diagnostics to the TUI event log (nil falls back to fmt.Printf
+// for tests). The handler is captured once (it lives for the whole capture
+// session) so the function depends only on its arguments, making it
+// unit-testable without a real Service.
+func watchServerChanges(changes <-chan serverdetect.ChangeEvent, h *handlers.AlbionHandler, paths *persistPaths, notify func(msgType, format string, args ...any)) {
+	for ev := range changes {
+		region := ev.Current.Location
+		if !region.IsKnown() {
+			continue
+		}
+		dir := region.DirName()
+		if h == nil {
+			continue
+		}
+		if err := paths.SwitchRegion(dir, h); err != nil {
+			if notify != nil {
+				notify("warning", "Warning: region switch to %s failed: %v\n", dir, err)
+			} else {
+				fmt.Printf("Warning: region switch to %s failed: %v\n", dir, err)
+			}
+			continue
+		}
+		if notify != nil {
+			notify("info", "Persistence switched to region %s (%s)\n", region, dir)
 		}
 	}
 }

--- a/cmd/tui/main_test.go
+++ b/cmd/tui/main_test.go
@@ -3,12 +3,15 @@ package main
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/cantalupo555/albion-lens/internal/serverdetect"
 	"github.com/cantalupo555/albion-lens/internal/tui"
 	"github.com/cantalupo555/albion-lens/pkg/backend"
+	"github.com/cantalupo555/albion-lens/pkg/handlers"
 	"github.com/cantalupo555/albion-lens/pkg/photon"
 )
 
@@ -222,3 +225,69 @@ func TestPeriodicSaveContinuesAfterError(t *testing.T) {
 
 // errBoom is a sentinel error used only by TestPeriodicSaveContinuesAfterError.
 var errBoom = errors.New("boom")
+
+// TestShutdownSequenceNoPanicOrDeadlock exercises the exact shutdown sequence
+// from main() with concurrent cluster-save activity and an active region
+// watcher. A future refactor that reorders the steps or drops the
+// shuttingDown gate would panic (WaitGroup re-use) or deadlock here.
+func TestShutdownSequenceNoPanicOrDeadlock(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	h := handlers.NewAlbionHandler()
+	h.SetLocalPlayer("Test")
+	paths := newPersistPaths("", nil)
+
+	// Cluster-save setup — mirrors main.go's callback pattern.
+	var clusterShutdown bool
+	var clusterMu sync.Mutex
+	var saveWg sync.WaitGroup
+
+	// Concurrent goroutine simulating the capture path firing callbacks.
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				// Same gate+mutex pattern as main.go's cluster-change callback.
+				clusterMu.Lock()
+				if !clusterShutdown {
+					saveWg.Add(1)
+					clusterMu.Unlock()
+					go func() {
+						defer saveWg.Done()
+						time.Sleep(2 * time.Millisecond) // simulate I/O latency
+						_ = paths.Save(h)
+					}()
+				} else {
+					clusterMu.Unlock()
+				}
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}()
+
+	// Region watcher — mirrors main.go's watchServerChanges goroutine.
+	changes := make(chan serverdetect.ChangeEvent, 4)
+	var watchWg sync.WaitGroup
+	watchWg.Add(1)
+	go func() {
+		defer watchWg.Done()
+		watchServerChanges(changes, h, paths, nil)
+	}()
+
+	// Let concurrent activity accumulate.
+	time.Sleep(20 * time.Millisecond)
+
+	// Shutdown sequence — exact order from main.go.
+	clusterMu.Lock()
+	clusterShutdown = true
+	clusterMu.Unlock()
+	close(stop)
+	saveWg.Wait()  // drain in-flight saves (no panic)
+	close(changes) // simulates svc.Stop() closing ServerChanged
+	watchWg.Wait() // drain watcher (no deadlock)
+
+	// Reaching this point means the shutdown sequence is panic-free.
+}

--- a/cmd/tui/main_test.go
+++ b/cmd/tui/main_test.go
@@ -176,7 +176,7 @@ func TestPeriodicSaveFiresAndStopsOnCancel(t *testing.T) {
 		periodicSave(ctx, 10*time.Millisecond, func() error {
 			calls.Add(1)
 			return nil
-		})
+		}, nil)
 		close(done)
 	}()
 
@@ -207,7 +207,7 @@ func TestPeriodicSaveContinuesAfterError(t *testing.T) {
 		periodicSave(ctx, 10*time.Millisecond, func() error {
 			calls.Add(1)
 			return errBoom
-		})
+		}, nil)
 		close(done)
 	}()
 

--- a/cmd/tui/persist.go
+++ b/cmd/tui/persist.go
@@ -1,0 +1,341 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cantalupo555/albion-lens/internal/serverdetect"
+	"github.com/cantalupo555/albion-lens/internal/storage"
+	"github.com/cantalupo555/albion-lens/pkg/handlers"
+)
+
+// clusterSaveWindow is the minimum interval between two cluster-change saves.
+// It coalesces rapid map transitions (e.g. hopping through several zones) into
+// a single write, matching the reference's 15-minute rate limit. The periodic
+// 5-minute ticker remains as a separate safety net.
+const clusterSaveWindow = 15 * time.Minute
+
+// Names of the three persisted JSON state files plus the server-hint override
+// file. Kept in one place so the resolver, the legacy migration, and any
+// diagnostics reference the same constants.
+const (
+	dungeonRunsFile  = "dungeon-runs.json"
+	sessionStatsFile = "session-stats.json"
+	killDeathLogFile = "kill-death-log.json"
+	serverHintFile   = "server-hint.txt"
+)
+
+// persistPaths owns the on-disk locations of the persisted state files for the
+// currently active server region, and serializes all save/load/switch
+// operations through a single mutex.
+//
+// The region field is the on-disk subdirectory name (e.g. "UserData-AMERICA");
+// the empty string means the legacy/shared root. When the detected region
+// changes, SwitchRegion flushes the old region to disk, resets in-memory state,
+// and loads the new region — observed as one atomic transition by savers.
+// warnFn delivers a diagnostic message to the user-visible event log. When
+// nil (tests, pre-TUI init), callers fall back to fmt.Printf so the message
+// is not lost.
+type warnFn func(format string, args ...any)
+
+type persistPaths struct {
+	mu      sync.Mutex
+	enabled bool
+	region  string
+	dungeon string
+	stats   string
+	kdlog   string
+	initErr error
+	warn    warnFn
+}
+
+// warnf emits a diagnostic message via the configured callback, or via
+// fmt.Printf when no callback is set (tests).
+func (p *persistPaths) warnf(format string, args ...any) {
+	if p.warn != nil {
+		p.warn(format, args...)
+		return
+	}
+	fmt.Printf(format, args...)
+}
+
+// newPersistPaths resolves the initial paths for the given region. If path
+// resolution fails (e.g. HOME unset or data dir read-only), persistence is
+// disabled: enabled=false and all operations become no-ops, matching the
+// pre-region behavior of emitting a warning and continuing without persistence.
+// warn routes diagnostics to the TUI event log during operation; pass nil for
+// tests or pre-TUI initialization (falls back to fmt.Printf).
+func newPersistPaths(initialRegion string, warn warnFn) *persistPaths {
+	p := &persistPaths{enabled: true, warn: warn}
+	if err := p.reassignLocked(initialRegion); err != nil {
+		p.enabled = false
+		p.initErr = err
+	}
+	return p
+}
+
+// Enabled reports whether persistence is active. When false, Load/Save/Switch
+// are no-ops and the caller should skip their warnings about failed saves.
+func (p *persistPaths) Enabled() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.enabled
+}
+
+// InitError returns the error that caused persistence to be disabled at
+// startup, or nil if initialization succeeded. It lets the caller log the
+// specific cause (e.g. HOME unset, permissions) instead of a generic message.
+func (p *persistPaths) InitError() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.initErr
+}
+
+// Region returns the currently active region subdirectory name ("" = legacy).
+func (p *persistPaths) Region() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.region
+}
+
+// reassignLocked re-resolves all three paths for the given region. The caller
+// MUST hold p.mu. An error leaves the previous paths untouched.
+func (p *persistPaths) reassignLocked(region string) error {
+	dungeon, err := storage.DataFileFor(region, dungeonRunsFile)
+	if err != nil {
+		return err
+	}
+	stats, err := storage.DataFileFor(region, sessionStatsFile)
+	if err != nil {
+		return err
+	}
+	kdlog, err := storage.DataFileFor(region, killDeathLogFile)
+	if err != nil {
+		return err
+	}
+	p.region = region
+	p.dungeon = dungeon
+	p.stats = stats
+	p.kdlog = kdlog
+	return nil
+}
+
+// Load reads all three files into the handler under the current region's paths.
+// A missing file is the first-run case and loads empty state (storage.Load
+// contract); a corrupt file surfaces as an error and leaves state unchanged.
+// A no-op when persistence is disabled.
+func (p *persistPaths) Load(h *handlers.AlbionHandler) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.enabled {
+		return nil
+	}
+	return p.loadLocked(h)
+}
+
+func (p *persistPaths) loadLocked(h *handlers.AlbionHandler) error {
+	// Best-effort: attempt all three files independently. Each failure is
+	// logged so the user knows exactly which file is corrupt, not just the
+	// first one. The first error is returned so callers can report a summary.
+	// Because SwitchRegion has already reset the in-memory state to empty, a
+	// corrupt file leaves that piece empty (not stale) — the new region
+	// degrades to partial data rather than mixing regions.
+	var firstErr error
+	if err := h.LoadDungeonRuns(p.dungeon); err != nil {
+		p.warnf("Warning: could not load %s: %v\n", dungeonRunsFile, err)
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	if err := h.LoadTotalStats(p.stats); err != nil {
+		p.warnf("Warning: could not load %s: %v\n", sessionStatsFile, err)
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	if err := h.LoadKillDeathLog(p.kdlog); err != nil {
+		p.warnf("Warning: could not load %s: %v\n", killDeathLogFile, err)
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// Save writes all three files from the handler under the current region's
+// paths. Each Save is atomic (tmp+rename); a failure mid-way leaves previously
+// written files intact and aborts the remainder. A no-op when persistence is
+// disabled.
+func (p *persistPaths) Save(h *handlers.AlbionHandler) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.enabled {
+		return nil
+	}
+	return p.saveLocked(h)
+}
+
+func (p *persistPaths) saveLocked(h *handlers.AlbionHandler) error {
+	if err := h.SaveDungeonRuns(p.dungeon); err != nil {
+		return err
+	}
+	if err := h.SaveTotalStats(p.stats); err != nil {
+		return err
+	}
+	return h.SaveKillDeathLog(p.kdlog)
+}
+
+// SwitchRegion transitions persistence to a new region as a single atomic
+// operation (under p.mu):
+//
+//  1. Flush the current state to the OLD region's paths (so no data is lost).
+//  2. Reset in-memory state to empty (so a corrupt new-region file cannot leak
+//     the old region's data — Load* leaves state untouched on decode error).
+//  3. Run the one-time legacy→region migration, which copies any pre-region
+//     data into the new region dir on first detection only.
+//  4. Resolve the new region's paths.
+//  5. Load the new region's state.
+//
+// A no-op when persistence is disabled or the region is unchanged.
+//
+// Concurrency note: the capture goroutine may keep updating the handler's
+// in-memory state during the switch. Events arriving between the reset (step 2)
+// and the load (step 5) are dropped. Region switches are rare (roughly one per
+// login), so this microsecond window is an acceptable tradeoff versus the
+// complexity of pausing capture.
+func (p *persistPaths) SwitchRegion(newRegion string, h *handlers.AlbionHandler) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.enabled || p.region == newRegion {
+		return nil
+	}
+
+	// 1. Flush the region we are leaving.
+	if err := p.saveLocked(h); err != nil {
+		return fmt.Errorf("flush %q before switch: %w", p.region, err)
+	}
+
+	// 2. Reset so the new region cannot inherit the old one's data on a
+	//    corrupt load.
+	h.ResetPersistedState()
+
+	// 3. One-time legacy migration. Atomically claimed via an exclusive marker
+	//    create, so it runs exactly once across the whole process lifetime:
+	//    only the first confirmed region inherits the pre-region data; later
+	//    regions start empty.
+	if err := storage.MigrateLegacyData(newRegion); err != nil {
+		// Non-fatal: a failed migration should not block region switching.
+		// The new region simply starts empty.
+		p.warnf("Warning: legacy migration to %s skipped: %v\n", newRegion, err)
+	}
+
+	// 4. Re-resolve paths for the new region.
+	if err := p.reassignLocked(newRegion); err != nil {
+		return fmt.Errorf("resolve %q: %w", newRegion, err)
+	}
+
+	// 5. Load the new region.
+	return p.loadLocked(h)
+}
+
+// serverHintOverride reads a user-provided region override from server-hint.txt
+// in the storage root. The file is a manual escape hatch for when the server IP
+// prefixes change (see serverdetect.Servers): the user writes a region name and
+// persistence pins to it, bypassing IP detection entirely.
+//
+// Accepted (case-insensitive, whitespace-trimmed) values:
+//
+//	"Americas", "America", "West"      → UserData-AMERICA
+//	"Europe", "EU"                     → UserData-EUROPE
+//	"Asia", "East"                     → UserData-ASIA
+//	"UserData-AMERICA" etc. (DirName)  → matched directly
+//
+// Returns ServerLocationUnknown (no override) if the file is absent, empty, or
+// holds an unrecognized value. A read error is treated as "no override" with a
+// warning, since the hint is best-effort.
+func serverHintOverride() serverdetect.ServerLocation {
+	root, err := storage.DataDir()
+	if err != nil {
+		return serverdetect.ServerLocationUnknown
+	}
+	data, err := os.ReadFile(filepath.Join(root, serverHintFile))
+	if err != nil {
+		if !os.IsNotExist(err) {
+			fmt.Printf("Warning: could not read %s: %v\n", serverHintFile, err)
+		}
+		return serverdetect.ServerLocationUnknown
+	}
+	loc := parseServerHint(string(data))
+	if loc == serverdetect.ServerLocationUnknown && strings.TrimSpace(string(data)) != "" {
+		fmt.Printf("Warning: unrecognized value %q in %s; expected Americas, Europe, or Asia\n",
+			strings.TrimSpace(string(data)), serverHintFile)
+	}
+	return loc
+}
+
+// parseServerHint maps a free-form hint string to a ServerLocation. Returns
+// ServerLocationUnknown for empty or unrecognized input.
+func parseServerHint(s string) serverdetect.ServerLocation {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return serverdetect.ServerLocationUnknown
+	}
+	lower := strings.ToLower(s)
+
+	// Allow the exact DirName forms ("UserData-AMERICA").
+	for _, loc := range []serverdetect.ServerLocation{
+		serverdetect.ServerLocationAmerica,
+		serverdetect.ServerLocationAsia,
+		serverdetect.ServerLocationEurope,
+	} {
+		if lower == strings.ToLower(loc.DirName()) {
+			return loc
+		}
+	}
+
+	switch lower {
+	case "americas", "america", "west", "us":
+		return serverdetect.ServerLocationAmerica
+	case "europe", "eu":
+		return serverdetect.ServerLocationEurope
+	case "asia", "east":
+		return serverdetect.ServerLocationAsia
+	}
+	return serverdetect.ServerLocationUnknown
+}
+
+// rateLimiter decides whether an action should fire now, given that it last
+// fired at some recorded time and must be spaced at least Window apart. It uses
+// a compare-and-swap on the last-fired timestamp so concurrent triggers cannot
+// stack: only the first one within a window wins.
+//
+// Used by the cluster-change save path: many zone transitions in quick
+// succession yield at most one save per Window.
+type rateLimiter struct {
+	last   atomic.Int64 // unix nanos of the last approved trigger
+	window time.Duration
+}
+
+// newRateLimiter returns a rateLimiter with the given minimum spacing. A
+// brand-new limiter (last == 0) approves the first trigger immediately.
+func newRateLimiter(window time.Duration) *rateLimiter {
+	return &rateLimiter{window: window}
+}
+
+// Allow reports whether the action may fire at now. When it returns true, the
+// limiter has also recorded now as the last fire time atomically, so concurrent
+// callers racing on the same instant see at most one winner.
+func (r *rateLimiter) Allow(now time.Time) bool {
+	nowN := now.UnixNano()
+	last := r.last.Load()
+	if nowN-last < int64(r.window) {
+		return false
+	}
+	return r.last.CompareAndSwap(last, nowN)
+}

--- a/cmd/tui/persist_test.go
+++ b/cmd/tui/persist_test.go
@@ -1,0 +1,555 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cantalupo555/albion-lens/internal/serverdetect"
+	"github.com/cantalupo555/albion-lens/pkg/events"
+	"github.com/cantalupo555/albion-lens/pkg/handlers"
+)
+
+// TestPersistPathsSwitchRegionEndToEnd verifies the full region-switch flow:
+//
+//  1. State accumulates in the legacy root and is saved there.
+//  2. First SwitchRegion migrates the legacy snapshot into the new region dir
+//     and reloads it (state preserved across the switch).
+//  3. A second SwitchRegion to a different region starts EMPTY — the migration
+//     marker prevents the original legacy data from seeding every region.
+//
+// This is the core correctness guarantee of region segregation: no
+// cross-region bleed.
+func TestPersistPathsSwitchRegionEndToEnd(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", root)
+
+	h := handlers.NewAlbionHandler()
+	h.SetLocalPlayer("Hero")
+
+	// Seed in-memory state with a fame event so there is something to persist.
+	seedFame(t, h, 1234)
+
+	paths := newPersistPaths("", nil) // legacy / Unknown region
+	if !paths.Enabled() {
+		t.Fatal("persistence disabled; expected enabled")
+	}
+	if paths.Region() != "" {
+		t.Fatalf("initial region = %q, want empty (legacy)", paths.Region())
+	}
+
+	// Save to legacy root.
+	if err := paths.Save(h); err != nil {
+		t.Fatalf("initial save: %v", err)
+	}
+	legacyStats := filepath.Join(root, "albion-lens", "session-stats.json")
+	if _, err := os.Stat(legacyStats); err != nil {
+		t.Fatalf("legacy stats file not created: %v", err)
+	}
+
+	// Switch to Americas. The legacy data should migrate into UserData-AMERICA
+	// and the in-memory fame should be preserved (reloaded from the new dir).
+	if err := paths.SwitchRegion("UserData-AMERICA", h); err != nil {
+		t.Fatalf("switch to Americas: %v", err)
+	}
+	if paths.Region() != "UserData-AMERICA" {
+		t.Fatalf("region after switch = %q, want UserData-AMERICA", paths.Region())
+	}
+	if got := h.GetTotalFame(); got != 1234 {
+		t.Errorf("fame after migrate-and-reload = %d, want 1234 (preserved)", got)
+	}
+	if _, err := os.Stat(filepath.Join(root, "albion-lens", "UserData-AMERICA", "session-stats.json")); err != nil {
+		t.Errorf("Americas stats file missing after migration: %v", err)
+	}
+
+	// Switch to Europe. Europe must start EMPTY: the migration marker should
+	// prevent the original legacy snapshot from being copied again.
+	if err := paths.SwitchRegion("UserData-EUROPE", h); err != nil {
+		t.Fatalf("switch to Europe: %v", err)
+	}
+	if got := h.GetTotalFame(); got != 0 {
+		t.Errorf("Europe fame = %d, want 0 (region starts empty, no bleed)", got)
+	}
+}
+
+// TestPersistPathsSwitchToSameRegionIsNoOp confirms switching to the current
+// region does not flush/reset/load (which would drop in-flight state).
+func TestPersistPathsSwitchToSameRegionIsNoOp(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	h := handlers.NewAlbionHandler()
+
+	paths := newPersistPaths("UserData-AMERICA", nil)
+	if err := paths.Load(h); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// Accumulate state during the session (after the initial load).
+	seedFame(t, h, 500)
+
+	// Switch to the same region: no-op, fame preserved.
+	if err := paths.SwitchRegion("UserData-AMERICA", h); err != nil {
+		t.Fatalf("switch same: %v", err)
+	}
+	if got := h.GetTotalFame(); got != 500 {
+		t.Errorf("fame after same-region switch = %d, want 500 (unchanged)", got)
+	}
+}
+
+// TestPersistPathsLoadRoundTrip verifies the three files survive save+load and
+// that a fresh handler hydrates from them.
+func TestPersistPathsLoadRoundTrip(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	h := handlers.NewAlbionHandler()
+	h.SetLocalPlayer("Hero")
+	seedFame(t, h, 9000)
+
+	paths := newPersistPaths("UserData-ASIA", nil)
+	if err := paths.Save(h); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Fresh handler + paths: load should restore the persisted fame.
+	fresh := handlers.NewAlbionHandler()
+	paths2 := newPersistPaths("UserData-ASIA", nil)
+	if err := paths2.Load(fresh); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got := fresh.GetTotalFame(); got != 9000 {
+		t.Errorf("restored fame = %d, want 9000", got)
+	}
+}
+
+// TestPersistPathsDisabledOnBadRoot confirms a bad data dir disables
+// persistence gracefully (operations become no-ops rather than panicking).
+func TestPersistPathsDisabledOnBadRoot(t *testing.T) {
+	// An unset HOME and XDG_DATA_HOME makes path resolution fail.
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("HOME", "")
+
+	paths := newPersistPaths("", nil)
+	if paths.Enabled() {
+		t.Fatal("expected persistence disabled when HOME and XDG_DATA_HOME unset")
+	}
+	// All operations must be safe no-ops.
+	h := handlers.NewAlbionHandler()
+	if err := paths.Load(h); err != nil {
+		t.Errorf("Load on disabled paths returned err: %v", err)
+	}
+	if err := paths.Save(h); err != nil {
+		t.Errorf("Save on disabled paths returned err: %v", err)
+	}
+	if err := paths.SwitchRegion("UserData-AMERICA", h); err != nil {
+		t.Errorf("SwitchRegion on disabled paths returned err: %v", err)
+	}
+}
+
+func TestParseServerHint(t *testing.T) {
+	cases := []struct {
+		in   string
+		want serverdetect.ServerLocation
+	}{
+		{"", serverdetect.ServerLocationUnknown},
+		{"   ", serverdetect.ServerLocationUnknown},
+		{"nonsense", serverdetect.ServerLocationUnknown},
+		{"Americas", serverdetect.ServerLocationAmerica},
+		{"AMERICA", serverdetect.ServerLocationAmerica},
+		{" america ", serverdetect.ServerLocationAmerica},
+		{"west", serverdetect.ServerLocationAmerica},
+		{"US", serverdetect.ServerLocationAmerica},
+		{"Europe", serverdetect.ServerLocationEurope},
+		{"eu", serverdetect.ServerLocationEurope},
+		{"Asia", serverdetect.ServerLocationAsia},
+		{"east", serverdetect.ServerLocationAsia},
+		{"UserData-AMERICA", serverdetect.ServerLocationAmerica},
+		{"userdata-europe", serverdetect.ServerLocationEurope},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := parseServerHint(tc.in); got != tc.want {
+				t.Errorf("parseServerHint(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPersistPathsSwitchRegionCorruptFileNoBleed is the core correctness
+// guarantee of region segregation: when the new region's stats file is corrupt,
+// the switch must NOT leak the old region's data into the new one. Reset must
+// run before the load, so a corrupt load (which leaves state untouched) finds
+// an already-empty handler rather than the previous region's counters.
+//
+// It also covers the totalFame dedup baseline reset: a fresh fame event in the
+// new region must be accepted even though the old region saw a higher total.
+func TestPersistPathsSwitchRegionCorruptFileNoBleed(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", root)
+
+	h := handlers.NewAlbionHandler()
+	h.SetLocalPlayer("Hero")
+	seedFame(t, h, 1234)
+
+	paths := newPersistPaths("", nil)
+	if err := paths.Save(h); err != nil {
+		t.Fatalf("save legacy: %v", err)
+	}
+
+	// Pre-seed the Americas region dir with a corrupt session-stats.json so
+	// the switch's load fails on that file. The dungeon-runs and kd-log files
+	// are absent, so they load as empty.
+	americasDir := filepath.Join(root, "albion-lens", "UserData-AMERICA")
+	if err := os.MkdirAll(americasDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(americasDir, "session-stats.json"),
+		[]byte("{not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The switch loads the corrupt file, which fails — but the reset already
+	// cleared the old region's fame, so the new region starts empty (no bleed).
+	if err := paths.SwitchRegion("UserData-AMERICA", h); err == nil {
+		t.Error("SwitchRegion with corrupt stats file: expected error, got nil")
+	}
+	if got := h.GetTotalFame(); got != 0 {
+		t.Errorf("after switch into corrupt region, fame = %d, want 0 (no bleed from old region)", got)
+	}
+
+	// The totalFame dedup baseline must be reset, so a fresh fame event in the
+	// new region is accepted (not rejected by the "total must not decrease"
+	// guard). Seed 500 fame: it must land.
+	seedFame(t, h, 500)
+	if got := h.GetTotalFame(); got != 500 {
+		t.Errorf("post-switch fame event rejected: got %d, want 500 (totalFame not reset)", got)
+	}
+}
+
+// TestResetPersistedStateClearsAll directly verifies the handler zeros the
+// persisted surfaces, since the SwitchRegion integration tests only check fame.
+func TestResetPersistedStateClearsAll(t *testing.T) {
+	h := handlers.NewAlbionHandler()
+	h.SetLocalPlayer("Hero")
+	seedFame(t, h, 1000)
+
+	// Pre-reset: fame and the daily bucket are non-zero.
+	if h.GetTotalFame() != 1000 {
+		t.Fatalf("seed: fame = %d, want 1000", h.GetTotalFame())
+	}
+
+	h.ResetPersistedState()
+
+	// Post-reset: every cumulative counter is zero.
+	checks := []struct {
+		name string
+		got  int64
+	}{
+		{"fame", h.GetTotalFame()},
+		{"silver", h.GetTotalSilver()},
+		{"respec", h.GetTotalRespec()},
+	}
+	for _, tc := range checks {
+		if tc.got != 0 {
+			t.Errorf("after reset, %s = %d, want 0", tc.name, tc.got)
+		}
+	}
+	for _, tc := range []struct {
+		name string
+		got  int
+	}{
+		{"kills", h.GetTotalKills()},
+		{"deaths", h.GetTotalDeaths()},
+		{"loot", h.GetTotalLoot()},
+	} {
+		if tc.got != 0 {
+			t.Errorf("after reset, %s = %d, want 0", tc.name, tc.got)
+		}
+	}
+
+	// The daily/hourly buckets must be empty too.
+	snap := h.TotalSnapshot()
+	if len(snap.Daily) != 0 || len(snap.Hourly) != 0 {
+		t.Errorf("after reset, daily/hourly buckets not empty: daily=%d hourly=%d",
+			len(snap.Daily), len(snap.Hourly))
+	}
+}
+
+// TestServerHintOverrideFromFile confirms the hint is read from server-hint.txt
+// in the storage root, and absent returns Unknown (no override).
+func TestServerHintOverrideFromFile(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", root)
+
+	if got := serverHintOverride(); got != serverdetect.ServerLocationUnknown {
+		t.Errorf("hint with no file = %v, want Unknown", got)
+	}
+
+	hintPath := filepath.Join(root, "albion-lens", serverHintFile)
+	if err := os.MkdirAll(filepath.Dir(hintPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(hintPath, []byte("Europe"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := serverHintOverride(); got != serverdetect.ServerLocationEurope {
+		t.Errorf("hint from file = %v, want Europe", got)
+	}
+
+	// Unrecognized value must return Unknown (not match a wrong region).
+	if err := os.WriteFile(hintPath, []byte("Europ"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := serverHintOverride(); got != serverdetect.ServerLocationUnknown {
+		t.Errorf("unrecognized hint = %v, want Unknown", got)
+	}
+}
+
+// TestRateLimiterFirstCallAllowed confirms a fresh limiter approves the first
+// trigger immediately (no artificial startup delay). The timestamp must be far
+// past epoch since last=0 means "never"; in production time.Now() always is.
+func TestRateLimiterFirstCallAllowed(t *testing.T) {
+	r := newRateLimiter(time.Hour)
+	if !r.Allow(time.Unix(1_000_000_000, 0)) {
+		t.Error("first Allow() = false, want true")
+	}
+}
+
+// TestRateLimiterCoalescesWithinWindow verifies rapid triggers are coalesced:
+// only the first within a window wins; the next is allowed only after window.
+func TestRateLimiterCoalescesWithinWindow(t *testing.T) {
+	r := newRateLimiter(15 * time.Minute)
+	start := time.Unix(1_000_000, 0)
+
+	if !r.Allow(start) {
+		t.Fatal("first trigger denied")
+	}
+	// Within the window: denied.
+	if r.Allow(start.Add(1 * time.Minute)) {
+		t.Error("trigger 1min after first allowed; want denied (within window)")
+	}
+	if r.Allow(start.Add(14 * time.Minute)) {
+		t.Error("trigger 14min after first allowed; want denied (within window)")
+	}
+	// Exactly at window boundary: allowed.
+	if !r.Allow(start.Add(15 * time.Minute)) {
+		t.Error("trigger at 15min boundary denied; want allowed")
+	}
+	// Immediately after: denied again (new window started).
+	if r.Allow(start.Add(15*time.Minute + 1*time.Second)) {
+		t.Error("trigger 1s after re-fire allowed; want denied")
+	}
+}
+
+// TestRateLimiterConcurrentOnlyOneWins confirms that many concurrent triggers
+// at the same instant produce exactly one winner (CAS prevents stacking).
+func TestRateLimiterConcurrentOnlyOneWins(t *testing.T) {
+	r := newRateLimiter(time.Hour)
+	now := time.Unix(5_000_000, 0)
+
+	const n = 50
+	wins := make(chan bool, n)
+	for i := 0; i < n; i++ {
+		go func() { wins <- r.Allow(now) }()
+	}
+	count := 0
+	for i := 0; i < n; i++ {
+		if <-wins {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("concurrent Allow at one instant: %d winners, want 1", count)
+	}
+}
+
+// TestWatchServerChangesSwitchesOnKnownRegion verifies watchServerChanges
+// re-points persistence when a known region arrives, ignores Unknown
+// transitions, and exits cleanly when the channel closes.
+func TestWatchServerChangesSwitchesOnKnownRegion(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	h := handlers.NewAlbionHandler()
+	paths := newPersistPaths("", nil)
+
+	changes := make(chan serverdetect.ChangeEvent, 4)
+	done := make(chan struct{})
+	go func() {
+		watchServerChanges(changes, h, paths, nil)
+		close(done)
+	}()
+
+	// Unknown transition must be ignored (paths stay on legacy).
+	changes <- serverdetect.ChangeEvent{Current: serverdetect.Unknown()}
+	// Known region: paths must switch.
+	changes <- serverdetect.ChangeEvent{Current: serverdetect.MatchByIPString("5.188.125.1")}
+	close(changes)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watchServerChanges did not exit after channel close")
+	}
+
+	if got := paths.Region(); got != "UserData-AMERICA" {
+		t.Errorf("region after switch = %q, want UserData-AMERICA", got)
+	}
+}
+
+// TestWatchServerChangesNilHandlerNoPanic confirms a nil handler does not
+// crash the watcher (the guard skips the transition).
+func TestWatchServerChangesNilHandlerNoPanic(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	paths := newPersistPaths("", nil)
+
+	changes := make(chan serverdetect.ChangeEvent, 1)
+	done := make(chan struct{})
+	go func() {
+		watchServerChanges(changes, nil, paths, nil) // nil handler
+		close(done)
+	}()
+
+	changes <- serverdetect.ChangeEvent{Current: serverdetect.MatchByIPString("5.188.125.1")}
+	close(changes)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watcher did not exit; nil-handler guard may have panicked")
+	}
+	// Region unchanged: nil handler means SwitchRegion was never called.
+	if got := paths.Region(); got != "" {
+		t.Errorf("region changed despite nil handler: %q", got)
+	}
+}
+
+// TestPersistPathsSwitchRegionMigrationFailureIsNonFatal verifies that a
+// migration error during SwitchRegion does not block the region switch: paths
+// are reassigned, the handler state is reset, and the new region loads (even
+// if empty). Migration failure is triggered by placing an unreadable .json
+// file in the legacy root that copyFile cannot open.
+func TestPersistPathsSwitchRegionMigrationFailureIsNonFatal(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", root)
+
+	h := handlers.NewAlbionHandler()
+	h.SetLocalPlayer("Hero")
+	seedFame(t, h, 5000)
+
+	paths := newPersistPaths("", nil)
+	if err := paths.Save(h); err != nil {
+		t.Fatalf("initial save: %v", err)
+	}
+
+	// Add an unreadable .json file in the legacy root so migration's copyFile
+	// fails on it. Using a separate file (not one of the three persisted files)
+	// ensures saveLocked's atomic rename doesn't reset its permissions.
+	badFile := filepath.Join(root, "albion-lens", "zzz-corrupt.json")
+	if err := os.WriteFile(badFile, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write bad file: %v", err)
+	}
+	if err := os.Chmod(badFile, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(badFile, 0o644) })
+
+	// SwitchRegion must not return an error: migration failure is non-fatal.
+	// The unreadable file sorts after the persisted files, so migration copies
+	// them first, then fails on zzz-corrupt.json and returns an error — but
+	// SwitchRegion logs the warning and continues.
+	err := paths.SwitchRegion("UserData-EUROPE", h)
+	if err != nil {
+		t.Fatalf("SwitchRegion returned error despite non-fatal migration: %v", err)
+	}
+
+	// Region must have switched.
+	if got := paths.Region(); got != "UserData-EUROPE" {
+		t.Fatalf("region = %q, want UserData-EUROPE", got)
+	}
+}
+
+// TestPersistPathsLoadBestEffortMultipleCorrupt verifies that loadLocked
+// attempts all three files independently: when multiple are corrupt, the load
+// still returns an error but does not panic or abort before trying each file.
+func TestPersistPathsLoadBestEffortMultipleCorrupt(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", root)
+
+	h := handlers.NewAlbionHandler()
+	seedFame(t, h, 999)
+
+	paths := newPersistPaths("", nil)
+	if err := paths.Save(h); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	// Corrupt two of the three files.
+	dataDir := filepath.Join(root, "albion-lens")
+	if err := os.WriteFile(filepath.Join(dataDir, sessionStatsFile), []byte("{bad"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, killDeathLogFile), []byte("{bad"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load must return an error (at least one file corrupt) but must not panic.
+	err := paths.Load(h)
+	if err == nil {
+		t.Error("expected error from load with corrupt files, got nil")
+	}
+}
+
+// TestPersistPathsConcurrentSaveAndSwitch verifies the persistPaths mutex
+// serializes Save and SwitchRegion so they cannot interleave and corrupt
+// state. Runs under -race; any data race or panic fails the test.
+func TestPersistPathsConcurrentSaveAndSwitch(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	h := handlers.NewAlbionHandler()
+	paths := newPersistPaths("", nil)
+
+	regions := []string{"UserData-AMERICA", "UserData-EUROPE", "UserData-ASIA"}
+	stop := make(chan struct{})
+	var saverWg, switcherWg sync.WaitGroup
+
+	// Saver: hammer Save until stopped.
+	saverWg.Add(1)
+	go func() {
+		defer saverWg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = paths.Save(h)
+			}
+		}
+	}()
+
+	// Switcher: cycle regions a bounded number of times.
+	switcherWg.Add(1)
+	go func() {
+		defer switcherWg.Done()
+		for i := 0; i < 200; i++ {
+			_ = paths.SwitchRegion(regions[i%len(regions)], h)
+		}
+	}()
+
+	switcherWg.Wait() // bounded work finishes
+	close(stop)       // release the saver
+	saverWg.Wait()
+	// One final serialized save must succeed (the mutex is healthy).
+	_ = paths.Save(h)
+}
+
+// seedFame feeds a fame event that increments the cumulative total by n, used
+// to give the handler non-zero persisted state for round-trip testing.
+func seedFame(t *testing.T, h *handlers.AlbionHandler, n int64) {
+	t.Helper()
+	h.OnEvent(0, map[byte]interface{}{
+		1:                     int64(50_000_000_000), // total fame (FixPoint)
+		2:                     n * 10_000,            // gained n (FixPoint = /10000)
+		events.ParamEventCode: int16(events.EventUpdateFame),
+	})
+	if got := h.GetTotalFame(); got != n {
+		t.Fatalf("seedFame: total fame = %d, want %d (seed failed)", got, n)
+	}
+}

--- a/internal/serverdetect/detector.go
+++ b/internal/serverdetect/detector.go
@@ -1,0 +1,188 @@
+package serverdetect
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+// DefaultStabilityDuration is how long a candidate region must be observed
+// continuously before it is promoted to the current server. Mirrors the
+// reference's 5-second ServerDetectionStabilityDuration. It prevents a single
+// stray packet (e.g. a brief reroute) from flipping the active region and
+// thrashing the on-disk state.
+const DefaultStabilityDuration = 5 * time.Second
+
+// ChangeEvent describes a transition of the detected server. Previous may be
+// Unknown (first detection or after a reset); Current may be Unknown (the
+// detector reverted to "no confident region" after seeing a different one).
+type ChangeEvent struct {
+	Previous ServerInfo
+	Current  ServerInfo
+}
+
+// Detector tracks the active Albion server region from observed Photon server
+// IPs. It is safe for concurrent use: DetectFromIP is called from the capture
+// hot path (one goroutine), while Current/LastPacketReceived may be polled from
+// others.
+//
+// State machine (mirrors AlbionServerDetectionService):
+//
+//   - A new region becomes Current only after being observed as a stable
+//     candidate for StabilityDuration (default 5s).
+//   - When a packet from a *different* known region arrives while a region is
+//     already current, the detector first resets Current to Unknown (emitting a
+//     change event) and then begins observing the new candidate. This avoids
+//     attributing data to the old region while the new one is unconfirmed.
+type Detector struct {
+	// nowFunc supplies "current" time. Defaults to time.Now; overridable for
+	// deterministic tests.
+	nowFunc func() time.Time
+
+	stability time.Duration
+
+	mu                 sync.Mutex
+	current            ServerInfo
+	candidate          ServerInfo
+	candidateFirstSeen time.Time
+	lastPacketRecv     time.Time
+
+	// onChange is invoked outside the detector's mutex (after releasing it) so
+	// handlers may safely re-enter Current() without deadlocking. Nil = no-op.
+	onChange func(ChangeEvent)
+}
+
+// Option configures a Detector at construction.
+type Option func(*Detector)
+
+// WithNowFunc overrides the time source (for tests).
+func WithNowFunc(fn func() time.Time) Option {
+	return func(d *Detector) {
+		if fn != nil {
+			d.nowFunc = fn
+		}
+	}
+}
+
+// WithStability overrides the candidate stability window. A shorter duration
+// flips regions faster (useful in tests); a longer one is more conservative.
+func WithStability(dur time.Duration) Option {
+	return func(d *Detector) { d.stability = dur }
+}
+
+// WithOnChange registers a callback invoked after every confirmed transition.
+// The callback runs on the same goroutine as DetectFromIP (the capture path),
+// so it must be non-blocking; persist/IO work should be dispatched elsewhere.
+func WithOnChange(fn func(ChangeEvent)) Option {
+	return func(d *Detector) { d.onChange = fn }
+}
+
+// NewDetector constructs a Detector with the given options applied.
+func NewDetector(opts ...Option) *Detector {
+	d := &Detector{
+		nowFunc:   time.Now,
+		stability: DefaultStabilityDuration,
+		current:   unknown,
+		candidate: unknown,
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
+}
+
+// Current returns the currently active server (Unknown if none is confirmed).
+func (d *Detector) Current() ServerInfo {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.current
+}
+
+// LastPacketReceived returns the time of the last packet that matched a known
+// region. Zero if no such packet has ever been observed.
+func (d *Detector) LastPacketReceived() time.Time {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.lastPacketRecv
+}
+
+// DetectFromIP feeds one observed server IP to the detector. The IP is the
+// Photon server's address — for incoming packets (server→client) this is the
+// source IP, for outgoing packets (client→server) it is the destination IP.
+// Callers should pass whichever endpoint belongs to the server.
+//
+// Non-matching IPs (Unknown region, nil, IPv6, or unrecognized prefix) are
+// ignored entirely: they carry no region signal and must not perturb the
+// current state.
+func (d *Detector) DetectFromIP(ip net.IP) {
+	detected := MatchByIP(ip)
+	if detected.Location == ServerLocationUnknown {
+		return
+	}
+
+	var event ChangeEvent
+	hasEvent := false
+
+	now := d.nowFunc()
+
+	func() {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+
+		d.lastPacketRecv = now
+
+		// Already confident about this region: reset any in-flight candidate
+		// (a previous, unconfirmed different region) and stay put.
+		if d.current.Location == detected.Location {
+			d.candidate = unknown
+			d.candidateFirstSeen = time.Time{}
+			return
+		}
+
+		if d.current.Location != ServerLocationUnknown {
+			// We were confident about a *different* region. Drop confidence
+			// immediately and begin observing the new candidate.
+			event = ChangeEvent{Previous: d.current, Current: unknown}
+			hasEvent = true
+			d.current = unknown
+			d.candidate = detected
+			d.candidateFirstSeen = now
+			return
+		}
+
+		// Current is Unknown: try to promote a stable candidate.
+		if promoted, ok := d.tryPromoteStableCandidate(detected, now); ok {
+			event = promoted
+			hasEvent = true
+		}
+	}()
+
+	if hasEvent && d.onChange != nil {
+		d.onChange(event)
+	}
+}
+
+// tryPromoteStableCandidate promotes the candidate to current once it has been
+// observed for at least StabilityDuration. The caller MUST hold d.mu.
+//
+// If the incoming region differs from the pending candidate, the candidate is
+// replaced and the stability clock restarts (returns ok=false). If the same
+// candidate has been observed long enough, it is promoted and a change event
+// is returned (ok=true).
+func (d *Detector) tryPromoteStableCandidate(detected ServerInfo, now time.Time) (ChangeEvent, bool) {
+	if d.candidate.Location != detected.Location {
+		d.candidate = detected
+		d.candidateFirstSeen = now
+		return ChangeEvent{}, false
+	}
+
+	if now.Sub(d.candidateFirstSeen) < d.stability {
+		return ChangeEvent{}, false
+	}
+
+	previous := d.current
+	d.current = detected
+	d.candidate = unknown
+	d.candidateFirstSeen = time.Time{}
+	return ChangeEvent{Previous: previous, Current: detected}, true
+}

--- a/internal/serverdetect/detector_test.go
+++ b/internal/serverdetect/detector_test.go
@@ -1,0 +1,230 @@
+package serverdetect
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeClock is a controllable time source for deterministic detector tests.
+type fakeClock struct {
+	t atomic.Int64 // unix nanos
+}
+
+func newFakeClock(start time.Time) *fakeClock {
+	f := &fakeClock{}
+	f.t.Store(start.UnixNano())
+	return f
+}
+
+func (f *fakeClock) now() time.Time {
+	return time.Unix(0, f.t.Load())
+}
+
+func (f *fakeClock) advance(d time.Duration) {
+	f.t.Add(d.Nanoseconds())
+}
+
+func TestDetectorInitial(t *testing.T) {
+	d := NewDetector()
+	if got := d.Current().Location; got != ServerLocationUnknown {
+		t.Errorf("Current() before any detection = %v, want Unknown", got)
+	}
+	if got := d.LastPacketReceived(); !got.IsZero() {
+		t.Errorf("LastPacketReceived before any detection = %v, want zero", got)
+	}
+}
+
+func TestDetectorIgnoresUnknownIP(t *testing.T) {
+	var called int32
+	d := NewDetector(WithOnChange(func(ChangeEvent) { atomic.AddInt32(&called, 1) }))
+	// Non-matching / invalid IPs must not change state or emit events.
+	d.DetectFromIP(net.ParseIP("8.8.8.8"))
+	d.DetectFromIP(net.ParseIP("not-an-ip")) // ParseIP returns nil → ignored
+	d.DetectFromIP(nil)
+	d.DetectFromIP(net.ParseIP("2001:db8::1")) // IPv6 → ignored
+
+	if d.Current().Location != ServerLocationUnknown {
+		t.Errorf("state changed after unknown IPs: %v", d.Current().Location)
+	}
+	if got := d.LastPacketReceived(); !got.IsZero() {
+		t.Errorf("LastPacketReceived updated by unknown IPs: %v", got)
+	}
+	if atomic.LoadInt32(&called) != 0 {
+		t.Errorf("onChange fired for unknown IPs: %d calls", called)
+	}
+}
+
+func TestDetectorPromotesAfterStability(t *testing.T) {
+	clk := newFakeClock(time.Unix(1_700_000_000, 0))
+	var events []ChangeEvent
+	d := NewDetector(
+		WithNowFunc(clk.now),
+		WithStability(5*time.Second),
+		WithOnChange(func(e ChangeEvent) { events = append(events, e) }),
+	)
+
+	// First packet from Americas: becomes candidate, NOT current yet.
+	d.DetectFromIP(net.IPv4(5, 188, 125, 10))
+	if d.Current().Location != ServerLocationUnknown {
+		t.Fatalf("promoted before stability window: %v", d.Current().Location)
+	}
+	if len(events) != 0 {
+		t.Fatalf("emitted %d events before promotion, want 0", len(events))
+	}
+
+	// Within the window: still a candidate, no promotion.
+	clk.advance(4 * time.Second)
+	d.DetectFromIP(net.IPv4(5, 188, 125, 11))
+	if d.Current().Location != ServerLocationUnknown {
+		t.Fatalf("promoted before stability elapsed: %v", d.Current().Location)
+	}
+
+	// After stability window: promoted.
+	clk.advance(2 * time.Second) // total 6s >= 5s
+	d.DetectFromIP(net.IPv4(5, 188, 125, 12))
+	if got := d.Current().Location; got != ServerLocationAmerica {
+		t.Errorf("after stability, Current = %v, want Americas", got)
+	}
+	if len(events) != 1 || events[0].Previous.Location != ServerLocationUnknown ||
+		events[0].Current.Location != ServerLocationAmerica {
+		t.Errorf("promotion event = %+v, want prev=Unknown cur=Americas", events[0])
+	}
+}
+
+func TestDetectorNoPromotionForUnstableCandidate(t *testing.T) {
+	// A candidate seen only briefly (then signal disappears) must never promote.
+	clk := newFakeClock(time.Unix(1_700_000_000, 0))
+	d := NewDetector(WithNowFunc(clk.now), WithStability(5*time.Second))
+
+	d.DetectFromIP(net.IPv4(5, 188, 125, 10)) // candidate Americas
+	clk.advance(2 * time.Second)
+	// No more Americas packets. Even after a long time, Current stays Unknown
+	// because no packet re-confirmed the candidate past the window.
+	clk.advance(1 * time.Hour)
+	if d.Current().Location != ServerLocationUnknown {
+		t.Errorf("promoted without re-confirmation past window: %v", d.Current().Location)
+	}
+}
+
+func TestDetectorDifferentCandidateReplacesAndRestartsClock(t *testing.T) {
+	clk := newFakeClock(time.Unix(1_700_000_000, 0))
+	d := NewDetector(WithNowFunc(clk.now), WithStability(5*time.Second))
+
+	// Start observing Americas.
+	d.DetectFromIP(net.IPv4(5, 188, 125, 10))
+	clk.advance(3 * time.Second)
+
+	// Switch candidate to Europe mid-window: candidate replaced, clock restarts.
+	d.DetectFromIP(net.IPv4(193, 169, 238, 5))
+	clk.advance(3 * time.Second) // 3s on Europe, still < 5s
+	d.DetectFromIP(net.IPv4(193, 169, 238, 6))
+	if d.Current().Location != ServerLocationUnknown {
+		t.Errorf("promoted Europe before stability: %v", d.Current().Location)
+	}
+
+	// Push past the window for Europe.
+	clk.advance(3 * time.Second) // total 6s on Europe
+	d.DetectFromIP(net.IPv4(193, 169, 238, 7))
+	if got := d.Current().Location; got != ServerLocationEurope {
+		t.Errorf("after Europe stability, Current = %v, want Europe", got)
+	}
+}
+
+func TestDetectorSameRegionResetsCandidate(t *testing.T) {
+	// Once a region is Current, a stray packet from another region that does
+	// NOT confirm should not cause the same-region current to be lost.
+	// (Confirmed-different-region reset is covered separately.)
+	clk := newFakeClock(time.Unix(1_700_000_000, 0))
+	d := NewDetector(WithNowFunc(clk.now), WithStability(5*time.Second))
+
+	// Promote Americas.
+	stabilize(d, clk, net.IPv4(5, 188, 125, 10), 5*time.Second)
+	if d.Current().Location != ServerLocationAmerica {
+		t.Fatalf("setup: Americas not current, got %v", d.Current().Location)
+	}
+
+	// More Americas packets while already current: no-op, candidate cleared.
+	d.DetectFromIP(net.IPv4(5, 188, 125, 99))
+	if got := d.Current().Location; got != ServerLocationAmerica {
+		t.Errorf("same-region re-detection lost current: %v", got)
+	}
+}
+
+func TestDetectorResetToUnknownOnRegionChange(t *testing.T) {
+	clk := newFakeClock(time.Unix(1_700_000_000, 0))
+	var events []ChangeEvent
+	d := NewDetector(
+		WithNowFunc(clk.now),
+		WithStability(5*time.Second),
+		WithOnChange(func(e ChangeEvent) { events = append(events, e) }),
+	)
+
+	// Establish Americas.
+	stabilize(d, clk, net.IPv4(5, 188, 125, 10), 5*time.Second)
+	events = events[:0] // drop the initial promotion event
+
+	// Packet from Europe arrives while Americas is current:
+	// detector must immediately reset to Unknown (event 1), then promote Europe
+	// only after stability (event 2).
+	d.DetectFromIP(net.IPv4(193, 169, 238, 5))
+	if d.Current().Location != ServerLocationUnknown {
+		t.Fatalf("after first Europe packet, Current = %v, want Unknown (reset)", d.Current().Location)
+	}
+	if len(events) != 1 || events[0].Previous.Location != ServerLocationAmerica ||
+		events[0].Current.Location != ServerLocationUnknown {
+		t.Errorf("reset event = %+v, want prev=Americas cur=Unknown", events[0])
+	}
+
+	// Confirm Europe past the window.
+	clk.advance(6 * time.Second)
+	d.DetectFromIP(net.IPv4(193, 169, 238, 6))
+	if got := d.Current().Location; got != ServerLocationEurope {
+		t.Errorf("after Europe stability, Current = %v, want Europe", got)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected promotion event after reset, got %d total events", len(events))
+	}
+	if events[1].Previous.Location != ServerLocationUnknown ||
+		events[1].Current.Location != ServerLocationEurope {
+		t.Errorf("promotion event = %+v, want prev=Unknown cur=Europe", events[1])
+	}
+}
+
+func TestDetectorOnChangeInvokedOutsideLock(t *testing.T) {
+	// onChange must be able to re-enter Current() without deadlocking.
+	clk := newFakeClock(time.Unix(1_700_000_000, 0))
+	var d *Detector
+	d = NewDetector(
+		WithNowFunc(clk.now),
+		WithStability(5*time.Second),
+		WithOnChange(func(e ChangeEvent) {
+			// Re-entrant read during callback dispatch.
+			_ = d.Current()
+		}),
+	)
+	stabilize(d, clk, net.IPv4(5, 188, 125, 10), 5*time.Second)
+	// If the callback held the lock, this test would hang/timeout under -race.
+}
+
+func TestDetectorLastPacketUpdatedOnKnownMatch(t *testing.T) {
+	clk := newFakeClock(time.Unix(1_700_000_000, 0))
+	d := NewDetector(WithNowFunc(clk.now), WithStability(5*time.Second))
+	if got := d.LastPacketReceived(); !got.IsZero() {
+		t.Fatalf("initial LastPacketReceived = %v, want zero", got)
+	}
+	d.DetectFromIP(net.IPv4(5, 188, 125, 10))
+	want := clk.now()
+	if got := d.LastPacketReceived(); !got.Equal(want) {
+		t.Errorf("LastPacketReceived = %v, want %v", got, want)
+	}
+}
+
+// stabilize feeds the same server IP repeatedly, advancing the clock past the
+// stability window, to drive the detector to a confirmed Current state.
+func stabilize(d *Detector, clk *fakeClock, ip net.IP, window time.Duration) {
+	d.DetectFromIP(ip)
+	clk.advance(window + time.Second)
+	d.DetectFromIP(ip)
+}

--- a/internal/serverdetect/registry.go
+++ b/internal/serverdetect/registry.go
@@ -1,0 +1,88 @@
+package serverdetect
+
+import (
+	"net"
+	"strings"
+)
+
+// ServerInfo describes a known Albion Online game server. It pairs a region
+// with the IPv4 prefix the server's Photon endpoints publish. Mirrors the
+// reference's AlbionServerInfo.
+type ServerInfo struct {
+	Location ServerLocation
+	// Name is the human-readable region label (e.g. "Americas").
+	Name string
+	// IpPrefix is the dotted-quad prefix the region's Photon servers share
+	// (e.g. "5.188.125"). Matched as a string prefix against an IP's textual
+	// form, exactly like the reference's sourceIp.StartsWith(prefix).
+	IpPrefix string
+}
+
+// unknown is the zero-match result returned when an IP does not map to any
+// known region (including when the input is nil or not an IPv4 address).
+var unknown = ServerInfo{}
+
+// servers is the authoritative list of known Albion Photon server regions.
+// The prefixes are maintained by the AlbionDataProject and used by the
+// reference StatisticsAnalysisTool. If a region's IPs change, update them here.
+//
+// To refresh: https://github.com/ao-data/albiondata  (server IP map).
+var servers = []ServerInfo{
+	{ServerLocationAmerica, "Americas", "5.188.125"},
+	{ServerLocationAsia, "Asia", "5.45.187"},
+	{ServerLocationEurope, "Europe", "193.169.238"},
+}
+
+// Unknown returns the sentinel "no match" ServerInfo. It is the zero value and
+// carries ServerLocationUnknown.
+func Unknown() ServerInfo { return unknown }
+
+// Servers returns the known server list (a copy of the backing slice header) so
+// callers can enumerate regions for migrations or diagnostics. The returned
+// slice must not be mutated.
+func Servers() []ServerInfo {
+	out := make([]ServerInfo, len(servers))
+	copy(out, servers)
+	return out
+}
+
+// MatchByIP resolves a server IP to its ServerInfo. Returns Unknown if ip is
+// nil, is not a 4-byte / 16-byte IPv4 representation, or does not start with
+// any known prefix.
+//
+// The match is a string prefix over the canonical dotted-quad form (e.g.
+// "5.188.125.42" starts with "5.188.125"), matching the reference's
+// AlbionServerRegistry.GetBySourceIp.
+func MatchByIP(ip net.IP) ServerInfo {
+	if ip == nil {
+		return unknown
+	}
+	// Normalize: To4 returns a 4-byte IPv4 if the input is one (or a v4-in-v6
+	// form), nil otherwise. We deliberately ignore IPv6 endpoints since the
+	// known prefixes are IPv4 only.
+	v4 := ip.To4()
+	if v4 == nil {
+		return unknown
+	}
+	s := v4.String()
+	for _, srv := range servers {
+		if strings.HasPrefix(s, srv.IpPrefix) {
+			return srv
+		}
+	}
+	return unknown
+}
+
+// MatchByIPString is a convenience over MatchByIP that accepts a textual IP.
+// Invalid addresses yield Unknown rather than an error, since detection is
+// best-effort: a malformed source IP simply means "no signal this packet".
+func MatchByIPString(s string) ServerInfo {
+	if s == "" {
+		return unknown
+	}
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return unknown
+	}
+	return MatchByIP(ip)
+}

--- a/internal/serverdetect/server.go
+++ b/internal/serverdetect/server.go
@@ -1,0 +1,59 @@
+// Package serverdetect identifies the active Albion Online server region
+// (Americas/Europe/Asia) from the Photon server's IP address, mirroring the
+// reference repository's AlbionServerRegistry + AlbionServerDetectionService.
+//
+// The region drives per-server data segregation on disk (UserData-{SERVER}
+// subdirectories) so a player who plays on multiple regions keeps their stats
+// isolated per region.
+package serverdetect
+
+// ServerLocation identifies an Albion Online game-server region. Values mirror
+// StatisticsAnalysisTool's ServerLocation enum.
+type ServerLocation int
+
+const (
+	ServerLocationUnknown ServerLocation = 0
+	ServerLocationAmerica ServerLocation = 1
+	ServerLocationAsia    ServerLocation = 2
+	ServerLocationEurope  ServerLocation = 3
+)
+
+// IsKnown reports whether the location is one of the concrete game regions
+// (not Unknown). Used by callers to decide whether per-region paths apply.
+func (s ServerLocation) IsKnown() bool {
+	switch s {
+	case ServerLocationAmerica, ServerLocationAsia, ServerLocationEurope:
+		return true
+	}
+	return false
+}
+
+// String returns the human-readable region name, or "Unknown".
+func (s ServerLocation) String() string {
+	switch s {
+	case ServerLocationAmerica:
+		return "Americas"
+	case ServerLocationAsia:
+		return "Asia"
+	case ServerLocationEurope:
+		return "Europe"
+	default:
+		return "Unknown"
+	}
+}
+
+// DirName returns the on-disk subdirectory name for a region, matching the
+// reference's UserData-{REGION} convention. Returns "" for Unknown so callers
+// can treat it as "no per-region subdir" (the legacy/shared directory).
+func (s ServerLocation) DirName() string {
+	switch s {
+	case ServerLocationAmerica:
+		return "UserData-AMERICA"
+	case ServerLocationAsia:
+		return "UserData-ASIA"
+	case ServerLocationEurope:
+		return "UserData-EUROPE"
+	default:
+		return ""
+	}
+}

--- a/internal/serverdetect/server_test.go
+++ b/internal/serverdetect/server_test.go
@@ -1,0 +1,133 @@
+package serverdetect
+
+import (
+	"net"
+	"testing"
+)
+
+func TestServerLocationIsKnown(t *testing.T) {
+	known := []ServerLocation{ServerLocationAmerica, ServerLocationAsia, ServerLocationEurope}
+	for _, loc := range known {
+		if !loc.IsKnown() {
+			t.Errorf("%v.IsKnown() = false, want true", loc)
+		}
+	}
+	if ServerLocationUnknown.IsKnown() {
+		t.Errorf("Unknown.IsKnown() = true, want false")
+	}
+}
+
+func TestServerLocationString(t *testing.T) {
+	cases := map[ServerLocation]string{
+		ServerLocationAmerica: "Americas",
+		ServerLocationAsia:    "Asia",
+		ServerLocationEurope:  "Europe",
+		ServerLocationUnknown: "Unknown",
+		// any other value is not valid enum input but should not panic
+		ServerLocation(99): "Unknown",
+	}
+	for loc, want := range cases {
+		if got := loc.String(); got != want {
+			t.Errorf("%v.String() = %q, want %q", loc, got, want)
+		}
+	}
+}
+
+func TestServerLocationDirName(t *testing.T) {
+	cases := map[ServerLocation]string{
+		ServerLocationAmerica: "UserData-AMERICA",
+		ServerLocationAsia:    "UserData-ASIA",
+		ServerLocationEurope:  "UserData-EUROPE",
+		ServerLocationUnknown: "",
+	}
+	for loc, want := range cases {
+		if got := loc.DirName(); got != want {
+			t.Errorf("%v.DirName() = %q, want %q", loc, got, want)
+		}
+	}
+}
+
+func TestMatchByIP(t *testing.T) {
+	cases := []struct {
+		name string
+		ip   string
+		want ServerLocation
+	}{
+		{"Americas full", "5.188.125.10", ServerLocationAmerica},
+		{"Americas boundary", "5.188.125.255", ServerLocationAmerica},
+		{"Asia", "5.45.187.5", ServerLocationAsia},
+		{"Europe", "193.169.238.42", ServerLocationEurope},
+		{"unknown prefix", "8.8.8.8", ServerLocationUnknown},
+		// Prefix must be a real prefix — 5.188.12 is NOT 5.188.125.
+		{"partial non-match", "5.188.12.9", ServerLocationUnknown},
+		// Prefix shares the leading octet but diverges immediately after.
+		{"shared first octet", "5.188.200.1", ServerLocationUnknown},
+		{"loopback", "127.0.0.1", ServerLocationUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MatchByIPString(tc.ip)
+			if got.Location != tc.want {
+				t.Errorf("MatchByIPString(%q) = %v, want %v", tc.ip, got.Location, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchByIPNil(t *testing.T) {
+	if got := MatchByIP(nil); got.Location != ServerLocationUnknown {
+		t.Errorf("MatchByIP(nil) = %v, want Unknown", got.Location)
+	}
+}
+
+func TestMatchByIPV6Ignored(t *testing.T) {
+	// A v4-mapped IPv6 address (::ffff:a.b.c.d) represents an IPv4 connection
+	// and is normalized by To4(), so it IS matched to the underlying region.
+	if got := MatchByIPString("::ffff:5.188.125.10"); got.Location != ServerLocationAmerica {
+		t.Errorf("MatchByIP(v4-mapped v6) = %v, want Americas (normalized to v4)", got.Location)
+	}
+	// A native IPv6 address does not match any known (IPv4-only) prefix.
+	if got := MatchByIPString("2001:db8::1"); got.Location != ServerLocationUnknown {
+		t.Errorf("MatchByIP(native v6) = %v, want Unknown", got.Location)
+	}
+}
+
+func TestMatchByIPStringInvalid(t *testing.T) {
+	cases := []string{"", "not-an-ip", "999.999.999.999", "5.188"}
+	for _, s := range cases {
+		if got := MatchByIPString(s); got.Location != ServerLocationUnknown {
+			t.Errorf("MatchByIPString(%q) = %v, want Unknown", s, got.Location)
+		}
+	}
+}
+
+func TestMatchByIPNetIPType(t *testing.T) {
+	// Verify the net.IP-based entrypoint behaves like the string one.
+	ip := net.IPv4(5, 188, 125, 10)
+	if got := MatchByIP(ip); got.Location != ServerLocationAmerica {
+		t.Errorf("MatchByIP(net.IPv4(...)) = %v, want Americas", got.Location)
+	}
+	// A 16-byte v4 representation (v4-in-v6) must still match.
+	if got := MatchByIP(ip.To16()); got.Location != ServerLocationAmerica {
+		t.Errorf("MatchByIP(v4-in-v6) = %v, want Americas", got.Location)
+	}
+}
+
+func TestServersReturnsCopy(t *testing.T) {
+	s1 := Servers()
+	s1[0] = ServerInfo{Location: ServerLocationUnknown, Name: "tampered", IpPrefix: "0.0.0"}
+	s2 := Servers()
+	// Mutating the returned slice must not affect subsequent calls.
+	if s2[0].Location == ServerLocationUnknown {
+		t.Fatalf("Servers() returned a slice that shared backing storage")
+	}
+	if len(s2) != 3 {
+		t.Errorf("len(Servers()) = %d, want 3", len(s2))
+	}
+}
+
+func TestUnknownSentinel(t *testing.T) {
+	if Unknown().Location != ServerLocationUnknown {
+		t.Fatalf("Unknown().Location = %v, want Unknown", Unknown().Location)
+	}
+}

--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -1,0 +1,143 @@
+package storage
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// migrationMarker is a sentinel file created in the legacy root after the
+// first legacy→region migration completes. Its presence makes subsequent
+// migrations (for other regions) no-ops, so the original legacy snapshot is
+// not re-copied into every newly detected region (which would seed a Europe
+// player's history into Americas, etc.).
+const migrationMarker = ".region-migration-done"
+
+// MigrateLegacyData copies all *.json files from the legacy/shared root into
+// the given region's subdirectory, exactly once.
+//
+// Behavior:
+//
+//   - region "" is a no-op (legacy → legacy has nothing to migrate).
+//   - The migration is claimed atomically via an exclusive marker create
+//     (O_CREATE|O_EXCL). The first caller to create the marker performs the
+//     copy; every other caller — concurrent or in a future session — sees the
+//     marker exists and returns immediately. This guarantees the original
+//     legacy snapshot is attributed to exactly one region and never re-seeds
+//     others, even under concurrent invocation.
+//   - Every *.json file in the root is copied into the region dir, skipping any
+//     that already exist there (so a partial earlier copy or a user-supplied
+//     seed is never overwritten).
+//
+// The copy (rather than rename) keeps the legacy root intact as a safety net.
+// Region subdirectories themselves under the root are never treated as data
+// files and are skipped by the *.json glob.
+func MigrateLegacyData(region string) error {
+	if region == "" {
+		return nil
+	}
+
+	root, err := DataDirFor("")
+	if err != nil {
+		return fmt.Errorf("resolve legacy root: %w", err)
+	}
+	regionDir, err := DataDirFor(region)
+	if err != nil {
+		return fmt.Errorf("resolve region dir: %w", err)
+	}
+
+	// Atomically claim the migration. O_CREATE|O_EXCL fails if the marker
+	// already exists, which serializes concurrent callers: only the winner
+	// proceeds to copy, everyone else returns. Marker-first prioritizes the
+	// "never re-seed other regions" guarantee over retry-on-crash mid-copy
+	// (a crash after claiming leaves the region empty; the legacy root remains
+	// as the fallback).
+	markerPath := filepath.Join(root, migrationMarker)
+	fh, err := os.OpenFile(markerPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		if os.IsExist(err) {
+			return nil // already migrated
+		}
+		return fmt.Errorf("claim migration marker: %w", err)
+	}
+	// Record which region won the claim (diagnostic; not read elsewhere).
+	_, _ = fh.WriteString(region + "\n")
+	_ = fh.Close()
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return fmt.Errorf("read legacy root: %w", err)
+	}
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !isJSONFile(name) {
+			continue
+		}
+		src := filepath.Join(root, name)
+		dst := filepath.Join(regionDir, name)
+		// Skip if the region dir already has this file (partial earlier copy
+		// or user-supplied seed). Never overwrite existing region data.
+		if _, err := os.Stat(dst); err == nil {
+			continue
+		}
+		if err := copyFile(src, dst); err != nil {
+			return fmt.Errorf("migrate %s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+// isJSONFile reports whether name ends in ".json" (case-insensitive). It does
+// not match the marker file (which has no .json suffix) or directories.
+func isJSONFile(name string) bool {
+	if len(name) < 6 {
+		return false
+	}
+	ext := name[len(name)-5:]
+	return ext == ".json" || ext == ".JSON"
+}
+
+// copyFile duplicates src onto dst, preserving nothing beyond contents. It is
+// the unit of legacy migration: simple, explicit, and easy to attribute in
+// errors. Permissions use 0o644 to match storage.Save's output.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}
+
+// MigrationDone reports whether the legacy→region migration has already run.
+// Exposed for diagnostics and tests; not needed by the normal runtime path.
+func MigrationDone() (bool, error) {
+	root, err := DataDirFor("")
+	if err != nil {
+		return false, err
+	}
+	_, err = os.Stat(filepath.Join(root, migrationMarker))
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}

--- a/internal/storage/migrate_test.go
+++ b/internal/storage/migrate_test.go
@@ -1,0 +1,211 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestMigrateLegacyDataNoOpForEmptyRegion(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	if err := MigrateLegacyData(""); err != nil {
+		t.Fatalf("MigrateLegacyData(\"\"): %v", err)
+	}
+	// No marker should be created for the empty region.
+	if done, err := MigrationDone(); err != nil || done {
+		t.Errorf("MigrationDone = (%v,%v), want (false,nil)", done, err)
+	}
+}
+
+func TestMigrateLegacyDataCopiesJSONFiles(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", root)
+
+	// Seed legacy data directly in the root.
+	legacyRoot := filepath.Join(root, appName)
+	if err := os.MkdirAll(legacyRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyRoot, "dungeon-runs.json"), []byte("[]"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyRoot, "session-stats.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A non-json file must be ignored.
+	if err := os.WriteFile(filepath.Join(legacyRoot, "notes.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MigrateLegacyData("UserData-AMERICA"); err != nil {
+		t.Fatalf("MigrateLegacyData: %v", err)
+	}
+
+	regionDir := filepath.Join(legacyRoot, "UserData-AMERICA")
+	for _, name := range []string{"dungeon-runs.json", "session-stats.json"} {
+		if _, err := os.Stat(filepath.Join(regionDir, name)); err != nil {
+			t.Errorf("expected %s migrated into region dir: %v", name, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(regionDir, "notes.txt")); err == nil {
+		t.Error("non-.json file was migrated")
+	}
+
+	done, err := MigrationDone()
+	if err != nil || !done {
+		t.Errorf("MigrationDone = (%v,%v), want (true,nil)", done, err)
+	}
+}
+
+func TestMigrateLegacyDataIdempotentAcrossRegions(t *testing.T) {
+	// The core guarantee: once migrated, legacy data must NOT seed a second
+	// region. Otherwise a Europe player's history would leak into Americas.
+	root := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", root)
+
+	legacyRoot := filepath.Join(root, appName)
+	if err := os.MkdirAll(legacyRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyRoot, "session-stats.json"),
+		[]byte(`{"fame":999}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First migration: Europe gets the legacy snapshot.
+	if err := MigrateLegacyData("UserData-EUROPE"); err != nil {
+		t.Fatalf("migrate Europe: %v", err)
+	}
+	// Mutate the Europe copy so we can tell a re-copy apart.
+	if err := os.WriteFile(
+		filepath.Join(legacyRoot, "UserData-EUROPE", "session-stats.json"),
+		[]byte(`{"fame":111}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second region: Americas must start EMPTY (marker present).
+	if err := MigrateLegacyData("UserData-AMERICA"); err != nil {
+		t.Fatalf("migrate Americas: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(legacyRoot, "UserData-AMERICA", "session-stats.json")); err == nil {
+		t.Error("Americas was seeded from legacy; marker failed to prevent re-migration")
+	}
+}
+
+func TestMigrateLegacyDataSkipsExistingRegionFiles(t *testing.T) {
+	// A region that already has a file must not have it overwritten by the
+	// legacy copy (user-supplied or partial seed wins).
+	root := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", root)
+
+	legacyRoot := filepath.Join(root, appName)
+	regionDir := filepath.Join(legacyRoot, "UserData-ASIA")
+	if err := os.MkdirAll(regionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(regionDir, "session-stats.json"),
+		[]byte(`{"fame":777}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyRoot, "session-stats.json"),
+		[]byte(`{"fame":999}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MigrateLegacyData("UserData-ASIA"); err != nil {
+		t.Fatalf("MigrateLegacyData: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(regionDir, "session-stats.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != `{"fame":777}` {
+		t.Errorf("region file overwritten by legacy copy: got %s", got)
+	}
+}
+
+func TestMigrateLegacyDataIgnoresRegionSubdirs(t *testing.T) {
+	// A region subdirectory under the root is not a .json file and must not be
+	// copied (would create nested UserData-* copies).
+	root := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", root)
+
+	legacyRoot := filepath.Join(root, appName)
+	if err := os.MkdirAll(filepath.Join(legacyRoot, "UserData-EUROPE"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyRoot, "dungeon-runs.json"), []byte("[]"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MigrateLegacyData("UserData-AMERICA"); err != nil {
+		t.Fatalf("MigrateLegacyData: %v", err)
+	}
+	// Only dungeon-runs.json should be copied, not the Europe subdir.
+	entries, err := os.ReadDir(filepath.Join(legacyRoot, "UserData-AMERICA"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			t.Errorf("subdirectory %q was copied into region dir", e.Name())
+		}
+	}
+}
+
+// TestMigrateLegacyDataConcurrentRegions verifies that concurrent migration
+// calls for different regions are safe (no panic, no half-written files). The
+// marker guarantees only the first region receives the legacy data; the others
+// must start empty. Run under -race.
+func TestMigrateLegacyDataConcurrentRegions(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", root)
+
+	legacyRoot := filepath.Join(root, appName)
+	if err := os.MkdirAll(legacyRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyRoot, "session-stats.json"),
+		[]byte(`{"fame":42}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	regions := []string{"UserData-AMERICA", "UserData-EUROPE", "UserData-ASIA"}
+	var wg sync.WaitGroup
+	errs := make(chan error, len(regions))
+	for _, r := range regions {
+		wg.Add(1)
+		go func(region string) {
+			defer wg.Done()
+			errs <- MigrateLegacyData(region)
+		}(r)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Errorf("concurrent MigrateLegacyData returned error: %v", err)
+		}
+	}
+
+	// Migration is complete after the race; re-running on the losing regions
+	// must be a clean no-op (marker present).
+	copied := 0
+	for _, r := range regions {
+		fp := filepath.Join(legacyRoot, r, "session-stats.json")
+		if _, err := os.Stat(fp); err == nil {
+			copied++
+		}
+	}
+	// Exactly one region wins the legacy data; the others start empty.
+	if copied != 1 {
+		t.Errorf("expected exactly 1 region to receive legacy data, got %d", copied)
+	}
+	// The marker must exist, so future migrations never re-seed.
+	done, err := MigrationDone()
+	if err != nil || !done {
+		t.Errorf("MigrationDone after concurrent run = (%v, %v), want (true, nil)", done, err)
+	}
+}

--- a/internal/storage/paths.go
+++ b/internal/storage/paths.go
@@ -11,11 +11,10 @@ import (
 // appName is the per-application subdirectory under the XDG data dir.
 const appName = "albion-lens"
 
-// DataDir resolves the application data directory following the XDG Base
-// Directory Specification: $XDG_DATA_HOME/albion-lens, falling back to
-// ~/.local/share/albion-lens when XDG_DATA_HOME is unset. The directory (and
-// any missing parents) are created with mode 0755.
-func DataDir() (string, error) {
+// xdgBase resolves the XDG data root: $XDG_DATA_HOME when set, otherwise
+// ~/.local/share. It performs no filesystem access and is shared by the legacy
+// and per-region path resolvers.
+func xdgBase() (string, error) {
 	base := os.Getenv("XDG_DATA_HOME")
 	if base == "" {
 		home, err := os.UserHomeDir()
@@ -24,17 +23,55 @@ func DataDir() (string, error) {
 		}
 		base = filepath.Join(home, ".local", "share")
 	}
+	return base, nil
+}
+
+// DataDir resolves the legacy/shared application data directory following the
+// XDG Base Directory Specification: $XDG_DATA_HOME/albion-lens, falling back to
+// ~/.local/share/albion-lens when XDG_DATA_HOME is unset. The directory (and
+// any missing parents) are created with mode 0755.
+//
+// This is the Unknown-region fallback and is identical to DataDirFor("").
+func DataDir() (string, error) {
+	return DataDirFor("")
+}
+
+// DataFile joins the legacy data directory with the given file name. It is a
+// convenience over DataDir for callers that just need a single path, and is
+// identical to DataFileFor("", name).
+func DataFile(name string) (string, error) {
+	return DataFileFor("", name)
+}
+
+// DataDirFor resolves a per-region application data directory:
+//
+//	$XDG_DATA_HOME/albion-lens/<region>/   when region != ""
+//	$XDG_DATA_HOME/albion-lens/            when region == "" (legacy fallback)
+//
+// An empty region yields the shared root (identical to DataDir), so callers
+// with no active region pass "" without special-casing. The region is the
+// on-disk subdirectory name (e.g. "UserData-AMERICA"); it is opaque to storage
+// and owned by the caller (serverdetect.ServerLocation.DirName). The directory
+// (and any missing parents) are created with mode 0755.
+func DataDirFor(region string) (string, error) {
+	base, err := xdgBase()
+	if err != nil {
+		return "", err
+	}
 	dir := filepath.Join(base, appName)
+	if region != "" {
+		dir = filepath.Join(dir, region)
+	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
 	}
 	return dir, nil
 }
 
-// DataFile joins the data directory with the given file name. It is a
-// convenience over DataDir for callers that just need a single path.
-func DataFile(name string) (string, error) {
-	dir, err := DataDir()
+// DataFileFor joins a per-region data directory with the given file name. See
+// DataDirFor for the region semantics (empty region = legacy/shared root).
+func DataFileFor(region, name string) (string, error) {
+	dir, err := DataDirFor(region)
 	if err != nil {
 		return "", err
 	}

--- a/internal/storage/paths_test.go
+++ b/internal/storage/paths_test.go
@@ -57,3 +57,94 @@ func TestDataFileJoinsName(t *testing.T) {
 		t.Errorf("DataFile = %q, want %q", got, want)
 	}
 }
+
+// TestDataDirForEmptyEqualsDataDir confirms the Unknown-region fallback path
+// is exactly the legacy root, so callers can pass "" unconditionally.
+func TestDataDirForEmptyEqualsDataDir(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	legacy, err := DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	empty, err := DataDirFor("")
+	if err != nil {
+		t.Fatalf("DataDirFor(\"\", err): %v", err)
+	}
+	if legacy != empty {
+		t.Errorf("DataDir() = %q != DataDirFor(\"\") = %q", legacy, empty)
+	}
+}
+
+func TestDataFileForEmptyEqualsDataFile(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	legacy, err := DataFile("stats.json")
+	if err != nil {
+		t.Fatalf("DataFile: %v", err)
+	}
+	empty, err := DataFileFor("", "stats.json")
+	if err != nil {
+		t.Fatalf("DataFileFor: %v", err)
+	}
+	if legacy != empty {
+		t.Errorf("DataFile() = %q != DataFileFor(\"\") = %q", legacy, empty)
+	}
+}
+
+// TestDataDirForRegionNestedUnderRoot confirms per-region dirs live under the
+// app root and are created (including missing parents).
+func TestDataDirForRegionNestedUnderRoot(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", base)
+
+	got, err := DataDirFor("UserData-AMERICA")
+	if err != nil {
+		t.Fatalf("DataDirFor: %v", err)
+	}
+
+	want := filepath.Join(base, appName, "UserData-AMERICA")
+	if got != want {
+		t.Errorf("DataDirFor = %q, want %q", got, want)
+	}
+	if fi, err := os.Stat(want); err != nil || !fi.IsDir() {
+		t.Errorf("region dir not created at %q (err=%v)", want, err)
+	}
+}
+
+func TestDataFileForRegionJoinsName(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", base)
+
+	got, err := DataFileFor("UserData-EUROPE", "session-stats.json")
+	if err != nil {
+		t.Fatalf("DataFileFor: %v", err)
+	}
+
+	want := filepath.Join(base, appName, "UserData-EUROPE", "session-stats.json")
+	if got != want {
+		t.Errorf("DataFileFor = %q, want %q", got, want)
+	}
+}
+
+// TestDataDirForIsolation verifies two regions resolve to disjoint paths
+// (no cross-region bleed), the core guarantee of region segregation.
+func TestDataDirForIsolation(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	am, err := DataDirFor("UserData-AMERICA")
+	if err != nil {
+		t.Fatalf("AMERICA: %v", err)
+	}
+	eu, err := DataDirFor("UserData-EUROPE")
+	if err != nil {
+		t.Fatalf("EUROPE: %v", err)
+	}
+	legacy, err := DataDirFor("")
+	if err != nil {
+		t.Fatalf("legacy: %v", err)
+	}
+	if am == eu || am == legacy || eu == legacy {
+		t.Errorf("region paths collide: am=%q eu=%q legacy=%q", am, eu, legacy)
+	}
+}

--- a/internal/tui/components/statusbar.go
+++ b/internal/tui/components/statusbar.go
@@ -12,6 +12,7 @@ type StatusBar struct {
 	online         bool
 	playerName     string
 	currentZone    string
+	region         string
 	packetsTotal   uint64
 	packetsPerSec  float64
 	eventsDecoded  uint64
@@ -53,6 +54,15 @@ func (s StatusBar) SetPlayerName(name string) StatusBar {
 // omitted from the status bar (before the first ChangeCluster is captured).
 func (s StatusBar) SetZone(zone string) StatusBar {
 	s.currentZone = zone
+	return s
+}
+
+// SetRegion updates the detected server region label (e.g. "Europe"). When
+// empty or "Unknown", the region indicator is omitted — the detector needs a
+// few seconds of stable Photon traffic before it confirms a region, so the
+// indicator appears only once detection is confident.
+func (s StatusBar) SetRegion(region string) StatusBar {
+	s.region = region
 	return s
 }
 
@@ -118,6 +128,15 @@ func (s StatusBar) View() string {
 		status += "  " + lipgloss.NewStyle().
 			Foreground(lipgloss.Color("39")).
 			Render("◎ "+s.currentZone)
+	}
+
+	// Region indicator (shown once the server region is confidently detected).
+	// Helps users verify which region's persistence directory is active,
+	// especially after a region switch or when a server-hint override is set.
+	if s.online && s.region != "" && s.region != "Unknown" {
+		status += "  " + lipgloss.NewStyle().
+			Foreground(lipgloss.Color("141")).
+			Render("🌍 "+s.region)
 	}
 
 	// Buffer Stats Logic

--- a/internal/tui/components/statusbar_test.go
+++ b/internal/tui/components/statusbar_test.go
@@ -130,6 +130,33 @@ func TestStatusBarViewOnline(t *testing.T) {
 	}
 }
 
+// TestStatusBarRegionIndicator verifies the region indicator renders when a
+// known region is set + online, and is omitted for Unknown / empty / offline.
+func TestStatusBarRegionIndicator(t *testing.T) {
+	s := NewStatusBar().SetWidth(100).SetOnline(true).SetRegion("Europe")
+	if out := s.View(); !strings.Contains(out, "🌍 Europe") {
+		t.Errorf("expected region indicator in view, got:\n%s", out)
+	}
+
+	// Unknown region must be omitted.
+	s = NewStatusBar().SetWidth(100).SetOnline(true).SetRegion("Unknown")
+	if out := s.View(); strings.Contains(out, "🌍") {
+		t.Errorf("Unknown region should be omitted, got:\n%s", out)
+	}
+
+	// Empty region must be omitted.
+	s = NewStatusBar().SetWidth(100).SetOnline(true)
+	if out := s.View(); strings.Contains(out, "🌍") {
+		t.Errorf("empty region should be omitted, got:\n%s", out)
+	}
+
+	// Online region must not render while offline.
+	s = NewStatusBar().SetWidth(100).SetOnline(false).SetRegion("Europe")
+	if out := s.View(); strings.Contains(out, "🌍") {
+		t.Errorf("region should not render offline, got:\n%s", out)
+	}
+}
+
 func TestStatusBarViewDroppedEvents(t *testing.T) {
 	stats := &photon.Stats{
 		EventsDecoded: uint64(100),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -368,7 +368,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// Periodic tick
 	case TickMsg:
-		// Refresh player identification, zone, and online status from the backend
+		// Refresh player identification, zone, region, and online status from the backend
 		if m.svc != nil {
 			m.statusBar = m.statusBar.SetPlayerName(m.svc.LocalPlayerName())
 			m.statusBar = m.statusBar.SetOnline(m.svc.IsOnline())
@@ -376,6 +376,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			zone := m.svc.CurrentZone()
 			m.statusBar = m.statusBar.SetZone(zone.DisplayString())
 			m.zonePanel = m.zonePanel.SetZone(zone).SetNow(time.Now())
+
+			m.statusBar = m.statusBar.SetRegion(m.svc.CurrentServer().String())
 
 			// Refresh dungeon runs panel
 			if h := m.svc.Handler(); h != nil {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/cantalupo555/albion-lens/internal/serverdetect"
 	"github.com/cantalupo555/albion-lens/internal/tui/components"
 	"github.com/cantalupo555/albion-lens/pkg/backend"
 	"github.com/cantalupo555/albion-lens/pkg/events"
@@ -754,6 +756,41 @@ func TestUpdateTickMsgWithService(t *testing.T) {
 	view := m.View().Content
 	if strings.Contains(view, "◎") {
 		t.Error("expected no zone indicator with nil handler")
+	}
+}
+
+// TestUpdateTickMsgWiresRegionToStatusBar is the integration test for the
+// TickMsg → svc.CurrentServer() → StatusBar.SetRegion wiring. Without this
+// test, removing the SetRegion line in the TickMsg handler would not fail any
+// test (the existing TickMsg test uses backend.New() which has a nil detector
+// and returns Unknown — identical to an empty region from the StatusBar guard).
+func TestUpdateTickMsgWiresRegionToStatusBar(t *testing.T) {
+	svc := backend.New()
+	// Wire a detector with zero stability so two matching packets promote
+	// instantly to a known region.
+	d := serverdetect.NewDetector(serverdetect.WithStability(0))
+	svc.SetDetectorForTest(d)
+
+	americasIP := net.ParseIP("5.188.125.10")
+	d.DetectFromIP(americasIP) // first packet: sets candidate
+	d.DetectFromIP(americasIP) // second packet: confirms → promoted
+
+	if got := svc.CurrentServer(); got != serverdetect.ServerLocationAmerica {
+		t.Fatalf("precondition: CurrentServer = %v, want Americas", got)
+	}
+
+	m := New(svc, nil, nil)
+	m = updateModel(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+
+	// TickMsg refreshes region + online from the backend. svc.IsOnline()
+	// returns false (no handler), so set online afterwards to exercise the
+	// render guard.
+	m = updateModel(m, TickMsg(time.Now()))
+	m.statusBar = m.statusBar.SetOnline(true)
+
+	view := m.View().Content
+	if !strings.Contains(view, "Americas") {
+		t.Errorf("expected region indicator 'Americas' in status bar view after TickMsg, got:\n%s", view)
 	}
 }
 

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -1,9 +1,11 @@
 package backend
 
 import (
+	"net"
 	"testing"
 	"time"
 
+	"github.com/cantalupo555/albion-lens/internal/serverdetect"
 	"github.com/cantalupo555/albion-lens/pkg/photon"
 )
 
@@ -447,6 +449,174 @@ func TestServiceHandlerWithoutStart(t *testing.T) {
 	}
 }
 
+// TestServiceServerAccessorsBeforeStart checks the region-detection accessors
+// are nil-safe before Start() (the detector is created during Start).
+func TestServiceServerAccessorsBeforeStart(t *testing.T) {
+	s := New()
+
+	if got := s.CurrentServer(); got != serverdetect.ServerLocationUnknown {
+		t.Errorf("CurrentServer before Start = %v, want Unknown", got)
+	}
+	ch := s.ServerChanged()
+	if ch == nil {
+		t.Fatal("ServerChanged() returned nil channel before Start")
+	}
+	// Channel must be open and empty (no transitions without capture).
+	select {
+	case ev, ok := <-ch:
+		if !ok {
+			t.Error("ServerChanged channel closed before Start")
+		}
+		t.Errorf("ServerChanged channel had event before Start: %+v", ev)
+	default:
+		// expected: no event ready
+	}
+}
+
+// TestServiceServerChangedChannelExposed confirms ServerChanged returns the
+// same channel the service forwards region transitions to, and that a value
+// pushed on the internal channel is observable from the public accessor.
+func TestServiceServerChangedChannelExposed(t *testing.T) {
+	s := New()
+
+	americas := serverdetect.MatchByIPString("5.188.125.1")
+	s.serverChangedCh <- serverdetect.ChangeEvent{
+		Previous: serverdetect.Unknown(),
+		Current:  americas,
+	}
+
+	select {
+	case ev := <-s.ServerChanged():
+		if ev.Current.Location != serverdetect.ServerLocationAmerica {
+			t.Errorf("event current = %v, want Americas", ev.Current.Location)
+		}
+		if ev.Previous.Location != serverdetect.ServerLocationUnknown {
+			t.Errorf("event previous = %v, want Unknown", ev.Previous.Location)
+		}
+	default:
+		t.Error("ServerChanged() did not observe the forwarded event")
+	}
+}
+
+// initDetectorForTest wires a region detector onto a Service without invoking
+// the full Start() path (which requires a real capture device). It mirrors the
+// wiring Start() uses: onChange forwards to serverChangedCh and bumps the drop
+// counter on overflow. stability is configurable so tests can promote a region
+// instantly.
+func initDetectorForTest(s *Service, stability time.Duration) {
+	s.detector = serverdetect.NewDetector(
+		serverdetect.WithStability(stability),
+		serverdetect.WithOnChange(func(e serverdetect.ChangeEvent) {
+			select {
+			case s.serverChangedCh <- e:
+			default:
+				s.serverChangesDropped.Add(1)
+			}
+		}),
+	)
+}
+
+// TestServiceHandlePacketFeedsDetector is the wiring test for the
+// capture→detector→ServerChanged path. It calls handlePacket (the per-packet
+// callback) with a known server IP and asserts a region transition flows to
+// ServerChanged. This catches regressions where the packetHandler forgets to
+// feed the detector or passes the wrong IP field.
+func TestServiceHandlePacketFeedsDetector(t *testing.T) {
+	s := New()
+	// Zero stability so the candidate promotes on the second matching packet
+	// without a multi-second wait (the first sets the candidate, the second
+	// confirms and promotes — see detector.tryPromoteStableCandidate).
+	initDetectorForTest(s, 0)
+
+	serverIP := net.ParseIP("5.188.125.10")
+	// Two matching packets: first establishes the candidate, second promotes.
+	s.handlePacket(nil, serverIP, net.ParseIP("192.168.1.5"), 5056, 50000)
+	s.handlePacket(nil, serverIP, net.ParseIP("192.168.1.5"), 5056, 50000)
+
+	select {
+	case ev := <-s.ServerChanged():
+		if ev.Current.Location != serverdetect.ServerLocationAmerica {
+			t.Errorf("handlePacket produced region %v, want Americas", ev.Current.Location)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("handlePacket did not forward a region transition to ServerChanged")
+	}
+
+	// A non-matching packet (local-only IPs) must not fire a transition.
+	select {
+	case ev := <-s.ServerChanged():
+		t.Errorf("non-matching packet produced unexpected event: %+v", ev)
+	default:
+	}
+}
+
+// TestServiceHandlePacketFeedsDetectorOutgoing confirms dstIP is also fed, so
+// detection works for outgoing (client→server) packets where the server is the
+// destination rather than the source.
+func TestServiceHandlePacketFeedsDetectorOutgoing(t *testing.T) {
+	s := New()
+	initDetectorForTest(s, 0)
+
+	// Outgoing packet: srcIP is local, dstIP is the server.
+	serverIP := net.ParseIP("193.169.238.7")
+	s.handlePacket(nil, net.ParseIP("192.168.1.5"), serverIP, 50000, 5056)
+	s.handlePacket(nil, net.ParseIP("192.168.1.5"), serverIP, 50000, 5056)
+
+	select {
+	case ev := <-s.ServerChanged():
+		if ev.Current.Location != serverdetect.ServerLocationEurope {
+			t.Errorf("outgoing packet produced region %v, want Europe", ev.Current.Location)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("outgoing packet did not forward a region transition")
+	}
+}
+
+// TestServiceServerChangesDroppedCounter verifies the overflow counter bumps
+// when the ServerChanged buffer is full and a transition is dropped.
+func TestServiceServerChangesDroppedCounter(t *testing.T) {
+	s := New()
+	initDetectorForTest(s, 0)
+
+	// Drive repeated region switches (Americas ↔ Europe). Each switch needs a
+	// reset-to-Unknown packet + a confirm packet, so the buffer (capacity 4)
+	// fills quickly and later transitions overflow.
+	americas := net.ParseIP("5.188.125.10")
+	europe := net.ParseIP("193.169.238.7")
+	for i := 0; i < 40; i++ {
+		target := americas
+		if i%2 == 1 {
+			target = europe
+		}
+		// Two packets to complete a switch (candidate + confirm).
+		s.handlePacket(nil, target, nil, 0, 0)
+		s.handlePacket(nil, target, nil, 0, 0)
+	}
+
+	// Drain everything we can; what matters is that the drop counter went up.
+	for {
+		select {
+		case <-s.ServerChanged():
+		default:
+			if got := s.ServerChangesDropped(); got == 0 {
+				t.Error("expected dropped transitions when buffer is full, got 0")
+			}
+			return
+		}
+	}
+}
+
+// TestServiceHandlePacketNilDetectorNoPanic confirms handlePacket is safe to
+// call before Start() wires the detector. The nil-detector guard is defensive
+// (unreachable in normal operation since Start() creates the detector before
+// capture begins), but a regression that removes the guard would crash.
+func TestServiceHandlePacketNilDetectorNoPanic(t *testing.T) {
+	s := New()
+	// s.detector is nil (Start() not called). handlePacket must skip detection
+	// without panicking.
+	s.handlePacket(nil, net.ParseIP("5.188.125.10"), net.ParseIP("192.168.1.5"), 5056, 50000)
+}
+
 // TestDefaultBufferSizeConstants tests default buffer size constants
 func TestDefaultBufferSizeConstants(t *testing.T) {
 	if defaultEventBufferSize != 250 {
@@ -563,8 +733,8 @@ func newServiceWithStatsUpdater(t *testing.T) *Service {
 	return s
 }
 
-// TestServiceStopClosesAllChannels verifies that Stop() closes all three
-// public-facing channels (Events, Stats, OnlineStatus).
+// TestServiceStopClosesAllChannels verifies that Stop() closes all four
+// public-facing channels (Events, Stats, OnlineStatus, ServerChanged).
 func TestServiceStopClosesAllChannels(t *testing.T) {
 	s := newServiceWithStatsUpdater(t)
 
@@ -583,6 +753,11 @@ func TestServiceStopClosesAllChannels(t *testing.T) {
 	_, ok = <-s.OnlineStatus
 	if ok {
 		t.Error("OnlineStatus channel not closed after Stop()")
+	}
+
+	_, ok = <-s.ServerChanged()
+	if ok {
+		t.Error("ServerChanged channel not closed after Stop()")
 	}
 }
 

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -1,6 +1,8 @@
 // Package backend provides a unified service layer for Albion Online packet capture and event processing.
 package backend
 
+import "github.com/cantalupo555/albion-lens/internal/serverdetect"
+
 // Option configures the Service using functional options pattern
 type Option func(*Service)
 
@@ -50,5 +52,15 @@ func WithEventBufferSize(size int) Option {
 func WithStatsBufferSize(size int) Option {
 	return func(s *Service) {
 		s.statsBufferSize = size
+	}
+}
+
+// WithDetectorOptions configures the server-region detector. The service still
+// appends its own OnChange callback (which forwards to ServerChanged), so
+// callers should not set their own OnChange here. Useful for tests that need a
+// shorter stability window or a custom nowFunc.
+func WithDetectorOptions(opts ...serverdetect.Option) Option {
+	return func(s *Service) {
+		s.detectorOpts = append(s.detectorOpts, opts...)
 	}
 }

--- a/pkg/backend/service.go
+++ b/pkg/backend/service.go
@@ -8,8 +8,10 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/cantalupo555/albion-lens/internal/serverdetect"
 	"github.com/cantalupo555/albion-lens/pkg/capture"
 	"github.com/cantalupo555/albion-lens/pkg/handlers"
 	"github.com/cantalupo555/albion-lens/pkg/photon"
@@ -31,13 +33,21 @@ type Service struct {
 	bpfFilter       string
 	eventBufferSize int
 	statsBufferSize int
+	detectorOpts    []serverdetect.Option
 
 	// Internal components
 	handler  *handlers.AlbionHandler
 	parser   *photon.Parser
 	capture  *capture.Capture
+	detector *serverdetect.Detector
 	stopChan chan struct{}
 	wg       sync.WaitGroup // Tracks statsUpdater goroutine
+
+	// serverChangesDropped counts region transitions that could not be forwarded
+	// to serverChangedCh because its buffer was full. Exposed for diagnostics
+	// (the buffer is small and region changes are rare, so this stays at zero
+	// in normal use; a non-zero value signals the frontend is not draining).
+	serverChangesDropped atomic.Int64
 
 	// Public channels (read-only for frontends)
 	Events       <-chan GameEvent
@@ -48,6 +58,13 @@ type Service struct {
 	eventsChan       chan GameEvent
 	statsChan        chan *photon.Stats
 	onlineStatusChan chan bool
+	serverChangedCh  chan serverdetect.ChangeEvent
+
+	// serverChanged exposes region transitions to frontends (e.g. so the TUI
+	// can re-resolve persistence paths and reload per-region state). It is
+	// buffered because region changes are rare and the capture goroutine that
+	// produces them must not block.
+	serverChanged <-chan serverdetect.ChangeEvent
 
 	// State
 	running bool
@@ -70,12 +87,17 @@ func New(opts ...Option) *Service {
 	s.eventsChan = make(chan GameEvent, s.eventBufferSize)
 	s.statsChan = make(chan *photon.Stats, s.statsBufferSize)
 	s.onlineStatusChan = make(chan bool, 1)
+	// serverChangedCh is intentionally small: region transitions are rare
+	// (typically one per login). The buffer absorbs the burst between the
+	// capture goroutine producing the event and the frontend draining it.
+	s.serverChangedCh = make(chan serverdetect.ChangeEvent, 4)
 	s.stopChan = make(chan struct{})
 
 	// Expose read-only channels
 	s.Events = s.eventsChan
 	s.Stats = s.statsChan
 	s.OnlineStatus = s.onlineStatusChan
+	s.serverChanged = s.serverChangedCh
 
 	return s
 }
@@ -124,13 +146,27 @@ func (s *Service) Start() error {
 	s.parser.Stats.BufferCapacity = cap(s.eventsChan) // Set once at startup
 	// Note: Parser debug is not enabled because it uses fmt.Printf which interferes with TUI
 
+	// Server region detector: identifies Americas/Europe/Asia from the Photon
+	// server's IP. The detector's onChange forwards transitions to
+	// serverChangedCh for frontends to act on (e.g. switching persistence
+	// directories). Created here so it lives for the whole capture session.
+	detectorOpts := append([]serverdetect.Option{}, s.detectorOpts...)
+	detectorOpts = append(detectorOpts, serverdetect.WithOnChange(func(e serverdetect.ChangeEvent) {
+		select {
+		case s.serverChangedCh <- e:
+		default:
+			// Buffer full: drop rather than block the capture hot path.
+			// Region changes are rare; the periodic save + save-on-exit
+			// remain as safety nets so a dropped transition is recoverable.
+			s.serverChangesDropped.Add(1)
+		}
+	}))
+	s.detector = serverdetect.NewDetector(detectorOpts...)
+
 	// Create capture. NewCaptureWithFilter falls back to the default Albion
 	// port set when s.bpfFilter is empty, so WithBPFFilter("") and omitting
 	// the option behave identically.
-	packetHandler := func(payload []byte, srcIP, dstIP net.IP, srcPort, dstPort uint16) {
-		_ = s.parser.ParsePacket(payload)
-	}
-	s.capture = capture.NewCaptureWithFilter(packetHandler, s.bpfFilter)
+	s.capture = capture.NewCaptureWithFilter(s.handlePacket, s.bpfFilter)
 
 	// Set online/offline callback
 	s.capture.OnlineCallback = func(online bool) {
@@ -186,6 +222,14 @@ func (s *Service) Start() error {
 	return nil
 }
 
+// SetDetectorForTest attaches a pre-configured detector, bypassing Start().
+// Intended only for tests that need a known server region without live packet
+// capture. The detector's onChange callback is NOT wired to serverChangedCh,
+// so CurrentServer() works but ServerChanged() will not emit events.
+func (s *Service) SetDetectorForTest(d *serverdetect.Detector) {
+	s.detector = d
+}
+
 // Stop stops the service and cleans up resources. It blocks until the
 // statsUpdater goroutine has fully exited, then closes all public channels.
 // Safe to call multiple times (subsequent calls are no-ops).
@@ -219,6 +263,7 @@ func (s *Service) Stop() {
 	close(s.eventsChan)
 	close(s.statsChan)
 	close(s.onlineStatusChan)
+	close(s.serverChangedCh)
 }
 
 // emitEvent sends a game event to the events channel without blocking. If the
@@ -385,6 +430,51 @@ func (s *Service) CurrentZone() handlers.ZoneInfo {
 		return handlers.ZoneInfo{}
 	}
 	return s.handler.GetCurrentZone()
+}
+
+// CurrentServer returns the currently detected Albion server region, or
+// ServerLocationUnknown if no region has been confirmed yet (the detector
+// requires a stable Photon server IP for 5 seconds before promoting).
+func (s *Service) CurrentServer() serverdetect.ServerLocation {
+	if s.detector == nil {
+		return serverdetect.ServerLocationUnknown
+	}
+	return s.detector.Current().Location
+}
+
+// ServerChanged returns a channel that receives an event each time the
+// detected Albion server region transitions (Unknown→region, region→Unknown,
+// or region→region). The channel is closed when the service stops.
+//
+// Frontends use this to re-resolve per-region persistence directories and
+// reload state for the newly active region.
+func (s *Service) ServerChanged() <-chan serverdetect.ChangeEvent {
+	return s.serverChanged
+}
+
+// ServerChangesDropped returns the count of region transitions that were
+// discarded because the ServerChanged buffer was full. Non-zero in normal use
+// means the frontend is not draining the channel fast enough.
+func (s *Service) ServerChangesDropped() int64 {
+	return s.serverChangesDropped.Load()
+}
+
+// handlePacket is the per-packet callback wired into the capture layer. It
+// feeds both packet endpoints to the region detector (for incoming packets the
+// server is the source IP, for outgoing it is the destination; the detector
+// ignores non-matching local IPs) and then forwards the payload to the Photon
+// parser.
+//
+// Extracted as a method so the capture→detector→parser wiring is unit-testable
+// without a real capture device.
+func (s *Service) handlePacket(payload []byte, srcIP, dstIP net.IP, srcPort, dstPort uint16) {
+	if s.detector != nil {
+		s.detector.DetectFromIP(srcIP)
+		s.detector.DetectFromIP(dstIP)
+	}
+	if s.parser != nil {
+		_ = s.parser.ParsePacket(payload)
+	}
 }
 
 // ParserStats returns the current parser statistics.

--- a/pkg/handlers/albion.go
+++ b/pkg/handlers/albion.go
@@ -396,6 +396,15 @@ type AlbionHandler struct {
 
 	// Event callback for frontend integration (TUI, Wails, etc.)
 	eventCallback EventCallback
+
+	// clusterChangeCallback is invoked once per confirmed zone transition
+	// (ChangeCluster / OpJoin that materially changes the zone). Frontends use
+	// it to trigger a rate-limited persistence flush so a crash shortly after a
+	// map change loses at most the post-transition progress. Guarded by
+	// clusterCbMu because it is set after Start() while the capture goroutine
+	// may already be producing transitions.
+	clusterCbMu     sync.RWMutex
+	clusterChangeCb func()
 }
 
 // DiscoveredEvent tracks unknown events in discovery mode
@@ -436,6 +445,17 @@ func (h *AlbionHandler) SetDiscoveryMode(discovery bool) {
 // SetEventCallback sets a callback function for TUI integration
 func (h *AlbionHandler) SetEventCallback(callback EventCallback) {
 	h.eventCallback = callback
+}
+
+// SetClusterChangeCallback registers a function invoked on each confirmed zone
+// transition (a ChangeCluster or OpJoin that materially changes the map). The
+// callback runs on the capture goroutine, so it must be non-blocking; callers
+// typically dispatch persistence work to a separate goroutine with a rate
+// limit. Passing nil clears the callback.
+func (h *AlbionHandler) SetClusterChangeCallback(fn func()) {
+	h.clusterCbMu.Lock()
+	h.clusterChangeCb = fn
+	h.clusterCbMu.Unlock()
 }
 
 // SetLocalPlayer records the local player's name, auto-detected from the OpJoin
@@ -539,6 +559,16 @@ func (h *AlbionHandler) processZoneTransition(newZone ZoneInfo) {
 		ClusterIndex: newZone.ClusterIndex,
 		Previous:     prev.MapType,
 	})
+
+	// Notify the cluster-change hook. Fires only on a confirmed material
+	// transition — the dedup skip above returns before reaching here. The
+	// callback must be non-blocking; callers rate-limit and dispatch I/O.
+	h.clusterCbMu.RLock()
+	cb := h.clusterChangeCb
+	h.clusterCbMu.RUnlock()
+	if cb != nil {
+		cb()
+	}
 }
 
 // notifyEvent calls the event callback if set
@@ -1010,6 +1040,40 @@ func (h *AlbionHandler) LoadKillDeathLog(path string) error {
 	h.kdLog = entries
 	h.kdLogMu.Unlock()
 	return nil
+}
+
+// ResetPersistedState clears all in-memory state that is persisted to disk:
+// dungeon runs, the kill/death log, and the cumulative stats counters (with
+// their daily/hourly buckets). The active dungeon run is dropped too, since it
+// is runtime-only and belongs to the region being left.
+//
+// The fame-dedup baseline (totalFame) is also reset: it tracks the last
+// server-reported total fame and is not persisted, so leaving the old region's
+// value would cause the new region's first (lower) fame events to be rejected
+// by the monotonic guard in handleUpdateFame.
+//
+// Used when switching the active server region: save the current region, reset,
+// then load the new region. Resetting before the load guarantees that a corrupt
+// new-region file (which Load* leaves untouched on error) cannot leak the
+// previous region's data into the new one.
+func (h *AlbionHandler) ResetPersistedState() {
+	h.dungeonMu.Lock()
+	h.dungeonRuns = nil
+	h.activeRun = nil
+	h.dungeonMu.Unlock()
+
+	h.kdLogMu.Lock()
+	h.kdLog = nil
+	h.kdLogMu.Unlock()
+
+	h.stats.apply(TotalStats{
+		Daily:  map[string]StatValues{},
+		Hourly: map[string]StatValues{},
+	})
+
+	// Reset the fame-dedup baseline so the new region's events are not
+	// rejected by the "totalFame must not decrease" guard.
+	h.totalFame.Store(0)
 }
 
 // GetTotalFame returns the cumulative fame gained across all launches.

--- a/pkg/handlers/zone_test.go
+++ b/pkg/handlers/zone_test.go
@@ -221,7 +221,6 @@ func TestChangeClusterUpdatesZone(t *testing.T) {
 		0: "@ISLAND@my-island",
 		2: "My Island",
 	})
-
 	zone := handler.GetCurrentZone()
 	if zone.MapType != MapTypeIsland {
 		t.Errorf("expected GetCurrentZone MapTypeIsland, got %v", zone.MapType)
@@ -550,5 +549,68 @@ func TestClusterDisplay(t *testing.T) {
 		if got := ClusterDisplay(tt.index); got != tt.want {
 			t.Errorf("ClusterDisplay(%q) = %q, want %q", tt.index, got, tt.want)
 		}
+	}
+}
+
+// TestClusterChangeCallbackFiresOnTransition verifies the cluster-change
+// callback fires exactly once per confirmed material zone transition.
+func TestClusterChangeCallbackFiresOnTransition(t *testing.T) {
+	handler := NewAlbionHandler()
+
+	var calls int
+	handler.SetClusterChangeCallback(func() { calls++ })
+
+	// First transition (Unknown → Island): fires.
+	handler.OnResponse(events.OperationChangeCluster, 0, "", map[byte]interface{}{
+		0: "@ISLAND@island-1",
+		2: "Island One",
+	})
+	if calls != 1 {
+		t.Errorf("after first transition, callback calls = %d, want 1", calls)
+	}
+
+	// Second transition (Island → open-world city): fires.
+	handler.OnResponse(events.OperationChangeCluster, 0, "", map[byte]interface{}{
+		0: "4000",
+	})
+	if calls != 2 {
+		t.Errorf("after second transition, callback calls = %d, want 2", calls)
+	}
+}
+
+// TestClusterChangeCallbackSkippedOnDedup verifies the callback does NOT fire
+// for a suppressed duplicate transition (same map type, cluster, island).
+func TestClusterChangeCallbackSkippedOnDedup(t *testing.T) {
+	handler := NewAlbionHandler()
+
+	var calls int
+	handler.SetClusterChangeCallback(func() { calls++ })
+
+	params := map[byte]interface{}{
+		0: "@ISLAND@island-1",
+		2: "Same Island",
+	}
+	// First transition: fires.
+	handler.OnResponse(events.OperationChangeCluster, 0, "", params)
+	// Identical repeat: dedup-suppressed, callback must not fire.
+	handler.OnResponse(events.OperationChangeCluster, 0, "", params)
+
+	if calls != 1 {
+		t.Errorf("callback calls after duplicate transition = %d, want 1", calls)
+	}
+}
+
+// TestClusterChangeCallbackClears confirms passing nil disables the callback.
+func TestClusterChangeCallbackClears(t *testing.T) {
+	handler := NewAlbionHandler()
+	var calls int
+	handler.SetClusterChangeCallback(func() { calls++ })
+	handler.SetClusterChangeCallback(nil)
+
+	handler.OnResponse(events.OperationChangeCluster, 0, "", map[byte]interface{}{
+		0: "4000",
+	})
+	if calls != 0 {
+		t.Errorf("callback fired after being cleared: %d calls", calls)
 	}
 }

--- a/pkg/photon/parser.go
+++ b/pkg/photon/parser.go
@@ -45,10 +45,10 @@ type Parser struct {
 	pendingFragments map[int32]*fragmentedPacket
 	fragmentsMu      sync.RWMutex // Protects pendingFragments
 	debug            bool
-	stopCleanup      chan struct{} // Signal to stop cleanup goroutine
-	closeOnce        sync.Once     // Ensures Close is idempotent
+	stopCleanup      chan struct{}  // Signal to stop cleanup goroutine
+	closeOnce        sync.Once      // Ensures Close is idempotent
 	wg               sync.WaitGroup // Tracks cleanupLoop goroutine
-	Stats            *Stats        // Parser statistics
+	Stats            *Stats         // Parser statistics
 }
 
 // fragmentedPacket holds data for reassembling fragmented packets


### PR DESCRIPTION
## Summary
This PR implements two persistence enhancements: (1) automatic segregation of persisted state by detected Albion server region (Americas/Asia/Europe) using Photon IP prefix matching with a 5-second stability window, and (2) rate-limited persistence saves on zone/cluster transitions (15-minute window) with atomic compare-and-swap coalescing. All during-TUI warnings now route through the visible event log instead of being hidden by the alt-screen.

## Motivation
Previously, all persisted state was stored in a single shared directory, causing cross-region data leakage and making it impossible to maintain separate statistics per server region. Additionally, persistence was only flushed on a fixed periodic interval, meaning progress could be lost when changing zones or clusters. These changes ensure data integrity per region and timely saves on map transitions while keeping I/O bounded during rapid zone hops.

## Changes Made
- **Server region detection** (`internal/serverdetect/`): New package with IPv4 /24 prefix matching against known Photon server ranges, a stable-candidate state machine with 5-second anti-flicker window, and `ChangeEvent` callbacks emitted after confirmed transitions
- **Per-region storage paths** (`internal/storage/`): Added `DataDirFor`/`DataFileFor` helpers that resolve to `$XDG_DATA_HOME/albion-lens/<region>/` subdirectories; legacy root remains the fallback when region is unknown
- **One-time legacy migration** (`internal/storage/migrate.go`): Atomic `O_CREATE|O_EXCL` marker ensures pre-region JSON data is copied into exactly one region directory on first detection, never re-seeding other regions
- **Backend wiring** (`pkg/backend/`): Server detector integrated into the packet capture pipeline; `ServerChanged` channel exposes region transitions to frontends; `SetDetectorForTest` enables deterministic testing
- **Handler callbacks** (`pkg/handlers/`): Added `SetClusterChangeCallback` for zone-transition notifications and `ResetPersistedState` which clears all in-memory counters including the `totalFame` dedup baseline
- **Region-aware persistence resolver** (`cmd/tui/persist.go`): New `persistPaths` type with mutex-guarded `SwitchRegion` (atomic save → reset → migrate → load), a CAS-based 15-minute rate limiter for cluster-change saves, `server-hint.txt` override escape hatch, and `warnFn` callback routing diagnostics to the TUI event log
- **TUI shutdown safety** (`cmd/tui/main.go`): Cluster-change saves run in tracked goroutines drained via `sync.WaitGroup` during shutdown; a mutex gates the callback to prevent `Add`-after-`Wait` panics; warnings route through `bulkEventChan` instead of `fmt.Printf`
- **Status bar region indicator** (`internal/tui/components/statusbar.go`): Added `SetRegion` and 🌍 region label rendered once the detector confidently identifies the active server

## Testing
- [x] Tested locally
- [x] Unit tests added
- [ ] Documentation updated

## Breaking Changes
None for end users. The legacy data directory is preserved; on first region detection, existing JSON files are atomically copied into the winning region's subdirectory via an exclusive marker. No manual migration or configuration changes are required.

## Related Issues
- Closes #113
- Closes #115

---

<!-- start-auto-generated -->
This is an auto-generated description by sintesitech[bot]

This PR segregates persisted state by detected Albion server region (Americas/Asia/Europe) using Photon IP prefix matching with a 5-second stability window, and adds rate-limited persistence saves on zone/cluster transitions via a CAS-based 15-minute coalescing window. Key changes include a new `serverdetect` package, per-region storage paths with one-time legacy migration, wiring through the backend and handler layers, and a region-aware persistence resolver in the TUI that routes warnings to the event log. The status bar now shows the detected region once confirmed, and shutdown safety is improved with tracked goroutines and mutex-gated callbacks. These changes close issues #113 and #115.

---
<sup>Written for commit 1bfabad60b06c5a9d91586b57dd2d8291774e9d1. Summary will update on new commits.</sup>
<!-- end-auto-generated -->